### PR TITLE
[ecs] agent: network mode should be awsvpc for correct instantiation

### DIFF
--- a/datadog/agent/ecs.go
+++ b/datadog/agent/ecs.go
@@ -37,7 +37,7 @@ func ECSLinuxDaemonDefinition(e aws.Environment, name string, apiKeySSMParamName
 			TaskRole: &awsx.DefaultRoleWithPolicyArgs{
 				RoleArn: pulumi.StringPtr(e.ECSTaskRole()),
 			},
-			NetworkMode: pulumi.StringPtr("bridge"),
+			NetworkMode: pulumi.StringPtr("awsvpc"),
 			Family:      e.CommonNamer.DisplayName(pulumi.String("datadog-agent-ec2")),
 			Volumes: classicECS.TaskDefinitionVolumeArray{
 				classicECS.TaskDefinitionVolumeArgs{


### PR DESCRIPTION
What does this PR do?
---------------------
This PR addresses an issue where the ECS deployments failed due to an incorrect network mode being defined for EC2-based ECS cluster tasks. 

Which scenarios this will impact?
-------------------
ECS EC2(classic) based deployments

Motivation
----------
`bridge` mode was resulting in the following cluster/task instantiation error:
```
 * creating ECS Service (<id>-ec2-linux-dd-agent): InvalidParameterException: Network Configuration is not valid for the given networkMode of this task definition.
```

Changing the mode to `awsvpc` seems to address the problem.

source: https://stackoverflow.com/questions/59678757/awsvpc-network-configuration-is-not-valid-for-the-given-networkmode-of-this-tas

Additional Notes
----------------
