### PR TITLE
Use pulumi.Random to generate Mac Addresses

### DIFF
--- a/aws/scenarios/microVMs/microvms/resources/amd64.go
+++ b/aws/scenarios/microVMs/microvms/resources/amd64.go
@@ -21,20 +21,20 @@ func NewAMD64ResourceCollection(recipe string) *AMD64ResourceCollection {
 	}
 }
 
-func (a *AMD64ResourceCollection) GetDomainXLS(args map[string]interface{}) string {
+func (a *AMD64ResourceCollection) GetDomainXLS(args map[string]pulumi.StringInput) pulumi.StringOutput {
 	return formatResourceXML(amd64DomainXLS, args)
 }
 
-func (a *AMD64ResourceCollection) GetNetworkXLS(args ...interface{}) string {
-	return GetDefaultNetworkXLS(args...)
+func (a *AMD64ResourceCollection) GetNetworkXLS(args map[string]pulumi.StringInput) pulumi.StringOutput {
+	return GetDefaultNetworkXLS(args)
 }
 
-func (a *AMD64ResourceCollection) GetVolumeXML(args ...interface{}) string {
-	return GetDefaultVolumeXML(args...)
+func (a *AMD64ResourceCollection) GetVolumeXML(args map[string]pulumi.StringInput) pulumi.StringOutput {
+	return GetDefaultVolumeXML(args)
 }
 
-func (a *AMD64ResourceCollection) GetPoolXML(args ...interface{}) string {
-	return GetDefaultPoolXML(args...)
+func (a *AMD64ResourceCollection) GetPoolXML(args map[string]pulumi.StringInput) pulumi.StringOutput {
+	return GetDefaultPoolXML(args)
 }
 
 func (a *AMD64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomainArgs) *libvirt.DomainArgs {
@@ -65,7 +65,7 @@ func (a *AMD64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomain
 		Memory:   pulumi.Int(args.Memory),
 		Vcpu:     pulumi.Int(args.Vcpu),
 		Xml: libvirt.DomainXmlArgs{
-			Xslt: pulumi.String(args.Xls),
+			Xslt: args.Xls,
 		},
 	}
 }

--- a/aws/scenarios/microVMs/microvms/resources/arm64.go
+++ b/aws/scenarios/microVMs/microvms/resources/arm64.go
@@ -22,20 +22,20 @@ func NewARM64ResourceCollection(recipe string) *ARM64ResourceCollection {
 
 }
 
-func (a *ARM64ResourceCollection) GetDomainXLS(args map[string]interface{}) string {
+func (a *ARM64ResourceCollection) GetDomainXLS(args map[string]pulumi.StringInput) pulumi.StringOutput {
 	return formatResourceXML(arm64DomainXLS, args)
 }
 
-func (a *ARM64ResourceCollection) GetNetworkXLS(args ...interface{}) string {
-	return GetDefaultNetworkXLS(args...)
+func (a *ARM64ResourceCollection) GetNetworkXLS(args map[string]pulumi.StringInput) pulumi.StringOutput {
+	return GetDefaultNetworkXLS(args)
 }
 
-func (a *ARM64ResourceCollection) GetVolumeXML(args ...interface{}) string {
-	return GetDefaultVolumeXML(args...)
+func (a *ARM64ResourceCollection) GetVolumeXML(args map[string]pulumi.StringInput) pulumi.StringOutput {
+	return GetDefaultVolumeXML(args)
 }
 
-func (a *ARM64ResourceCollection) GetPoolXML(args ...interface{}) string {
-	return GetDefaultPoolXML(args...)
+func (a *ARM64ResourceCollection) GetPoolXML(args map[string]pulumi.StringInput) pulumi.StringOutput {
+	return GetDefaultPoolXML(args)
 }
 
 func (a *ARM64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomainArgs) *libvirt.DomainArgs {
@@ -65,7 +65,7 @@ func (a *ARM64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomain
 		Memory:   pulumi.Int(args.Memory),
 		Vcpu:     pulumi.Int(args.Vcpu),
 		Xml: libvirt.DomainXmlArgs{
-			Xslt: pulumi.String(args.Xls),
+			Xslt: args.Xls,
 		},
 	}
 }

--- a/aws/scenarios/microVMs/microvms/resources/default.go
+++ b/aws/scenarios/microVMs/microvms/resources/default.go
@@ -3,7 +3,8 @@ package resources
 import (
 	// import embed
 	_ "embed"
-	"fmt"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 //go:embed default/domain.xls
@@ -22,14 +23,14 @@ func GetDefaultDomainXLS(args ...interface{}) string {
 	return defaultDomainXLS
 }
 
-func GetDefaultNetworkXLS(args ...interface{}) string {
-	return fmt.Sprintf(defaultNetworkXLS, args...)
+func GetDefaultNetworkXLS(args map[string]pulumi.StringInput) pulumi.StringOutput {
+	return formatResourceXML(defaultNetworkXLS, args)
 }
 
-func GetDefaultVolumeXML(args ...interface{}) string {
-	return fmt.Sprintf(defaultVolumeXML, args...)
+func GetDefaultVolumeXML(args map[string]pulumi.StringInput) pulumi.StringOutput {
+	return formatResourceXML(defaultVolumeXML, args)
 }
 
-func GetDefaultPoolXML(args ...interface{}) string {
-	return fmt.Sprintf(defaultPoolXML, args...)
+func GetDefaultPoolXML(args map[string]pulumi.StringInput) pulumi.StringOutput {
+	return formatResourceXML(defaultPoolXML, args)
 }

--- a/aws/scenarios/microVMs/microvms/resources/default/network.xls
+++ b/aws/scenarios/microVMs/microvms/resources/default/network.xls
@@ -5,7 +5,7 @@
 
   <xsl:template match="/network/ip/dhcp">
     <xsl:copy>
-        %s
+        {dhcpEntries}
       <xsl:apply-templates/>
     </xsl:copy>
   </xsl:template>

--- a/aws/scenarios/microVMs/microvms/resources/default/pool.xml
+++ b/aws/scenarios/microVMs/microvms/resources/default/pool.xml
@@ -1,12 +1,12 @@
 <pool type='dir'>
-  <name>%s</name>
+    <name>{poolName}</name>
   <capacity unit='bytes'>0</capacity>
   <allocation unit='bytes'>0</allocation>
   <available unit='bytes'>0</available>
   <source>
   </source>
   <target>
-    <path>%s</path>
+      <path>{poolPath}</path>
 	<permissions>
       <owner>$(cat /etc/passwd | grep libvirt-qemu | cut -d ':' -f 3)</owner>
 	  <group>$(cat /etc/group | grep kvm | cut -d ':' -f 3)</group>

--- a/aws/scenarios/microVMs/microvms/resources/default/volume.xml
+++ b/aws/scenarios/microVMs/microvms/resources/default/volume.xml
@@ -1,11 +1,11 @@
 <volume type='file'>
-  <name>%s</name>
-  <key>%s</key>
+    <name>{imageName}</name>
+    <key>{volumeKey}</key>
   <capacity unit='bytes'>10737418240</capacity>
   <allocation unit='bytes'>10000007168</allocation>
   <physical unit='bytes'>10000000000</physical>
   <target>
-    <path>%s</path>
+      <path>{volumePath}</path>
     <format type='qcow2'/>
     <permissions>
       <mode>0666</mode>

--- a/aws/scenarios/microVMs/microvms/resources/distro.go
+++ b/aws/scenarios/microVMs/microvms/resources/distro.go
@@ -21,20 +21,20 @@ func NewDistroResourceCollection(recipe string) *DistroResourceCollection {
 	}
 }
 
-func (a *DistroResourceCollection) GetDomainXLS(args map[string]interface{}) string {
+func (a *DistroResourceCollection) GetDomainXLS(args map[string]pulumi.StringInput) pulumi.StringOutput {
 	return formatResourceXML(distroDomainXLS, args)
 }
 
-func (a *DistroResourceCollection) GetNetworkXLS(args ...interface{}) string {
-	return GetDefaultNetworkXLS(args...)
+func (a *DistroResourceCollection) GetNetworkXLS(args map[string]pulumi.StringInput) pulumi.StringOutput {
+	return GetDefaultNetworkXLS(args)
 }
 
-func (a *DistroResourceCollection) GetVolumeXML(args ...interface{}) string {
-	return GetDefaultVolumeXML(args...)
+func (a *DistroResourceCollection) GetVolumeXML(args map[string]pulumi.StringInput) pulumi.StringOutput {
+	return GetDefaultVolumeXML(args)
 }
 
-func (a *DistroResourceCollection) GetPoolXML(args ...interface{}) string {
-	return GetDefaultPoolXML(args...)
+func (a *DistroResourceCollection) GetPoolXML(args map[string]pulumi.StringInput) pulumi.StringOutput {
+	return GetDefaultPoolXML(args)
 }
 
 func (a *DistroResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomainArgs) *libvirt.DomainArgs {
@@ -54,7 +54,7 @@ func (a *DistroResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomai
 		Memory: pulumi.Int(args.Memory),
 		Vcpu:   pulumi.Int(args.Vcpu),
 		Xml: libvirt.DomainXmlArgs{
-			Xslt: pulumi.String(args.Xls),
+			Xslt: args.Xls,
 		},
 	}
 }


### PR DESCRIPTION
What does this PR do?
---------------------
This PR introduces the use of pulumi.Random to generate mac addresses for the microvm network devices.
As a consequence it also changes the way parameters for the resource XML are formatted into the templates.

Which scenarios this will impact?
-------------------
This PR impacts the microVMs scenario only.

Motivation
----------
Without the use of pulumi.Random, pulumi falsely detects the network as having changed on each update, and therefore recreates all microVMs, since the network is a dependent resource for the domains (VMs).

Additional Notes
----------------
