### PR TITLE
[ecs] agent: ec2 tasks should also enable execution

### DIFF
--- a/datadog/agent/ecs.go
+++ b/datadog/agent/ecs.go
@@ -26,6 +26,7 @@ func ECSLinuxDaemonDefinition(e aws.Environment, name string, apiKeySSMParamName
 			SecurityGroups: pulumi.ToStringArray(e.DefaultSecurityGroups()),
 			Subnets:        pulumi.ToStringArray(e.DefaultSubnets()),
 		},
+		EnableExecuteCommand: pulumi.BoolPtr(true),
 		TaskDefinitionArgs: &ecs.EC2ServiceTaskDefinitionArgs{
 			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
 				"datadog-agent": ecsLinuxAgentSingleContainerDefinition(*e.CommonEnvironment, apiKeySSMParamName),


### PR DESCRIPTION
What does this PR do?
---------------------
This PR allows the EC2 ECS tasks to also allow remote execution (like the fargate ones).

Which scenarios this will impact?
-------------------
It'll affect EC2 ECS agent deployments.

Motivation
----------
One might want to jump into the tasks for troubleshooting, inspection, or otherwise.

Additional Notes
----------------
This is also consistent with the ECS Fargate deployments.
