### PR TITLE
[docker] allow agent image path from pulumi variables

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -20,11 +20,11 @@ const (
 	ddInfraKubernetesVersion = "kubernetesVersion"
 
 	// Agent Namespace
-	ddAgentDeployParamName    = "deploy"
-	ddAgentVersionParamName   = "version"
-	ddAgentImagePathParamName = "imagePath"
-	ddAgentAPIKeyParamName    = "apiKey"
-	ddAgentAPPKeyParamName    = "appKey"
+	ddAgentDeployParamName        = "deploy"
+	ddAgentVersionParamName       = "version"
+	ddAgentFullImagePathParamName = "fullImagePath"
+	ddAgentAPIKeyParamName        = "apiKey"
+	ddAgentAPPKeyParamName        = "appKey"
 )
 
 type CommonEnvironment struct {
@@ -82,8 +82,8 @@ func (e *CommonEnvironment) AgentVersion() string {
 	return e.AgentConfig.Get(ddAgentVersionParamName)
 }
 
-func (e *CommonEnvironment) AgentImagePath() string {
-	return e.AgentConfig.Get(ddAgentImagePathParamName)
+func (e *CommonEnvironment) AgentFullImagePath() string {
+	return e.AgentConfig.Get(ddAgentFullImagePathParamName)
 }
 
 func (e *CommonEnvironment) AgentAPIKey() pulumi.StringOutput {

--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -20,10 +20,11 @@ const (
 	ddInfraKubernetesVersion = "kubernetesVersion"
 
 	// Agent Namespace
-	ddAgentDeployParamName  = "deploy"
-	ddAgentVersionParamName = "version"
-	ddAgentAPIKeyParamName  = "apiKey"
-	ddAgentAPPKeyParamName  = "appKey"
+	ddAgentDeployParamName    = "deploy"
+	ddAgentVersionParamName   = "version"
+	ddAgentImagePathParamName = "imagePath"
+	ddAgentAPIKeyParamName    = "apiKey"
+	ddAgentAPPKeyParamName    = "appKey"
 )
 
 type CommonEnvironment struct {
@@ -79,6 +80,10 @@ func (e *CommonEnvironment) AgentDeploy() bool {
 
 func (e *CommonEnvironment) AgentVersion() string {
 	return e.AgentConfig.Get(ddAgentVersionParamName)
+}
+
+func (e *CommonEnvironment) AgentImagePath() string {
+	return e.AgentConfig.Get(ddAgentImagePathParamName)
 }
 
 func (e *CommonEnvironment) AgentAPIKey() pulumi.StringOutput {


### PR DESCRIPTION
## What does this PR do?
Allow defining agent docker image path  from pulumi variables. This will allow environments with dev branch docker images, that are not published to docker hub

## Who will it impact?
Docker image users

