### PR TITLE
Allow to install Agent integration

### DIFF
--- a/command/filemanager.go
+++ b/command/filemanager.go
@@ -53,20 +53,26 @@ func (fm *FileManager) CopyFile(localPath, remotePath string, opts ...pulumi.Res
 }
 
 func (fm *FileManager) CopyInlineFile(name string, fileContent pulumi.StringInput, remotePath string, useSudo bool, opts ...pulumi.ResourceOption) (*remote.Command, error) {
-	return fm.runner.Command(name,
-		&Args{
-			Create: utils.WriteStringCommand(remotePath, useSudo),
-			Stdin:  fileContent,
-			Sudo:   useSudo,
-		}, opts...)
+	return fm.updateInlineFile(name, fileContent, remotePath, useSudo, utils.WriteStringCommand(remotePath, useSudo), opts...)
 }
 
 func (fm *FileManager) AppendInlineFile(name string, fileContent pulumi.StringInput, remotePath string, useSudo bool, opts ...pulumi.ResourceOption) (*remote.Command, error) {
+	return fm.updateInlineFile(name, fileContent, remotePath, useSudo, utils.AppendStringCommand(remotePath, useSudo), opts...)
+}
+
+func (fm *FileManager) updateInlineFile(
+	name string,
+	fileContent pulumi.StringInput,
+	remotePath string,
+	useSudo bool,
+	createCmd pulumi.StringInput,
+	opts ...pulumi.ResourceOption) (*remote.Command, error) {
 	return fm.runner.Command(name,
 		&Args{
-			Create: utils.AppendStringCommand(remotePath, useSudo),
-			Stdin:  fileContent,
-			Sudo:   useSudo,
+			Create:   createCmd,
+			Stdin:    fileContent,
+			Sudo:     useSudo,
+			Triggers: pulumi.Array{pulumi.String(remotePath), fileContent, pulumi.BoolPtr(useSudo)},
 		}, opts...)
 }
 

--- a/command/filemanager.go
+++ b/command/filemanager.go
@@ -61,6 +61,15 @@ func (fm *FileManager) CopyInlineFile(name string, fileContent pulumi.StringInpu
 		}, opts...)
 }
 
+func (fm *FileManager) AppendInlineFile(name string, fileContent pulumi.StringInput, remotePath string, useSudo bool, opts ...pulumi.ResourceOption) (*remote.Command, error) {
+	return fm.runner.Command(name,
+		&Args{
+			Create: utils.AppendStringCommand(remotePath, useSudo),
+			Stdin:  fileContent,
+			Sudo:   useSudo,
+		}, opts...)
+}
+
 // CopyRelativeFolder copies recursively a relative folder to a remote folder.
 // The path of the folder is relative to the caller of this function.
 // For example, if this function is called from ~/foo/test.go with remoteFolder="bar"

--- a/common/os/macos.go
+++ b/common/os/macos.go
@@ -12,7 +12,7 @@ func (*MacOS) GetServiceManager() *ServiceManager {
 	return &ServiceManager{restartCmd: []string{"launchctl stop com.datadoghq.agent", "launchctl start com.datadoghq.agent"}}
 }
 
