### PR TITLE
Enable the agent deployment by default

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -82,7 +82,7 @@ func (e *CommonEnvironment) ResourcesTags() pulumi.StringMap {
 
 // Agent Namespace
 func (e *CommonEnvironment) AgentDeploy() bool {
-	return e.GetBoolWithDefault(e.AgentConfig, ddAgentDeployParamName, false)
+	return e.GetBoolWithDefault(e.AgentConfig, ddAgentDeployParamName, true)
 }
 
 func (e *CommonEnvironment) AgentVersion() string {


### PR DESCRIPTION
What does this PR do?
---------------------

Enable the agent deployment by default.
This value was set at false because it was not possible to not install the Agent when creating a VM.
As now, the Agent installation is independent with the VM creation, this value can be set at true.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
