### PR TITLE
[agent] expose resource options in docker agent installation

### DIFF
--- a/datadog/agent/docker.go
+++ b/datadog/agent/docker.go
@@ -57,7 +57,7 @@ func DockerImageTag(e *config.CommonEnvironment) string {
 // dockerManager: a docker manager from a provisioned instance
 // agentImagePath: optional path to a docker agent image. Use an empty string to use  latest agent release by default
 // extraConfiguration: optional extra docker compose. Use an empty string to default to use only the agent compose.
-func NewDockerAgentInstallation(e *config.CommonEnvironment, dockerManager *command.DockerManager, extraConfiguration string, envVars pulumi.StringMap) (*remote.Command, error) {
+func NewDockerAgentInstallation(e *config.CommonEnvironment, dockerManager *command.DockerManager, extraConfiguration string, envVars pulumi.StringMap, opts ...pulumi.ResourceOption) (*remote.Command, error) {
 	composeContents := []command.DockerComposeInlineManifest{
 		{
 			Name:    "agent",
@@ -69,5 +69,5 @@ func NewDockerAgentInstallation(e *config.CommonEnvironment, dockerManager *comm
 		composeContents = append(composeContents, command.DockerComposeInlineManifest{Name: "agent-custom", Content: pulumi.String(extraConfiguration)})
 	}
 
-	return dockerManager.ComposeStrUp("agent", composeContents, envVars)
+	return dockerManager.ComposeStrUp("agent", composeContents, envVars, opts...)
 }


### PR DESCRIPTION
What does this PR do?
---------------------

Expose opts in agent's Docker Installation.

Which scenarios this will impact?
-------------------

agent.Docker

Motivation
----------

Allow to pass dependencies to agent's docker installation: in NDM docker compose up depends on some files that need to be uploaded

Additional Notes
----------------
