### PR TITLE
[ec2vm] expose aws env

### DIFF
--- a/aws/scenarios/dockerVM/run.go
+++ b/aws/scenarios/dockerVM/run.go
@@ -13,7 +13,7 @@ func Run(ctx *pulumi.Context) error {
 		return err
 	}
 
-	_, err = docker.NewAgentDockerInstaller(vm, docker.WithAgent())
+	_, err = docker.NewAgentDockerInstaller(vm.UnixVM, docker.WithAgent())
 
 	return err
 }

--- a/aws/scenarios/vm/ec2VM/ec2VM.go
+++ b/aws/scenarios/vm/ec2VM/ec2VM.go
@@ -11,8 +11,16 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-type EC2VM struct {
+type Infra struct {
 	env aws.Environment
+}
+
+func (infra *Infra) GetAwsEnvironment() aws.Environment {
+	return infra.env
+}
+
+type EC2VM struct {
+	Infra
 	commonvm.VM
 }
 
@@ -21,13 +29,9 @@ func NewEc2VM(ctx *pulumi.Context, options ...func(*Params) error) (*EC2VM, erro
 	return newVM(ctx, options...)
 }
 
-func (vm *EC2VM) GetAwsEnvironment() aws.Environment {
-	return vm.env
-}
-
 type EC2UnixVM struct {
+	Infra
 	*commonvm.UnixVM
-	*EC2VM
 }
 
 // NewUnixEc2VM creates a new EC2 instance. By default use WithOS(os.UbuntuOS, os.AMD64Arch).
@@ -44,7 +48,7 @@ func NewUnixEc2VM(ctx *pulumi.Context, options ...func(*Params) error) (*EC2Unix
 
 	return &EC2UnixVM{
 		UnixVM: unixVM,
-		EC2VM:  vm,
+		Infra:  vm.Infra,
 	}, nil
 }
 
@@ -93,8 +97,8 @@ func newVM(ctx *pulumi.Context, options ...func(*Params) error) (*EC2VM, error) 
 	}
 
 	return &EC2VM{
-		VM:  vm,
-		env: env,
+		VM:    vm,
+		Infra: Infra{env: env},
 	}, nil
 }
 


### PR DESCRIPTION
What does this PR do?
---------------------

Expose internal aws environment on EC2 vms. 

Which scenarios this will impact?
-------------------

unixvm

Motivation
----------

This is required to allow using the share a single aws environment in a scenario or test factory. Test setup using fakeintake will need this to initiate the fakeintake ec2 task

Additional Notes
----------------
