### PR TITLE
Reorder commands to run with user 'libvirt-qemu'

### DIFF
--- a/aws/scenarios/microVMs/microvms/libvirt_fs.go
+++ b/aws/scenarios/microVMs/microvms/libvirt_fs.go
@@ -157,7 +157,7 @@ func extractRootfs(fs *LibvirtFilesystem, runner *command.Runner, depends []pulu
 	for _, fsImage := range fs.images {
 
 		extractTopLevelArchive := command.Args{
-			Create: pulumi.Sprintf("pushd /tmp; tar -xzf %s; popd;", fsImage.imagePath),
+			Create: pulumi.Sprintf("cd /tmp && tar -xzf %s", fsImage.imagePath),
 			Delete: pulumi.Sprintf("rm -rf %s", fsImage.imagePath),
 		}
 		res, err := runner.Command(fsImage.volumeNamer.ResourceName("extract-base-volume-package"), &extractTopLevelArchive, pulumi.DependsOn(depends))
@@ -246,7 +246,7 @@ func setupLibvirtVMVolume(fs *LibvirtFilesystem, runner *command.Runner, depends
 }
 
 func (fs *LibvirtFilesystem) setupLibvirtFilesystem(runner *command.Runner, depends []pulumi.Resource) ([]pulumi.Resource, error) {
-	downloadRootfsDone, err := downloadRootfs(fs, runner, []pulumi.Resource{})
+	downloadRootfsDone, err := downloadRootfs(fs, runner, depends)
 	if err != nil {
 		return []pulumi.Resource{}, err
 	}

--- a/aws/scenarios/microVMs/microvms/provision.go
+++ b/aws/scenarios/microVMs/microvms/provision.go
@@ -151,6 +151,11 @@ func prepareLibvirtSSHKeys(runner *command.Runner, localRunner *command.LocalRun
 		return []pulumi.Resource{}, err
 	}
 
+	// This command writes the public ssh key which pulumi uses to talk to the libvirt daemon, in the authorized_keys
+	// file of the default user. We must write in this file because pulumi runs its commands as the default user.
+	//
+	// We override the runner-level user here with root, and construct the path to the default users .ssh directory,
+	// in order to write the public ssh key in the correct file.
 	sshWriteArgs := command.Args{
 		Create: pulumi.Sprintf("echo '%s' >> $(getent passwd 1000 | cut -d: -f6)/.ssh/authorized_keys", sshgenDone.Stdout),
 		Sudo:   true,

--- a/aws/scenarios/microVMs/microvms/provision.go
+++ b/aws/scenarios/microVMs/microvms/provision.go
@@ -59,7 +59,7 @@ func downloadAndExtractKernelPackage(runner *command.Runner, arch string, depend
 	}
 
 	extractPackageArgs := command.Args{
-		Create: pulumi.Sprintf("cd /tmp/kernel-packages; tar xvf %s | xargs -i tar xzf {};", kernelPackages),
+		Create: pulumi.Sprintf("cd /tmp/kernel-packages && tar xvf %s | xargs -i tar xzf {};", kernelPackages),
 	}
 	extractPackageDone, err := runner.Command("extract-kernel-packages", &extractPackageArgs, pulumi.DependsOn([]pulumi.Resource{downloadKernelPackage}))
 	if err != nil {

--- a/aws/scenarios/microVMs/microvms/run.go
+++ b/aws/scenarios/microVMs/microvms/run.go
@@ -138,6 +138,13 @@ func run(ctx *pulumi.Context, e aws.Environment) (*ScenarioDone, error) {
 		}
 		waitFor = append(waitFor, waitProvision...)
 
+		pair := getSSHKeyPair(&m, instance.Arch)
+		prepareSSHKeysDone, err := prepareLibvirtSSHKeys(instance.remoteRunner, instance.localRunner, instance.instanceNamer, instance.Arch, pair, []pulumi.Resource{})
+		if err != nil {
+			return nil, err
+		}
+		waitFor = append(waitFor, prepareSSHKeysDone...)
+
 		privkey := m.GetStringWithDefault(m.MicroVMConfig, config.SSHKeyConfigNames[arch], defaultLibvirtSSHKey(SSHKeyFileNames[arch]))
 		url := pulumi.Sprintf("qemu+ssh://ubuntu@%s/system?sshauth=privkey&keyfile=%s&known_hosts_verify=ignore", instance.instance.PrivateIp, privkey)
 


### PR DESCRIPTION
What does this PR do?
---------------------
This PR takes advantage of setting the runner-level user to run all comands as user `libvirt-qemu`.

Which scenarios this will impact?
-------------------
Impacts microvms scenario.

Motivation
----------

Additional Notes
----------------