-func (*MacOS) GetAgentConfigPath() string { return "~/.datadog-agent/datadog.yaml" }
+func (*MacOS) GetAgentConfigFolder() string { return "~/.datadog-agent" }
 
 func (*MacOS) GetAgentInstallCmd(version AgentVersion) (string, error) {
 	return getUnixInstallFormatString("install_mac_os.sh", version), nil

--- a/common/os/os.go
+++ b/common/os/os.go
@@ -28,7 +28,7 @@ type OS interface {
 	GetImage(Architecture) (string, error)
 	GetDefaultInstanceType(Architecture) string
 	GetServiceManager() *ServiceManager
-	GetAgentConfigPath() string
+	GetAgentConfigFolder() string
 	GetSSHUser() string
 	GetAgentInstallCmd(AgentVersion) (string, error)
 	GetType() Type

--- a/common/os/unix.go
+++ b/common/os/unix.go
@@ -19,7 +19,7 @@ func NewUnix(env config.Environment) *Unix {
 func (u *Unix) GetDefaultInstanceType(arch Architecture) string {
 	return getDefaultInstanceType(u.env, arch)
 }
-func (*Unix) GetAgentConfigPath() string { return "/etc/datadog-agent/datadog.yaml" }
+func (*Unix) GetAgentConfigFolder() string { return "/etc/datadog-agent" }
 
 func (*Unix) GetAgentInstallCmd(version AgentVersion) (string, error) {
 	return getUnixInstallFormatString("install_script.sh", version), nil

--- a/common/os/windows.go
+++ b/common/os/windows.go
@@ -32,7 +32,7 @@ func (*Windows) GetServiceManager() *ServiceManager {
 	return &ServiceManager{restartCmd: []string{`Start-Process "$($env:ProgramFiles)\Datadog\Datadog Agent\bin\agent.exe" -Wait -ArgumentList restart-service`}}
 }
 
-func (*Windows) GetAgentConfigPath() string { return `C:\ProgramData\Datadog\datadog.yaml` }
+func (*Windows) GetAgentConfigFolder() string { return `C:\ProgramData\Datadog` }
 
 func (*Windows) CreatePackageManager(runner *command.Runner) (command.PackageManager, error) {
 	return nil, errors.New("package manager is not supported on Windows")

--- a/common/utils/file.go
+++ b/common/utils/file.go
@@ -18,9 +18,17 @@ func ReadSecretFile(filePath string) (pulumi.StringOutput, error) {
 }
 
 func WriteStringCommand(filePath string, useSudo bool) pulumi.StringInput {
+	return writeStringCommand(filePath, useSudo, "")
+}
+
+func AppendStringCommand(filePath string, useSudo bool) pulumi.StringInput {
+	return writeStringCommand(filePath, useSudo, "-a")
+}
+
+func writeStringCommand(filePath string, useSudo bool, teeFlags string) pulumi.StringInput {
 	sudo := ""
 	if useSudo {
 		sudo = "sudo"
 	}
-	return pulumi.Sprintf(`cat - | %s tee %s > /dev/null`, sudo, filePath)
+	return pulumi.Sprintf(`cat - | %s tee %s %s > /dev/null`, sudo, teeFlags, filePath)
 }

--- a/datadog/agent/install.go
+++ b/datadog/agent/install.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"path"
 	"strings"
 
 	"github.com/DataDog/test-infra-definitions/command"
@@ -38,7 +39,7 @@ func NewInstaller(vm vm.VM, options ...func(*params) error) (*Installer, error) 
 
 	if params.agentConfig != "" {
 		fileManager := command.NewFileManager(runner)
-		remotePath := os.GetAgentConfigPath()
+		remotePath := path.Join(os.GetAgentConfigFolder(), "datadog.yaml")
 		agentConfig := env.AgentAPIKey().ApplyT(func(apiKey string) pulumi.String {
 			config := strings.ReplaceAll(params.agentConfig, "{{API_KEY}}", apiKey)
 			return pulumi.String(config)

--- a/datadog/agent/install.go
+++ b/datadog/agent/install.go
@@ -21,6 +21,7 @@ type Installer struct {
 // Temporary requires vm.UnixLikeVM until FileManager is available in VM
 func NewInstaller(vm *vm.UnixLikeVM, options ...func(*params) error) (*Installer, error) {
 	env := vm.GetCommonEnvironment()
+	options = addTelemetry(options)
 	params, err := newParams(env, options...)
 	if err != nil {
 		return nil, err
@@ -66,6 +67,20 @@ func NewInstaller(vm *vm.UnixLikeVM, options ...func(*params) error) (*Installer
 			}, pulumi.DependsOn([]pulumi.Resource{lastCommand}))
 	}
 	return &Installer{dependsOn: lastCommand}, err
+}
+
+func addTelemetry(options []func(*params) error) []func(*params) error {
+	config := `
+instances:
+  - expvar_url: http://localhost:5000/debug/vars
+    max_returned_metrics: 1000
+    metrics:      
+      - path: ".*"
+      - path: ".*/.*"
+      - path: ".*/.*/.*"
+`
+	options = append(options, WithIntegration("go_expvar.d", config))
+	return options
 }
 
 func updateAgentConfig(

--- a/datadog/agent/install.go
+++ b/datadog/agent/install.go
@@ -21,7 +21,6 @@ type Installer struct {
 // Temporary requires vm.UnixLikeVM until FileManager is available in VM
 func NewInstaller(vm *vm.UnixLikeVM, options ...func(*params) error) (*Installer, error) {
 	env := vm.GetCommonEnvironment()
-	options = addTelemetry(options)
 	params, err := newParams(env, options...)
 	if err != nil {
 		return nil, err
@@ -67,20 +66,6 @@ func NewInstaller(vm *vm.UnixLikeVM, options ...func(*params) error) (*Installer
 			}, pulumi.DependsOn([]pulumi.Resource{lastCommand}))
 	}
 	return &Installer{dependsOn: lastCommand}, err
-}
-
-func addTelemetry(options []func(*params) error) []func(*params) error {
-	config := `
-instances:
-  - expvar_url: http://localhost:5000/debug/vars
-    max_returned_metrics: 1000
-    metrics:      
-      - path: ".*"
-      - path: ".*/.*"
-      - path: ".*/.*/.*"
-`
-	options = append(options, WithIntegration("go_expvar.d", config))
-	return options
 }
 
 func updateAgentConfig(

--- a/datadog/agent/install.go
+++ b/datadog/agent/install.go
@@ -5,8 +5,11 @@ import (
 	"strings"
 
 	"github.com/DataDog/test-infra-definitions/command"
+	"github.com/DataDog/test-infra-definitions/common/namer"
+	"github.com/DataDog/test-infra-definitions/common/os"
 	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/common/vm"
+	"github.com/pulumi/pulumi-command/sdk/go/command/remote"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -14,7 +17,8 @@ type Installer struct {
 	dependsOn pulumi.Resource
 }
 
-func NewInstaller(vm vm.VM, options ...func(*params) error) (*Installer, error) {
+// Temporary requires vm.UnixLikeVM until FileManager is available in VM
+func NewInstaller(vm *vm.UnixLikeVM, options ...func(*params) error) (*Installer, error) {
 	env := vm.GetCommonEnvironment()
 	params, err := newParams(env, options...)
 	if err != nil {
@@ -51,10 +55,17 @@ func NewInstaller(vm vm.VM, options ...func(*params) error) (*Installer, error) 
 
 	}
 
+	var hash string
+	lastCommand, hash, err = installIntegrations(commonNamer, vm.GetFileManager(), params.integrations, os, lastCommand)
+
+	if err != nil {
+		return nil, err
+	}
+
 	// When the file content has changed, make sure the Agent is restarted.
 	serviceManager := os.GetServiceManager()
 	for _, cmd := range serviceManager.RestartAgentCmd() {
-		restartAgentRes := commonNamer.ResourceName("restart-agent", utils.StrHash(cmd, params.agentConfig))
+		restartAgentRes := commonNamer.ResourceName("restart-agent", utils.StrHash(cmd, params.agentConfig, utils.StrHash(hash)))
 		lastCommand, err = runner.Command(
 			restartAgentRes,
 			&command.Args{
@@ -62,4 +73,28 @@ func NewInstaller(vm vm.VM, options ...func(*params) error) (*Installer, error) 
 			}, pulumi.DependsOn([]pulumi.Resource{lastCommand}))
 	}
 	return &Installer{dependsOn: lastCommand}, err
+}
+
+func installIntegrations(
+	namer namer.Namer,
+	fileManager *command.FileManager,
+	integrations map[string]string,
+	os os.OS,
+	lastCommand *remote.Command) (*remote.Command, string, error) {
+	configFolder := os.GetAgentConfigFolder()
+	var parts []string
+	for folderName, content := range integrations {
+		var err error
+		confPath := path.Join(configFolder, "conf.d", folderName, "conf.yaml")
+		lastCommand, err = fileManager.CopyInlineFile(
+			namer.ResourceName(confPath, utils.StrHash(content)),
+			pulumi.String(content),
+			confPath, true, utils.PulumiDependsOn(lastCommand))
+		if err != nil {
+			return nil, "", err
+		}
+		parts = append(parts, folderName, content)
+	}
+
+	return lastCommand, utils.StrHash(parts...), nil
 }

--- a/datadog/agent/params.go
+++ b/datadog/agent/params.go
@@ -10,12 +10,15 @@ import (
 )
 
 type params struct {
-	version     os.AgentVersion
-	agentConfig string
+	version      os.AgentVersion
+	agentConfig  string
+	integrations map[string]string
 }
 
 func newParams(env *config.CommonEnvironment, options ...func(*params) error) (*params, error) {
-	p := &params{}
+	p := &params{
+		integrations: make(map[string]string),
+	}
 	defaultVersion := WithLatest()
 	if env.AgentVersion() != "" {
 		defaultVersion = WithVersion(env.AgentVersion())
@@ -58,6 +61,14 @@ func WithVersion(version string) func(*params) error {
 func WithAgentConfig(config string) func(*params) error {
 	return func(p *params) error {
 		p.agentConfig = config
+		return nil
+	}
+}
+
+// WithIntegration adds the configuration for an integration.
+func WithIntegration(folderName string, content string) func(*params) error {
+	return func(p *params) error {
+		p.integrations[folderName] = content
 		return nil
 	}
 }

--- a/datadog/agent/params.go
+++ b/datadog/agent/params.go
@@ -72,3 +72,17 @@ func WithIntegration(folderName string, content string) func(*params) error {
 		return nil
 	}
 }
+
+func WithTelemetry() func(*params) error {
+	return func(p *params) error {
+		config := `instances:
+  - expvar_url: http://localhost:5000/debug/vars
+    max_returned_metrics: 1000
+    metrics:      
+	  - path: ".*"
+	  - path: ".*/.*"
+	  - path: ".*/.*/.*"
+`
+		return WithIntegration("go_expvar.d", config)(p)
+	}
+}


### PR DESCRIPTION
What does this PR do?
---------------------

This PR adds the support for integrations. It also introduces `WithTelemetry` which provides the Agent telemetry (package `telemetry` and `go expvar`).

There is an issue when updating from `_, err = agent.NewInstaller(vm, agent.WithTelemetry())` to ` _, err = agent.NewInstaller(vm)`. Indeed, even with `pulumi.DeleteBeforeReplace(true)` on `restart-agent` resource, `restart-agent` is run before the integration files were removed. Any suggestions?

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
