### PR TITLE
Add runner level user

### DIFF
--- a/aws/scenarios/microVMs/microvms/run.go
+++ b/aws/scenarios/microVMs/microvms/run.go
@@ -124,19 +124,19 @@ func run(ctx *pulumi.Context, e aws.Environment) (*ScenarioDone, error) {
 			return nil, err
 		}
 
-		instance.remoteRunner, err = command.NewRunner(*e.CommonEnvironment, instance.instanceNamer.ResourceName("conn"), instance.Connection, func(r *command.Runner) (*remote.Command, error) {
+		instance.remoteRunner, err = command.NewRunner(*e.CommonEnvironment, instance.instanceNamer.ResourceName("conn"), "libvirt-qemu", instance.Connection, func(r *command.Runner) (*remote.Command, error) {
 			return command.WaitForCloudInit(e.Ctx, r)
 		})
 		if err != nil {
 			return nil, err
 		}
-		instance.localRunner = command.NewLocalRunner(*e.CommonEnvironment)
+		instance.localRunner = command.NewLocalRunner(*e.CommonEnvironment, "")
 
-		wait, err := provisionInstance(instance, &m)
+		waitProvision, err := provisionInstance(instance, &m)
 		if err != nil {
 			return nil, err
 		}
-		waitFor = append(waitFor, wait...)
+		waitFor = append(waitFor, waitProvision...)
 
 		privkey := m.GetStringWithDefault(m.MicroVMConfig, config.SSHKeyConfigNames[arch], defaultLibvirtSSHKey(SSHKeyFileNames[arch]))
 		url := pulumi.Sprintf("qemu+ssh://ubuntu@%s/system?sshauth=privkey&keyfile=%s&known_hosts_verify=ignore", instance.instance.PrivateIp, privkey)

--- a/aws/scenarios/microVMs/microvms/run.go
+++ b/aws/scenarios/microVMs/microvms/run.go
@@ -130,7 +130,7 @@ func run(ctx *pulumi.Context, e aws.Environment) (*ScenarioDone, error) {
 		if err != nil {
 			return nil, err
 		}
-		instance.localRunner = command.NewLocalRunner(*e.CommonEnvironment, "")
+		instance.localRunner = command.NewLocalRunner(*e.CommonEnvironment)
 
 		waitProvision, err := provisionInstance(instance, &m)
 		if err != nil {

--- a/aws/scenarios/microVMs/microvms/run.go
+++ b/aws/scenarios/microVMs/microvms/run.go
@@ -124,9 +124,9 @@ func run(ctx *pulumi.Context, e aws.Environment) (*ScenarioDone, error) {
 			return nil, err
 		}
 
-		instance.remoteRunner, err = command.NewRunner(*e.CommonEnvironment, instance.instanceNamer.ResourceName("conn"), "libvirt-qemu", instance.Connection, func(r *command.Runner) (*remote.Command, error) {
+		instance.remoteRunner, err = command.NewRunner(*e.CommonEnvironment, instance.instanceNamer.ResourceName("conn"), instance.Connection, func(r *command.Runner) (*remote.Command, error) {
 			return command.WaitForCloudInit(e.Ctx, r)
-		})
+		}, command.WithUser("libvirt-qemu"))
 		if err != nil {
 			return nil, err
 		}

--- a/command/filemanager.go
+++ b/command/filemanager.go
@@ -46,7 +46,7 @@ func (fm *FileManager) TempDirectory(name string, opts ...pulumi.ResourceOption)
 
 func (fm *FileManager) CopyFile(localPath, remotePath string, opts ...pulumi.ResourceOption) (*remote.CopyFile, error) {
 	return remote.NewCopyFile(fm.runner.e.Ctx, fm.runner.namer.ResourceName("copy", utils.StrHash(localPath, remotePath)), &remote.CopyFileArgs{
-		Connection: fm.runner.connection,
+		Connection: fm.runner.config.connection,
 		LocalPath:  pulumi.String(localPath),
 		RemotePath: pulumi.String(remotePath),
 	}, opts...)

--- a/command/runner.go
+++ b/command/runner.go
@@ -12,6 +12,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
+const DefaultUser = ""
+
 type Args struct {
 	Create      pulumi.StringInput
 	Update      pulumi.StringInput

--- a/command/runner.go
+++ b/command/runner.go
@@ -20,15 +20,13 @@ type Args struct {
 	Stdin       pulumi.StringPtrInput
 	Environment pulumi.StringMap
 	Sudo        bool
-	User        string
 }
 
 func (args *Args) toRemoteCommandArgs(config runnerConfiguration) *remote.CommandArgs {
 	var prefix string
+
 	if args.Sudo {
 		prefix = "sudo"
-	} else if args.User != "" {
-		prefix = fmt.Sprintf("sudo -u %s", args.User)
 	} else if config.user != "" {
 		prefix = fmt.Sprintf("sudo -u %s", config.user)
 	}
@@ -143,8 +141,6 @@ func (args *Args) toLocalCommandArgs(config runnerConfiguration) *local.CommandA
 	var prefix string
 	if args.Sudo {
 		prefix = "sudo"
-	} else if args.User != "" {
-		prefix = fmt.Sprintf("sudo -u %s", args.User)
 	} else if config.user != "" {
 		prefix = fmt.Sprintf("sudo -u %s", config.user)
 	}

--- a/command/runner.go
+++ b/command/runner.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/DataDog/test-infra-definitions/common/config"
@@ -20,18 +21,24 @@ type Args struct {
 	Sudo        bool
 }
 
-func (args *Args) toRemoteCommandArgs(c remote.ConnectionInput) *remote.CommandArgs {
+func (args *Args) toRemoteCommandArgs(config runnerConfiguration) *remote.CommandArgs {
+	var prefix string
+	if args.Sudo {
+		prefix = "sudo"
+	} else if config.user != "" {
+		prefix = fmt.Sprintf("sudo -u %s", config.user)
+	}
 	return &remote.CommandArgs{
-		Connection: c,
-		Create:     args.buildCommandInput(args.Create, args.Environment, args.Sudo),
-		Update:     args.buildCommandInput(args.Update, args.Environment, args.Sudo),
-		Delete:     args.buildCommandInput(args.Delete, args.Environment, args.Sudo),
+		Connection: config.connection,
+		Create:     args.buildCommandInput(args.Create, args.Environment, prefix),
+		Update:     args.buildCommandInput(args.Update, args.Environment, prefix),
+		Delete:     args.buildCommandInput(args.Delete, args.Environment, prefix),
 		Triggers:   args.Triggers,
 		Stdin:      args.Stdin,
 	}
 }
 
-func (args *Args) buildCommandInput(command pulumi.StringInput, env pulumi.StringMap, sudo bool) pulumi.StringInput {
+func (args *Args) buildCommandInput(command pulumi.StringInput, env pulumi.StringMap, prefix string) pulumi.StringInput {
 	if command == nil {
 		return nil
 	}
@@ -45,26 +52,29 @@ func (args *Args) buildCommandInput(command pulumi.StringInput, env pulumi.Strin
 		return strings.Join(inputs, " ")
 	}).(pulumi.StringOutput)
 
-	var prefix string
-	if sudo {
-		prefix = "sudo"
-	}
-
 	return pulumi.Sprintf("%s %s %s", prefix, envVarsStr, command)
+}
+
+type runnerConfiguration struct {
+	user       string
+	connection remote.ConnectionInput
 }
 
 type Runner struct {
 	e           config.CommonEnvironment
 	namer       namer.Namer
-	connection  remote.ConnectionInput
 	waitCommand *remote.Command
+	config      runnerConfiguration
 }
 
-func NewRunner(e config.CommonEnvironment, connName string, conn remote.ConnectionInput, readyFunc func(*Runner) (*remote.Command, error)) (*Runner, error) {
+func NewRunner(e config.CommonEnvironment, connName, asUser string, conn remote.ConnectionInput, readyFunc func(*Runner) (*remote.Command, error)) (*Runner, error) {
 	runner := &Runner{
-		e:          e,
-		namer:      namer.NewNamer(e.Ctx, "remote").WithPrefix(connName),
-		connection: conn,
+		e:     e,
+		namer: namer.NewNamer(e.Ctx, "remote").WithPrefix(connName),
+		config: runnerConfiguration{
+			connection: conn,
+			user:       asUser,
+		},
 	}
 
 	if readyFunc != nil {
@@ -83,31 +93,42 @@ func (r *Runner) Command(name string, args *Args, opts ...pulumi.ResourceOption)
 		opts = append(opts, pulumi.DependsOn([]pulumi.Resource{r.waitCommand}))
 	}
 
-	return remote.NewCommand(r.e.Ctx, r.namer.ResourceName("cmd", name), args.toRemoteCommandArgs(r.connection), opts...)
+	return remote.NewCommand(r.e.Ctx, r.namer.ResourceName("cmd", name), args.toRemoteCommandArgs(r.config), opts...)
 }
 
 type LocalRunner struct {
-	e     config.CommonEnvironment
-	namer namer.Namer
+	e      config.CommonEnvironment
+	namer  namer.Namer
+	config runnerConfiguration
 }
 
-func NewLocalRunner(e config.CommonEnvironment) *LocalRunner {
+func NewLocalRunner(e config.CommonEnvironment, asUser string) *LocalRunner {
 	return &LocalRunner{
 		e:     e,
 		namer: namer.NewNamer(e.Ctx, "local"),
+		config: runnerConfiguration{
+			user: asUser,
+		},
 	}
 }
 
-func (args *Args) toLocalCommandArgs() *local.CommandArgs {
+func (args *Args) toLocalCommandArgs(config runnerConfiguration) *local.CommandArgs {
+	var prefix string
+	if args.Sudo {
+		prefix = "sudo"
+	} else if config.user != "" {
+		prefix = fmt.Sprintf("sudo -u %s", config.user)
+	}
+
 	return &local.CommandArgs{
-		Create:   args.buildCommandInput(args.Create, args.Environment, args.Sudo),
-		Update:   args.buildCommandInput(args.Update, args.Environment, args.Sudo),
-		Delete:   args.buildCommandInput(args.Delete, args.Environment, args.Sudo),
+		Create:   args.buildCommandInput(args.Create, args.Environment, prefix),
+		Update:   args.buildCommandInput(args.Update, args.Environment, prefix),
+		Delete:   args.buildCommandInput(args.Delete, args.Environment, prefix),
 		Triggers: args.Triggers,
 		Stdin:    args.Stdin,
 	}
 }
 
 func (r *LocalRunner) Command(name string, args *Args, opts ...pulumi.ResourceOption) (*local.Command, error) {
-	return local.NewCommand(r.e.Ctx, r.namer.ResourceName("cmd", name), args.toLocalCommandArgs(), opts...)
+	return local.NewCommand(r.e.Ctx, r.namer.ResourceName("cmd", name), args.toLocalCommandArgs(r.config), opts...)
 }

--- a/command/runner.go
+++ b/command/runner.go
@@ -127,6 +127,8 @@ func (args *Args) toLocalCommandArgs(config runnerConfiguration) *local.CommandA
 	var prefix string
 	if args.Sudo {
 		prefix = "sudo"
+	} else if args.User != "" {
+		prefix = fmt.Sprintf("sudo -u %s", args.User)
 	} else if config.user != "" {
 		prefix = fmt.Sprintf("sudo -u %s", config.user)
 	}

--- a/command/runner.go
+++ b/command/runner.go
@@ -20,15 +20,19 @@ type Args struct {
 	Stdin       pulumi.StringPtrInput
 	Environment pulumi.StringMap
 	Sudo        bool
+	User        string
 }
 
 func (args *Args) toRemoteCommandArgs(config runnerConfiguration) *remote.CommandArgs {
 	var prefix string
 	if args.Sudo {
 		prefix = "sudo"
+	} else if args.User != "" {
+		prefix = fmt.Sprintf("sudo -u %s", args.User)
 	} else if config.user != "" {
 		prefix = fmt.Sprintf("sudo -u %s", config.user)
 	}
+
 	return &remote.CommandArgs{
 		Connection: config.connection,
 		Create:     args.buildCommandInput(args.Create, args.Environment, prefix),

--- a/command/utils.go
+++ b/command/utils.go
@@ -10,6 +10,7 @@ func WaitForCloudInit(ctx *pulumi.Context, runner *Runner) (*remote.Command, err
 		"wait-cloud-init",
 		&Args{
 			// `sudo` is required for amazon linux
-			Create: pulumi.String("sudo cloud-init status --wait"),
+			Create: pulumi.String("cloud-init status --wait"),
+			Sudo:   true,
 		})
 }

--- a/common/vm/vm.go
+++ b/common/vm/vm.go
@@ -79,7 +79,6 @@ func createRunner(
 	runner, err := command.NewRunner(
 		*commonEnv,
 		commonEnv.CommonNamer.ResourceName("connection"),
-		command.DefaultUser,
 		connection,
 		readyFunc)
 	if err != nil {

--- a/common/vm/vm.go
+++ b/common/vm/vm.go
@@ -79,6 +79,7 @@ func createRunner(
 	runner, err := command.NewRunner(
 		*commonEnv,
 		commonEnv.CommonNamer.ResourceName("connection"),
+		command.DefaultUser,
 		connection,
 		readyFunc)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 // indirect
 	github.com/acomagu/bufpipe v1.0.3 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect
+	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cheggaaa/pb v1.0.29 // indirect
 	github.com/cloudflare/circl v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,9 @@ github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da/go.mod h1:eHEWzANqSi
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
+github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
+github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=


### PR DESCRIPTION
What does this PR do?
---------------------
This PR provides support for adding a runner level option to set the user for all commands. It also extends `Args` to specify a specific `User` for individual command.
The priority level for deciding the user is: `sudo` -> `args.User` -> `runner.User`

Which scenarios this will impact?
-------------------
This impacts all scenarios.

Motivation
----------
The microvms scenario is simplified by being able to set a user for running all the commands, rather than handling permissions on a case-by-case basis.

Additional Notes
----------------
