### PR TITLE
Don't use TPM images by default on Windows as it is not supported by …

### DIFF
--- a/aws/scenarios/vm/os/windows.go
+++ b/aws/scenarios/vm/os/windows.go
@@ -27,7 +27,7 @@ func (w *windows) GetImage(arch commonos.Architecture) (string, error) {
 		return "", errors.New("ARM64 is not supported for Windows")
 	}
 	return ec2.GetLatestAMI(w.env, arch,
-		"/aws/service/ami-windows-latest/TPM-Windows_Server-2022-English-Full-Base",
+		"/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-Base",
 		"")
 }
 


### PR DESCRIPTION

What does this PR do?
---------------------
Don't use TPM images by default on Windows as it is not supported by all instance types.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
