### PR TITLE
Parse security groups and subnets from string

### DIFF
--- a/aws/environment.go
+++ b/aws/environment.go
@@ -91,15 +91,11 @@ func (e *Environment) DefaultVPCID() string {
 }
 
 func (e *Environment) DefaultSubnets() []string {
-	var arr []string
-	resInt := e.GetObjectWithDefault(e.InfraConfig, ddinfraDefaultSubnetsParamName, arr, e.envDefault.ddInfra.defaultSubnets)
-	return resInt.([]string)
+	return e.GetStringListWithDefault(e.InfraConfig, ddinfraDefaultSubnetsParamName, e.envDefault.ddInfra.defaultSubnets)
 }
 
 func (e *Environment) DefaultSecurityGroups() []string {
-	var arr []string
-	resInt := e.GetObjectWithDefault(e.InfraConfig, ddinfraDefaultSecurityGroupsParamName, arr, e.envDefault.ddInfra.defaultSecurityGroups)
-	return resInt.([]string)
+	return e.GetStringListWithDefault(e.InfraConfig, ddinfraDefaultSecurityGroupsParamName, e.envDefault.ddInfra.defaultSecurityGroups)
 }
 
 func (e *Environment) DefaultInstanceType() string {

--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -111,6 +111,19 @@ func (e *CommonEnvironment) GetBoolWithDefault(config *sdkconfig.Config, paramNa
 	return defaultValue
 }
 
+func (e *CommonEnvironment) GetStringListWithDefault(config *sdkconfig.Config, paramName string, defaultValue []string) []string {
+	val, err := config.Try(paramName)
+	if err == nil {
+		return strings.Split(val, ",")
+	}
+
+	if !errors.Is(err, sdkconfig.ErrMissingVar) {
+		e.Ctx.Log.Error(fmt.Sprintf("Parameter %s not parsable, err: %v, will use default value: %v", paramName, err, defaultValue), nil)
+	}
+
+	return defaultValue
+}
+
 func (e *CommonEnvironment) GetStringWithDefault(config *sdkconfig.Config, paramName string, defaultValue string) string {
 	val, err := config.Try(paramName)
 	if err == nil {


### PR DESCRIPTION
What does this PR do?
---------------------
Adds a helper to parse a comma separated string as a list of strings. This is used to parse security groups and subnets.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
