### PR TITLE
[owners] add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Package code owners
+
+# The listed owners will be automatically added as reviewers for PRs,
+# to ensure code quality and consistency of the package, and identify
+# possible side effects.
+# PRs should still be peer-reviewed by the team opening the PR
+
+# See https://help.github.com/articles/about-codeowners/ for syntax
+# Rules are matched bottom-to-top, so one team can own subdirectories
+# and another the rest of the directory.
+
+/.*                                     @DataDog/agent-e2e-testing
+


### PR DESCRIPTION
What does this PR do?
---------------------

Add repo owners

Which scenarios this will impact?
-------------------

None

Motivation
----------

Allow split ownership on the repo

Additional Notes
----------------
