### PR TITLE
Remove API key from agentinstall.Params

### DIFF
--- a/aws/scenarios/vm/ec2VM/params.go
+++ b/aws/scenarios/vm/ec2VM/params.go
@@ -13,9 +13,13 @@ type Params struct {
 }
 
 func newParams(env aws.Environment, options ...func(*Params) error) (*Params, error) {
+	commonParams, err := vm.NewParams(env.CommonEnvironment, os.GetOSes(env))
+	if err != nil {
+		return nil, err
+	}
 	params := &Params{
 		keyPair: env.DefaultKeyPairName(),
-		common:  vm.NewParams(os.GetOSes(env)),
+		common:  commonParams,
 	}
 
 	return common.ApplyOption(params, options)

--- a/aws/scenarios/vm/ec2VM/params.go
+++ b/aws/scenarios/vm/ec2VM/params.go
@@ -13,7 +13,7 @@ type Params struct {
 }
 
 func newParams(env aws.Environment, options ...func(*Params) error) (*Params, error) {
-	commonParams, err := vm.NewParams(env.CommonEnvironment, os.GetOSes(env))
+	commonParams, err := vm.NewParams(env.CommonEnvironment, os.GetSupportedOSes(env))
 	if err != nil {
 		return nil, err
 	}

--- a/azure/compute/vm/params.go
+++ b/azure/compute/vm/params.go
@@ -13,7 +13,7 @@ type Params struct {
 }
 
 func newParams(env azure.Environment, options ...func(*Params) error) (*Params, error) {
-	commonParams, err := vm.NewParams(env.CommonEnvironment, os.GetOSes(env))
+	commonParams, err := vm.NewParams(env.CommonEnvironment, os.GetSupportedOSes(env))
 	if err != nil {
 		return nil, err
 	}

--- a/azure/compute/vm/params.go
+++ b/azure/compute/vm/params.go
@@ -13,8 +13,12 @@ type Params struct {
 }
 
 func newParams(env azure.Environment, options ...func(*Params) error) (*Params, error) {
+	commonParams, err := vm.NewParams(env.CommonEnvironment, os.GetOSes(env))
+	if err != nil {
+		return nil, err
+	}
 	params := &Params{
-		common: vm.NewParams(os.GetOSes(env)),
+		common: commonParams,
 	}
 
 	return common.ApplyOption(params, options)

--- a/common/agentinstall/install.go
+++ b/common/agentinstall/install.go
@@ -25,7 +25,7 @@ func Install(runner *command.Runner, env *config.CommonEnvironment, params *Para
 
 	if params.agentConfig != "" {
 		fileManager := command.NewFileManager(runner)
-		remotePath := os.GetConfigPath()
+		remotePath := os.GetAgentConfigPath()
 		agentConfig := env.AgentAPIKey().ApplyT(func(apiKey string) pulumi.String {
 			config := strings.ReplaceAll(params.agentConfig, "{{API_KEY}}", apiKey)
 			return pulumi.String(config)

--- a/common/agentinstall/params.go
+++ b/common/agentinstall/params.go
@@ -27,7 +27,7 @@ func WithLatest() func(*Params) error {
 	}
 }
 
-// WithVersion use a specific version of the Agent. For example: `6.39.0` or `7.41.0-rc.7`
+// WithVersion use a specific version of the Agent. For example: `6.39.0` or `7.41.0~rc.7-1
 func WithVersion(version string) func(*Params) error {
 	return func(p *Params) error {
 		prefix := "7."
@@ -43,11 +43,7 @@ func WithVersion(version string) func(*Params) error {
 		}
 
 		p.version.minor = strings.TrimPrefix(version, prefix)
-		p.version.betaChannel = strings.Contains(version, "-")
-		if p.version.betaChannel {
-			// Update from `7.41.0-rc.7` to `7.41.0~rc.7-1
-			p.version.minor = strings.ReplaceAll(p.version.minor, "-", "~") + "-1"
-		}
+		p.version.betaChannel = strings.Contains(version, "~")
 		return nil
 	}
 }

--- a/common/agentinstall/params.go
+++ b/common/agentinstall/params.go
@@ -8,15 +8,12 @@ import (
 )
 
 type Params struct {
-	apiKey      string
 	version     version
 	agentConfig string
 }
 
-func NewParams(apiKey string, options ...func(*Params) error) (*Params, error) {
-	params := &Params{
-		apiKey: apiKey,
-	}
+func NewParams(options ...func(*Params) error) (*Params, error) {
+	params := &Params{}
 	options = append([]func(*Params) error{WithLatest()}, options...)
 	return common.ApplyOption(params, options)
 }
@@ -55,7 +52,7 @@ func WithVersion(version string) func(*Params) error {
 	}
 }
 
-// WithAgentConfig sets the configuration of the Agent.
+// WithAgentConfig sets the configuration of the Agent. `{{API_KEY}}` can be used as a placeholder for the API key.
 func WithAgentConfig(config string) func(*Params) error {
 	return func(p *Params) error {
 		p.agentConfig = config

--- a/common/agentinstall/params.go
+++ b/common/agentinstall/params.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/test-infra-definitions/common"
+	"github.com/DataDog/test-infra-definitions/common/config"
 )
 
 type Params struct {
@@ -12,9 +13,13 @@ type Params struct {
 	agentConfig string
 }
 
-func NewParams(options ...func(*Params) error) (*Params, error) {
+func NewParams(env *config.CommonEnvironment, options ...func(*Params) error) (*Params, error) {
 	params := &Params{}
-	options = append([]func(*Params) error{WithLatest()}, options...)
+	defaultVersion := WithLatest()
+	if env.AgentVersion() != "" {
+		defaultVersion = WithVersion(env.AgentVersion())
+	}
+	options = append([]func(*Params) error{defaultVersion}, options...)
 	return common.ApplyOption(params, options)
 }
 

--- a/common/vm/params.go
+++ b/common/vm/params.go
@@ -114,11 +114,11 @@ func WithUserData[OS os.OS, P ParamsGetter[OS]](userData string) func(P) error {
 }
 
 // WithHostAgent installs an Agent on this EC2 instance. By default use with agentinstall.WithLatest().
-func WithHostAgent[OS os.OS, P ParamsGetter[OS]](apiKey string, options ...func(*agentinstall.Params) error) func(P) error {
+func WithHostAgent[OS os.OS, P ParamsGetter[OS]](options ...func(*agentinstall.Params) error) func(P) error {
 	return func(params P) error {
 		p := params.GetCommonParams()
 		var err error
-		p.OptionalAgentInstallParams, err = agentinstall.NewParams(apiKey, options...)
+		p.OptionalAgentInstallParams, err = agentinstall.NewParams(options...)
 		return err
 	}
 }

--- a/common/vm/vm.go
+++ b/common/vm/vm.go
@@ -24,7 +24,7 @@ func InitVM(
 	}
 
 	if optionalAgentInstallParams != nil {
-		agentinstall.Install(runner, env.GetCommonEnvironment().CommonNamer, optionalAgentInstallParams, os)
+		agentinstall.Install(runner, env.GetCommonEnvironment(), optionalAgentInstallParams, os)
 	}
 	ctx.Export("connection", connection)
 

--- a/common/vm/vm.go
+++ b/common/vm/vm.go
@@ -25,7 +25,7 @@ func InitVM(
 	}
 
 	if optionalAgentInstallParams != nil {
-		agentinstall.Install(runner, commonEnv.CommonNamer, optionalAgentInstallParams, os)
+		agentinstall.Install(runner, commonEnv, optionalAgentInstallParams, os)
 	}
 	ctx.Export("connection", connection)
 


### PR DESCRIPTION
What does this PR do?
---------------------

This PR provides small improvements:
 - Don't use SemVer for the Agent version as custom build versions are not SemVer versions.
- Remove API key from `agentinstall.Params` and use config map instead.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
