### PR TITLE
Add package managers for Nix OSes.

### DIFF
--- a/aws/scenarios/dockerVM/dockerVM/run.go
+++ b/aws/scenarios/dockerVM/dockerVM/run.go
@@ -1,24 +1,18 @@
 package dockervm
 
 import (
-	"fmt"
-
 	ec2vm "github.com/DataDog/test-infra-definitions/aws/scenarios/vm/ec2VM"
-	"github.com/DataDog/test-infra-definitions/common/docker"
-	commonvm "github.com/DataDog/test-infra-definitions/common/vm"
+	"github.com/DataDog/test-infra-definitions/datadog/agent/docker"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 func Run(ctx *pulumi.Context) error {
-	vm, err := ec2vm.NewEc2VM(ctx)
+	vm, err := ec2vm.NewNixEc2VM(ctx)
 	if err != nil {
 		return err
 	}
-	ubuntuVM, ok := vm.(*commonvm.UbuntuVM)
-	if !ok {
-		return fmt.Errorf("not an ubuntu VM")
-	}
-	_, err = docker.NewOnVM(ctx, ubuntuVM, docker.WithAgent())
+
+	_, err = docker.NewAgentDockerInstaller(vm, docker.WithAgent())
 
 	return err
 }

--- a/aws/scenarios/dockerVM/dockerVM/run.go
+++ b/aws/scenarios/dockerVM/dockerVM/run.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Run(ctx *pulumi.Context) error {
-	vm, err := ec2vm.NewNixEc2VM(ctx)
+	vm, err := ec2vm.NewUnixLikeEc2VM(ctx)
 	if err != nil {
 		return err
 	}

--- a/aws/scenarios/dockerVM/dockerVM/run.go
+++ b/aws/scenarios/dockerVM/dockerVM/run.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Run(ctx *pulumi.Context) error {
-	vm, err := ec2vm.NewUnixLikeEc2VM(ctx)
+	vm, err := ec2vm.NewUnixEc2VM(ctx)
 	if err != nil {
 		return err
 	}

--- a/aws/scenarios/microVMs/microvms/provision.go
+++ b/aws/scenarios/microVMs/microvms/provision.go
@@ -8,6 +8,7 @@ import (
 	sconfig "github.com/DataDog/test-infra-definitions/aws/scenarios/microVMs/config"
 	"github.com/DataDog/test-infra-definitions/command"
 	"github.com/DataDog/test-infra-definitions/common/namer"
+	"github.com/DataDog/test-infra-definitions/common/os"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -93,7 +94,7 @@ func copyKernelHeaders(runner *command.Runner, depends []pulumi.Resource) ([]pul
 }
 
 func installPackages(runner *command.Runner) ([]pulumi.Resource, error) {
-	aptManager := command.NewAptManager(runner)
+	aptManager := os.NewAptManager(runner)
 	installSocat, err := aptManager.Ensure("socat")
 	if err != nil {
 		return []pulumi.Resource{}, err

--- a/aws/scenarios/vm/ec2VM/ec2VM.go
+++ b/aws/scenarios/vm/ec2VM/ec2VM.go
@@ -16,14 +16,14 @@ func NewEc2VM(ctx *pulumi.Context, options ...func(*Params) error) (commonvm.VM,
 	return newVM(ctx, options...)
 }
 
-// NewNixEc2VM creates a new EC2 instance. By default use WithOS(os.UbuntuOS, os.AMD64Arch).
+// NewUnixLikeEc2VM creates a new EC2 instance. By default use WithOS(os.UbuntuOS, os.AMD64Arch).
 // The returned vm provides additional methods compared to NewEc2VM
-func NewNixEc2VM(ctx *pulumi.Context, options ...func(*Params) error) (*commonvm.NixVM, error) {
+func NewUnixLikeEc2VM(ctx *pulumi.Context, options ...func(*Params) error) (*commonvm.UnixLikeVM, error) {
 	vm, err := newVM(ctx, options...)
 	if err != nil {
 		return nil, err
 	}
-	return commonvm.NewNixVM(vm)
+	return commonvm.NewUnixLikeVM(vm)
 }
 
 // newVM creates a new EC2 instance. By default use WithOS(os.UbuntuOS, os.AMD64Arch).

--- a/aws/scenarios/vm/ec2VM/ec2VM.go
+++ b/aws/scenarios/vm/ec2VM/ec2VM.go
@@ -7,12 +7,27 @@ import (
 	"github.com/DataDog/test-infra-definitions/aws"
 	awsEc2 "github.com/DataDog/test-infra-definitions/aws/ec2/ec2"
 	commonos "github.com/DataDog/test-infra-definitions/common/os"
-	"github.com/DataDog/test-infra-definitions/common/vm"
+	commonvm "github.com/DataDog/test-infra-definitions/common/vm"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 // NewEc2VM creates a new EC2 instance. By default use WithOS(os.UbuntuOS, os.AMD64Arch).
-func NewEc2VM(ctx *pulumi.Context, options ...func(*Params) error) (vm.VM, error) {
+func NewEc2VM(ctx *pulumi.Context, options ...func(*Params) error) (commonvm.VM, error) {
+	return newVM(ctx, options...)
+}
+
+// NewNixEc2VM creates a new EC2 instance. By default use WithOS(os.UbuntuOS, os.AMD64Arch).
+// The returned vm provides additional methods compared to NewEc2VM
+func NewNixEc2VM(ctx *pulumi.Context, options ...func(*Params) error) (*commonvm.NixVM, error) {
+	vm, err := newVM(ctx, options...)
+	if err != nil {
+		return nil, err
+	}
+	return commonvm.NewNixVM(vm)
+}
+
+// newVM creates a new EC2 instance. By default use WithOS(os.UbuntuOS, os.AMD64Arch).
+func newVM(ctx *pulumi.Context, options ...func(*Params) error) (commonvm.VM, error) {
 	env, err := aws.NewEnvironment(ctx)
 	if err != nil {
 		return nil, err
@@ -46,7 +61,7 @@ func NewEc2VM(ctx *pulumi.Context, options ...func(*Params) error) (vm.VM, error
 		return nil, err
 	}
 
-	return vm.NewVM(
+	return commonvm.NewGenericVM(
 		params.common.InstanceName,
 		&env,
 		instance.PrivateIp,

--- a/aws/scenarios/vm/ec2VM/ec2VM.go
+++ b/aws/scenarios/vm/ec2VM/ec2VM.go
@@ -16,14 +16,14 @@ func NewEc2VM(ctx *pulumi.Context, options ...func(*Params) error) (commonvm.VM,
 	return newVM(ctx, options...)
 }
 
-// NewUnixLikeEc2VM creates a new EC2 instance. By default use WithOS(os.UbuntuOS, os.AMD64Arch).
+// NewUnixEc2VM creates a new EC2 instance. By default use WithOS(os.UbuntuOS, os.AMD64Arch).
 // The returned vm provides additional methods compared to NewEc2VM
-func NewUnixLikeEc2VM(ctx *pulumi.Context, options ...func(*Params) error) (*commonvm.UnixLikeVM, error) {
+func NewUnixEc2VM(ctx *pulumi.Context, options ...func(*Params) error) (*commonvm.UnixVM, error) {
 	vm, err := newVM(ctx, options...)
 	if err != nil {
 		return nil, err
 	}
-	return commonvm.NewUnixLikeVM(vm)
+	return commonvm.NewUnixVM(vm)
 }
 
 // newVM creates a new EC2 instance. By default use WithOS(os.UbuntuOS, os.AMD64Arch).

--- a/aws/scenarios/vm/os/amazonLinux.go
+++ b/aws/scenarios/vm/os/amazonLinux.go
@@ -3,6 +3,7 @@ package os
 import (
 	"github.com/DataDog/test-infra-definitions/aws"
 	"github.com/DataDog/test-infra-definitions/aws/ec2/ec2"
+	"github.com/DataDog/test-infra-definitions/command"
 	commonos "github.com/DataDog/test-infra-definitions/common/os"
 )
 
@@ -29,4 +30,8 @@ func (u *amazonLinux) GetImage(arch commonos.Architecture) (string, error) {
 
 func (u *amazonLinux) GetServiceManager() *commonos.ServiceManager {
 	return commonos.NewSystemCtlServiceManager()
+}
+
+func (*amazonLinux) CreatePackageManager(runner *command.Runner) (command.PackageManager, error) {
+	return newYumManager(runner), nil
 }

--- a/aws/scenarios/vm/os/debian.go
+++ b/aws/scenarios/vm/os/debian.go
@@ -3,6 +3,7 @@ package os
 import (
 	"github.com/DataDog/test-infra-definitions/aws"
 	"github.com/DataDog/test-infra-definitions/aws/ec2/ec2"
+	"github.com/DataDog/test-infra-definitions/command"
 	commonos "github.com/DataDog/test-infra-definitions/common/os"
 )
 
@@ -29,4 +30,8 @@ func (u *debian) GetImage(arch commonos.Architecture) (string, error) {
 
 func (*debian) GetServiceManager() *commonos.ServiceManager {
 	return commonos.NewServiceCmdServiceManager()
+}
+
+func (*debian) CreatePackageManager(runner *command.Runner) (command.PackageManager, error) {
+	return commonos.NewAptManager(runner), nil
 }

--- a/aws/scenarios/vm/os/fedora.go
+++ b/aws/scenarios/vm/os/fedora.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/aws"
 	"github.com/DataDog/test-infra-definitions/aws/ec2/ec2"
+	"github.com/DataDog/test-infra-definitions/command"
 	commonos "github.com/DataDog/test-infra-definitions/common/os"
 )
 
@@ -38,4 +39,8 @@ func (u *fedora) GetImage(arch commonos.Architecture) (string, error) {
 
 func (*fedora) GetServiceManager() *commonos.ServiceManager {
 	return commonos.NewSystemCtlServiceManager()
+}
+
+func (*fedora) CreatePackageManager(runner *command.Runner) (command.PackageManager, error) {
+	return newDnfManager(runner), nil
 }

--- a/aws/scenarios/vm/os/packagemanager.go
+++ b/aws/scenarios/vm/os/packagemanager.go
@@ -1,0 +1,15 @@
+package os
+
+import "github.com/DataDog/test-infra-definitions/command"
+
+func newYumManager(runner *command.Runner) command.PackageManager {
+	return command.NewGenericPackageManager(runner, "yum", "yum install -y", "", nil)
+}
+
+func newDnfManager(runner *command.Runner) command.PackageManager {
+	return command.NewGenericPackageManager(runner, "dnf", "dnf install -y", "", nil)
+}
+
+func newZypperManager(runner *command.Runner) command.PackageManager {
+	return command.NewGenericPackageManager(runner, "zypper", "zypper -n install", "zypper -n refresh", nil)
+}

--- a/aws/scenarios/vm/os/redhat.go
+++ b/aws/scenarios/vm/os/redhat.go
@@ -3,6 +3,7 @@ package os
 import (
 	"github.com/DataDog/test-infra-definitions/aws"
 	"github.com/DataDog/test-infra-definitions/aws/ec2/ec2"
+	"github.com/DataDog/test-infra-definitions/command"
 	commonos "github.com/DataDog/test-infra-definitions/common/os"
 )
 
@@ -27,4 +28,8 @@ func (u *redHat) GetImage(arch commonos.Architecture) (string, error) {
 
 func (*redHat) GetServiceManager() *commonos.ServiceManager {
 	return commonos.NewSystemCtlServiceManager()
+}
+
+func (*redHat) CreatePackageManager(runner *command.Runner) (command.PackageManager, error) {
+	return newYumManager(runner), nil
 }

--- a/aws/scenarios/vm/os/suse.go
+++ b/aws/scenarios/vm/os/suse.go
@@ -3,6 +3,7 @@ package os
 import (
 	"github.com/DataDog/test-infra-definitions/aws"
 	"github.com/DataDog/test-infra-definitions/aws/ec2/ec2"
+	"github.com/DataDog/test-infra-definitions/command"
 	commonos "github.com/DataDog/test-infra-definitions/common/os"
 )
 
@@ -30,4 +31,8 @@ func (u *suse) GetImage(arch commonos.Architecture) (string, error) {
 
 func (*suse) GetServiceManager() *commonos.ServiceManager {
 	return commonos.NewSystemCtlServiceManager()
+}
+
+func (*suse) CreatePackageManager(runner *command.Runner) (command.PackageManager, error) {
+	return newZypperManager(runner), nil
 }

--- a/azure/compute/vm/azurevm.go
+++ b/azure/compute/vm/azurevm.go
@@ -3,13 +3,27 @@ package vm
 import (
 	"github.com/DataDog/test-infra-definitions/azure"
 	"github.com/DataDog/test-infra-definitions/azure/compute"
-	"github.com/DataDog/test-infra-definitions/common/vm"
+	commonvm "github.com/DataDog/test-infra-definitions/common/vm"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 // NewAzureVM creates a new azure instance. By default use WithOS(os.UbuntuOS, os.AMD64Arch).
-func NewAzureVM(ctx *pulumi.Context, options ...func(*Params) error) (vm.VM, error) {
+func NewAzureVM(ctx *pulumi.Context, options ...func(*Params) error) (commonvm.VM, error) {
+	return newVM(ctx, options...)
+}
+
+// NewNixAzureVM creates a new azure instance. By default use WithOS(os.UbuntuOS, os.AMD64Arch).
+// The returned vm provides additional methods compared to NewAzureVM
+func NewNixAzureVM(ctx *pulumi.Context, options ...func(*Params) error) (*commonvm.NixVM, error) {
+	vm, err := newVM(ctx, options...)
+	if err != nil {
+		return nil, err
+	}
+	return commonvm.NewNixVM(vm)
+}
+
+func newVM(ctx *pulumi.Context, options ...func(*Params) error) (commonvm.VM, error) {
 	env, err := azure.NewEnvironment(ctx)
 	if err != nil {
 		return nil, err
@@ -32,7 +46,7 @@ func NewAzureVM(ctx *pulumi.Context, options ...func(*Params) error) (vm.VM, err
 		return nil, err
 	}
 
-	return vm.NewVM(
+	return commonvm.NewGenericVM(
 		params.common.InstanceName,
 		&env,
 		publicIP.IpAddress.Elem(),

--- a/azure/compute/vm/azurevm.go
+++ b/azure/compute/vm/azurevm.go
@@ -13,14 +13,14 @@ func NewAzureVM(ctx *pulumi.Context, options ...func(*Params) error) (commonvm.V
 	return newVM(ctx, options...)
 }
 
-// NewUnixLikeAzureVM creates a new azure instance. By default use WithOS(os.UbuntuOS, os.AMD64Arch).
+// NewUnixAzureVM creates a new azure instance. By default use WithOS(os.UbuntuOS, os.AMD64Arch).
 // The returned vm provides additional methods compared to NewAzureVM
-func NewUnixLikeAzureVM(ctx *pulumi.Context, options ...func(*Params) error) (*commonvm.UnixLikeVM, error) {
+func NewUnixAzureVM(ctx *pulumi.Context, options ...func(*Params) error) (*commonvm.UnixVM, error) {
 	vm, err := newVM(ctx, options...)
 	if err != nil {
 		return nil, err
 	}
-	return commonvm.NewUnixLikeVM(vm)
+	return commonvm.NewUnixVM(vm)
 }
 
 func newVM(ctx *pulumi.Context, options ...func(*Params) error) (commonvm.VM, error) {

--- a/azure/compute/vm/azurevm.go
+++ b/azure/compute/vm/azurevm.go
@@ -13,14 +13,14 @@ func NewAzureVM(ctx *pulumi.Context, options ...func(*Params) error) (commonvm.V
 	return newVM(ctx, options...)
 }
 
-// NewNixAzureVM creates a new azure instance. By default use WithOS(os.UbuntuOS, os.AMD64Arch).
+// NewUnixLikeAzureVM creates a new azure instance. By default use WithOS(os.UbuntuOS, os.AMD64Arch).
 // The returned vm provides additional methods compared to NewAzureVM
-func NewNixAzureVM(ctx *pulumi.Context, options ...func(*Params) error) (*commonvm.NixVM, error) {
+func NewUnixLikeAzureVM(ctx *pulumi.Context, options ...func(*Params) error) (*commonvm.UnixLikeVM, error) {
 	vm, err := newVM(ctx, options...)
 	if err != nil {
 		return nil, err
 	}
-	return commonvm.NewNixVM(vm)
+	return commonvm.NewUnixLikeVM(vm)
 }
 
 func newVM(ctx *pulumi.Context, options ...func(*Params) error) (commonvm.VM, error) {

--- a/common/os/macos.go
+++ b/common/os/macos.go
@@ -1,5 +1,7 @@
 package os
 
+import "github.com/DataDog/test-infra-definitions/command"
+
 type MacOS struct{}
 
 func NewMacOS() *MacOS {
@@ -14,4 +16,8 @@ func (*MacOS) GetAgentConfigPath() string { return "~/.datadog-agent/datadog.yam
 
 func (*MacOS) GetAgentInstallCmd(version AgentVersion) (string, error) {
 	return getUnixInstallFormatString("install_mac_os.sh", version), nil
+}
+
+func (*MacOS) CreatePackageManager(runner *command.Runner) (command.PackageManager, error) {
+	return NewBrewManager(runner), nil
 }

--- a/common/os/os.go
+++ b/common/os/os.go
@@ -1,5 +1,7 @@
 package os
 
+import "github.com/DataDog/test-infra-definitions/command"
+
 type Architecture string
 
 const (
@@ -30,4 +32,5 @@ type OS interface {
 	GetSSHUser() string
 	GetAgentInstallCmd(AgentVersion) (string, error)
 	GetType() Type
+	CreatePackageManager(runner *command.Runner) (command.PackageManager, error)
 }

--- a/common/os/os.go
+++ b/common/os/os.go
@@ -13,7 +13,7 @@ const (
 type Type int
 
 const (
-	UbuntuType  Type = iota
+	UnixType    Type = iota
 	WindowsType Type = iota
 	OtherType   Type = iota
 )

--- a/common/os/packagemanager.go
+++ b/common/os/packagemanager.go
@@ -1,0 +1,16 @@
+package os
+
+import (
+	"github.com/DataDog/test-infra-definitions/command"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func NewAptManager(runner *command.Runner) command.PackageManager {
+	return command.NewGenericPackageManager(runner, "apt", "apt-get install -y", "apt-get update -y",
+		pulumi.StringMap{"DEBIAN_FRONTEND": pulumi.String("noninteractive")})
+}
+
+func NewBrewManager(runner *command.Runner) command.PackageManager {
+	return command.NewGenericPackageManager(runner, "brew", "brew install -y", "brew update -y",
+		pulumi.StringMap{"NONINTERACTIVE": pulumi.String("1")})
+}

--- a/common/os/ubuntu.go
+++ b/common/os/ubuntu.go
@@ -17,10 +17,6 @@ func (*Ubuntu) GetServiceManager() *ServiceManager {
 	return NewServiceCmdServiceManager()
 }
 
-func (*Ubuntu) GetType() Type {
-	return UbuntuType
-}
-
 func (*Ubuntu) CreatePackageManager(runner *command.Runner) (command.PackageManager, error) {
 	return NewAptManager(runner), nil
 }

--- a/common/os/ubuntu.go
+++ b/common/os/ubuntu.go
@@ -1,6 +1,9 @@
 package os
 
-import "github.com/DataDog/test-infra-definitions/common/config"
+import (
+	"github.com/DataDog/test-infra-definitions/command"
+	"github.com/DataDog/test-infra-definitions/common/config"
+)
 
 type Ubuntu struct{ Unix }
 
@@ -16,4 +19,8 @@ func (*Ubuntu) GetServiceManager() *ServiceManager {
 
 func (*Ubuntu) GetType() Type {
 	return UbuntuType
+}
+
+func (*Ubuntu) CreatePackageManager(runner *command.Runner) (command.PackageManager, error) {
+	return NewAptManager(runner), nil
 }

--- a/common/os/unix.go
+++ b/common/os/unix.go
@@ -26,7 +26,7 @@ func (*Unix) GetAgentInstallCmd(version AgentVersion) (string, error) {
 }
 
 func (*Unix) GetType() Type {
-	return OtherType
+	return UnixType
 }
 
 func getDefaultInstanceType(env config.Environment, arch Architecture) string {

--- a/common/os/windows.go
+++ b/common/os/windows.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/DataDog/test-infra-definitions/command"
 	"github.com/DataDog/test-infra-definitions/common/config"
 )
 
@@ -32,6 +33,10 @@ func (*Windows) GetServiceManager() *ServiceManager {
 }
 
 func (*Windows) GetAgentConfigPath() string { return `C:\ProgramData\Datadog\datadog.yaml` }
+
+func (*Windows) CreatePackageManager(runner *command.Runner) (command.PackageManager, error) {
+	return nil, errors.New("package manager is not supported on Windows")
+}
 
 func (*Windows) GetAgentInstallCmd(version AgentVersion) (string, error) {
 	url, err := getAgentURL(version)

--- a/common/vm/nixvm.go
+++ b/common/vm/nixvm.go
@@ -1,0 +1,44 @@
+package vm
+
+import (
+	"errors"
+
+	"github.com/DataDog/test-infra-definitions/command"
+	commonos "github.com/DataDog/test-infra-definitions/common/os"
+)
+
+type NixVM struct {
+	aptManager        *command.AptManager
+	fileManager       *command.FileManager
+	runner            *command.Runner
+	lazyDockerManager *command.DockerManager
+	VM
+}
+
+func NewNixVM(vm VM) (*NixVM, error) {
+	if vm.GetOS().GetType() == commonos.WindowsType {
+		return nil, errors.New("the OS Windows is not a valid Nix OS. Use `NewXXXVM` instead of `NewNixXXXVM`")
+	}
+	runner := vm.GetRunner()
+	return &NixVM{
+		VM:          vm,
+		runner:      runner,
+		aptManager:  command.NewAptManager(runner),
+		fileManager: command.NewFileManager(runner),
+	}, nil
+
+}
+func (vm *NixVM) GetAptManager() *command.AptManager {
+	return vm.aptManager
+}
+
+func (vm *NixVM) GetFileManager() *command.FileManager {
+	return vm.fileManager
+}
+
+func (vm *NixVM) GetLazyDocker() *command.DockerManager {
+	if vm.lazyDockerManager == nil {
+		vm.lazyDockerManager = command.NewDockerManager(vm.GetRunner(), vm.GetAptManager())
+	}
+	return vm.lazyDockerManager
+}

--- a/common/vm/nixvm.go
+++ b/common/vm/nixvm.go
@@ -8,7 +8,7 @@ import (
 )
 
 type NixVM struct {
-	aptManager        *command.AptManager
+	packageManager    command.PackageManager
 	fileManager       *command.FileManager
 	runner            *command.Runner
 	lazyDockerManager *command.DockerManager
@@ -16,20 +16,26 @@ type NixVM struct {
 }
 
 func NewNixVM(vm VM) (*NixVM, error) {
-	if vm.GetOS().GetType() == commonos.WindowsType {
+	os := vm.GetOS()
+	if os.GetType() == commonos.WindowsType {
 		return nil, errors.New("the OS Windows is not a valid Nix OS. Use `NewXXXVM` instead of `NewNixXXXVM`")
 	}
+
 	runner := vm.GetRunner()
+	packageManager, err := os.CreatePackageManager(runner)
+	if err != nil {
+		return nil, err
+	}
 	return &NixVM{
-		VM:          vm,
-		runner:      runner,
-		aptManager:  command.NewAptManager(runner),
-		fileManager: command.NewFileManager(runner),
+		VM:             vm,
+		runner:         runner,
+		packageManager: packageManager,
+		fileManager:    command.NewFileManager(runner),
 	}, nil
 
 }
-func (vm *NixVM) GetAptManager() *command.AptManager {
-	return vm.aptManager
+func (vm *NixVM) GetPackageManager() command.PackageManager {
+	return vm.packageManager
 }
 
 func (vm *NixVM) GetFileManager() *command.FileManager {
@@ -38,7 +44,7 @@ func (vm *NixVM) GetFileManager() *command.FileManager {
 
 func (vm *NixVM) GetLazyDocker() *command.DockerManager {
 	if vm.lazyDockerManager == nil {
-		vm.lazyDockerManager = command.NewDockerManager(vm.GetRunner(), vm.GetAptManager())
+		vm.lazyDockerManager = command.NewDockerManager(vm.GetRunner(), vm.GetPackageManager())
 	}
 	return vm.lazyDockerManager
 }

--- a/common/vm/unixlikevm.go
+++ b/common/vm/unixlikevm.go
@@ -7,7 +7,7 @@ import (
 	commonos "github.com/DataDog/test-infra-definitions/common/os"
 )
 
-type NixVM struct {
+type UnixLikeVM struct {
 	packageManager    command.PackageManager
 	fileManager       *command.FileManager
 	runner            *command.Runner
@@ -15,7 +15,7 @@ type NixVM struct {
 	VM
 }
 
-func NewNixVM(vm VM) (*NixVM, error) {
+func NewUnixLikeVM(vm VM) (*UnixLikeVM, error) {
 	os := vm.GetOS()
 	if os.GetType() == commonos.WindowsType {
 		return nil, errors.New("the OS Windows is not a valid Nix OS. Use `NewXXXVM` instead of `NewNixXXXVM`")
@@ -26,7 +26,7 @@ func NewNixVM(vm VM) (*NixVM, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &NixVM{
+	return &UnixLikeVM{
 		VM:             vm,
 		runner:         runner,
 		packageManager: packageManager,
@@ -34,15 +34,15 @@ func NewNixVM(vm VM) (*NixVM, error) {
 	}, nil
 
 }
-func (vm *NixVM) GetPackageManager() command.PackageManager {
+func (vm *UnixLikeVM) GetPackageManager() command.PackageManager {
 	return vm.packageManager
 }
 
-func (vm *NixVM) GetFileManager() *command.FileManager {
+func (vm *UnixLikeVM) GetFileManager() *command.FileManager {
 	return vm.fileManager
 }
 
-func (vm *NixVM) GetLazyDocker() *command.DockerManager {
+func (vm *UnixLikeVM) GetLazyDocker() *command.DockerManager {
 	if vm.lazyDockerManager == nil {
 		vm.lazyDockerManager = command.NewDockerManager(vm.GetRunner(), vm.GetPackageManager())
 	}

--- a/common/vm/unixvm.go
+++ b/common/vm/unixvm.go
@@ -7,7 +7,7 @@ import (
 	commonos "github.com/DataDog/test-infra-definitions/common/os"
 )
 
-type UnixLikeVM struct {
+type UnixVM struct {
 	packageManager    command.PackageManager
 	fileManager       *command.FileManager
 	runner            *command.Runner
@@ -15,7 +15,7 @@ type UnixLikeVM struct {
 	VM
 }
 
-func NewUnixLikeVM(vm VM) (*UnixLikeVM, error) {
+func NewUnixVM(vm VM) (*UnixVM, error) {
 	os := vm.GetOS()
 	if os.GetType() == commonos.WindowsType {
 		return nil, errors.New("the OS Windows is not a valid Nix OS. Use `NewXXXVM` instead of `NewNixXXXVM`")
@@ -26,7 +26,7 @@ func NewUnixLikeVM(vm VM) (*UnixLikeVM, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &UnixLikeVM{
+	return &UnixVM{
 		VM:             vm,
 		runner:         runner,
 		packageManager: packageManager,
@@ -34,15 +34,15 @@ func NewUnixLikeVM(vm VM) (*UnixLikeVM, error) {
 	}, nil
 
 }
-func (vm *UnixLikeVM) GetPackageManager() command.PackageManager {
+func (vm *UnixVM) GetPackageManager() command.PackageManager {
 	return vm.packageManager
 }
 
-func (vm *UnixLikeVM) GetFileManager() *command.FileManager {
+func (vm *UnixVM) GetFileManager() *command.FileManager {
 	return vm.fileManager
 }
 
-func (vm *UnixLikeVM) GetLazyDocker() *command.DockerManager {
+func (vm *UnixVM) GetLazyDocker() *command.DockerManager {
 	if vm.lazyDockerManager == nil {
 		vm.lazyDockerManager = command.NewDockerManager(vm.GetRunner(), vm.GetPackageManager())
 	}

--- a/datadog/agent/docker/agentDockerInstaller.go
+++ b/datadog/agent/docker/agentDockerInstaller.go
@@ -12,7 +12,7 @@ type AgentDockerInstaller struct {
 	dependsOn pulumi.ResourceOption
 }
 
-func NewAgentDockerInstaller(vm *vm.UnixLikeVM, options ...func(*Params) error) (*AgentDockerInstaller, error) {
+func NewAgentDockerInstaller(vm *vm.UnixVM, options ...func(*Params) error) (*AgentDockerInstaller, error) {
 	commonEnv := vm.GetCommonEnvironment()
 	params, err := newParams(commonEnv, options...)
 	if err != nil {

--- a/datadog/agent/docker/agentDockerInstaller.go
+++ b/datadog/agent/docker/agentDockerInstaller.go
@@ -12,7 +12,7 @@ type AgentDockerInstaller struct {
 	dependsOn pulumi.ResourceOption
 }
 
-func NewAgentDockerInstaller(vm *vm.NixVM, options ...func(*Params) error) (*AgentDockerInstaller, error) {
+func NewAgentDockerInstaller(vm *vm.UnixLikeVM, options ...func(*Params) error) (*AgentDockerInstaller, error) {
 	commonEnv := vm.GetCommonEnvironment()
 	params, err := newParams(commonEnv, options...)
 	if err != nil {

--- a/datadog/agent/docker/agentDockerInstaller.go
+++ b/datadog/agent/docker/agentDockerInstaller.go
@@ -12,7 +12,7 @@ type AgentDockerInstaller struct {
 	dependsOn pulumi.ResourceOption
 }
 
-func NewAgentDockerInstaller(vm *vm.UbuntuVM, dockerManager *command.DockerManager, options ...func(*Params) error) (*AgentDockerInstaller, error) {
+func NewAgentDockerInstaller(vm *vm.NixVM, options ...func(*Params) error) (*AgentDockerInstaller, error) {
 	commonEnv := vm.GetCommonEnvironment()
 	params, err := newParams(commonEnv, options...)
 	if err != nil {
@@ -45,6 +45,7 @@ func NewAgentDockerInstaller(vm *vm.UbuntuVM, dockerManager *command.DockerManag
 	}
 
 	var dependOnResource pulumi.Resource
+	dockerManager := vm.GetLazyDocker()
 	if len(composeContents) > 0 {
 		dependOnResource, err = dockerManager.ComposeStrUp("docker-on-vm", composeContents, env, params.pulumiResources...)
 	} else {

--- a/kubernetes/kind.go
+++ b/kubernetes/kind.go
@@ -21,8 +21,7 @@ const (
 var kindClusterConfig string
 
 // Install Kind on a Linux virtual machine
-// Currently using ec2.VM waiting for correct abstraction
-func NewKindCluster(vm *vm.UbuntuVM, dockerManager *command.DockerManager, clusterName, arch string) (*remote.Command, error) {
+func NewKindCluster(vm *vm.NixVM, clusterName, arch string) (*remote.Command, error) {
 	runner := vm.GetRunner()
 	commonEnvironment := vm.GetCommonEnvironment()
 	packageManager := vm.GetAptManager()
@@ -30,7 +29,7 @@ func NewKindCluster(vm *vm.UbuntuVM, dockerManager *command.DockerManager, clust
 	if err != nil {
 		return nil, err
 	}
-	cmd, err := dockerManager.Install()
+	cmd, err := vm.GetLazyDocker().Install()
 	if err != nil {
 		return nil, err
 	}

--- a/kubernetes/kind.go
+++ b/kubernetes/kind.go
@@ -24,7 +24,7 @@ var kindClusterConfig string
 func NewKindCluster(vm *vm.NixVM, clusterName, arch string) (*remote.Command, error) {
 	runner := vm.GetRunner()
 	commonEnvironment := vm.GetCommonEnvironment()
-	packageManager := vm.GetAptManager()
+	packageManager := vm.GetPackageManager()
 	curlCommand, err := packageManager.Ensure("curl")
 	if err != nil {
 		return nil, err

--- a/kubernetes/kind.go
+++ b/kubernetes/kind.go
@@ -21,7 +21,7 @@ const (
 var kindClusterConfig string
 
 // Install Kind on a Linux virtual machine
-func NewKindCluster(vm *vm.NixVM, clusterName, arch string) (*remote.Command, error) {
+func NewKindCluster(vm *vm.UnixLikeVM, clusterName, arch string) (*remote.Command, error) {
 	runner := vm.GetRunner()
 	commonEnvironment := vm.GetCommonEnvironment()
 	packageManager := vm.GetPackageManager()

--- a/kubernetes/kind.go
+++ b/kubernetes/kind.go
@@ -21,7 +21,7 @@ const (
 var kindClusterConfig string
 
 // Install Kind on a Linux virtual machine
-func NewKindCluster(vm *vm.UnixLikeVM, clusterName, arch string) (*remote.Command, error) {
+func NewKindCluster(vm *vm.UnixVM, clusterName, arch string) (*remote.Command, error) {
 	runner := vm.GetRunner()
 	commonEnvironment := vm.GetCommonEnvironment()
 	packageManager := vm.GetPackageManager()


### PR DESCRIPTION
What does this PR do?
---------------------
Add the package managers for Nix OSes.
This PR also introduces `NixVM` which is a Linux / Unix / MacOS VM. `NixVM` has extra features compared to a regular VM:
 - FileManager (Not yet supported for Windows)
 - PackageManager (Doesn't make a lot of sense for Windows Server)
 - DockerManager (Not yet supported for Windows)

For tests that should be run for all OSes including Windows, the user should use `CreateXXVM` otherwise the user should use `CreateNixXXXVM`.

Reviewing commit by commit is recommended.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
