### PR TITLE
Add RemoteServiceConnector

### DIFF
--- a/common/utils/connection.go
+++ b/common/utils/connection.go
@@ -1,53 +1,6 @@
 package utils
 
-import (
-	"fmt"
-	"reflect"
-
-	"github.com/pulumi/pulumi/sdk/v3/go/auto"
-)
-
 type Connection struct {
 	Host string
 	User string
-}
-
-func NewConnection(result auto.UpResult, key string) (Connection, error) {
-	outputs, found := result.Outputs[key]
-	if !found {
-		return Connection{}, fmt.Errorf("cannot find %v in the stack result", key)
-	}
-
-	values, ok := outputs.Value.(map[string]interface{})
-	if !ok {
-		return Connection{}, fmt.Errorf("the type %v is not valid for the key %v", reflect.TypeOf(outputs.Value), key)
-	}
-
-	host, err := getMapStringValue(values, "host")
-	if err != nil {
-		return Connection{}, err
-	}
-
-	user, err := getMapStringValue(values, "user")
-	if err != nil {
-		return Connection{}, err
-	}
-
-	return Connection{
-		Host: host,
-		User: user,
-	}, nil
-
-}
-
-func getMapStringValue(values map[string]interface{}, key string) (string, error) {
-	value, found := values[key]
-	if !found {
-		return "", fmt.Errorf("key %v not found", key)
-	}
-	result, ok := value.(string)
-	if !ok {
-		return "", fmt.Errorf("invalid type for %v: %v. It must be `string`", key, reflect.TypeOf(key))
-	}
-	return result, nil
 }

--- a/common/utils/remoteServiceConnector.go
+++ b/common/utils/remoteServiceConnector.go
@@ -50,13 +50,13 @@ func NewRemoteServiceConnector[T any](ctx *pulumi.Context, initialValue T) *Remo
 // stackKeyName is the key in the stack name and should be unique
 // outputFieldName is the name of the field in the struct
 // value is the object to be saved in the stack
-func (s *RemoteServiceConnector[T]) Register(stackKeyName string, outputFieldName string, value pulumi.Input) {
-	s.ctx.Export(stackKeyName, value)
-	s.stackKeyFieldNameMap[stackKeyName] = outputFieldName
+func (c *RemoteServiceConnector[T]) Register(stackKeyName string, outputFieldName string, value pulumi.Input) {
+	c.ctx.Export(stackKeyName, value)
+	c.stackKeyFieldNameMap[stackKeyName] = outputFieldName
 }
 
-func (s *RemoteServiceConnector[T]) GetClientDataDeserializer() func(auto.UpResult) (*T, error) {
-	return s.deserializeFromUpResult
+func (c *RemoteServiceConnector[T]) GetClientDataDeserializer() func(auto.UpResult) (*T, error) {
+	return c.deserializeFromUpResult
 }
 
 func (c *RemoteServiceConnector[T]) deserializeFromUpResult(upResult auto.UpResult) (*T, error) {
@@ -80,7 +80,9 @@ func (c *RemoteServiceConnector[T]) deserializeFromUpResult(upResult auto.UpResu
 		}
 
 		if field.Kind() == reflect.Struct {
-			deserializeStruct(field, outputs)
+			if err := deserializeStruct(field, outputs); err != nil {
+				return nil, err
+			}
 		} else {
 			field.Set(reflect.ValueOf(outputs.Value))
 		}

--- a/common/utils/remoteServiceConnector.go
+++ b/common/utils/remoteServiceConnector.go
@@ -1,0 +1,109 @@
+package utils
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/auto"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// RemoteServiceConnector is a convenient struct to help implementing GetClientDataDeserializer().
+// Here is an example of usage when you want to serialize a Connection and a string.
+//
+//	 type ClientData struct {
+//	     MyString   string
+//	     Connection utils.Connection
+//	 }
+//
+//	 type MyRemoteService {
+//	     // This implement GetClientDataDeserializer() func(auto.UpResult) (*ClientData, error)
+//	     *RemoteServiceConnector[ClientData]
+//	 }
+//
+//		remoteServiceConnector := utils.NewRemoteServiceConnector(ctx, ClientData{})
+//		remoteServiceConnector.Register(stackKey, "Connection", connection)
+//		remoteServiceConnector.Register("test", "MyString", pulumi.String("Hello"))
+//
+//		return &MyRemoteService{
+//		    MyRemoteService: remoteServiceConnector
+//		}
+type RemoteServiceConnector[T any] struct {
+	ctx                  *pulumi.Context
+	stackKeyFieldNameMap map[string]string
+	value                T
+}
+
+// NewRemoteServiceConnector creates a new instance of RemoteServiceConnector[T].
+// initialValue is the initial value of the value returned by GetClientDataDeserializer.
+// initialValue can be used to return non pulumi.Input type.
+// T must be a struct.
+func NewRemoteServiceConnector[T any](ctx *pulumi.Context, initialValue T) *RemoteServiceConnector[T] {
+	return &RemoteServiceConnector[T]{
+		ctx:                  ctx,
+		value:                initialValue,
+		stackKeyFieldNameMap: make(map[string]string)}
+}
+
+// Register registers a field.
+// stackKeyName is the key in the stack name and should be unique
+// outputFieldName is the name of the field in the struct
+// value is the object to be saved in the stack
+func (s *RemoteServiceConnector[T]) Register(stackKeyName string, outputFieldName string, value pulumi.Input) {
+	s.ctx.Export(stackKeyName, value)
+	s.stackKeyFieldNameMap[stackKeyName] = outputFieldName
+}
+
+func (s *RemoteServiceConnector[T]) GetClientDataDeserializer() func(auto.UpResult) (*T, error) {
+	return s.deserializeFromUpResult
+}
+
+func (c *RemoteServiceConnector[T]) deserializeFromUpResult(upResult auto.UpResult) (*T, error) {
+	value := reflect.ValueOf(&c.value).Elem()
+	if value.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("the generic type T must be 'struct' whereas it is '%v'", value.Kind())
+	}
+	for stackKeyName, outputFieldName := range c.stackKeyFieldNameMap {
+		field := value.FieldByName(outputFieldName)
+		if !field.IsValid() {
+			return nil, fmt.Errorf("the field '%v' of the struct '%v' doesn't exist", outputFieldName, value.Type())
+		}
+
+		if !field.CanSet() {
+			return nil, fmt.Errorf("the field '%v' of the struct '%v' cannot be set", outputFieldName, value.Type())
+		}
+
+		outputs, found := upResult.Outputs[stackKeyName]
+		if !found {
+			return nil, fmt.Errorf("cannot find '%v' in the stack result", stackKeyName)
+		}
+
+		if field.Kind() == reflect.Struct {
+			deserializeStruct(field, outputs)
+		} else {
+			field.Set(reflect.ValueOf(outputs.Value))
+		}
+	}
+	return &c.value, nil
+}
+
+func deserializeStruct(field reflect.Value, output auto.OutputValue) error {
+	oututFields := output.Value.(map[string]interface{})
+	outputLowerFields := make(map[string]interface{})
+	for k, v := range oututFields {
+		outputLowerFields[strings.ToLower(k)] = v
+	}
+	fieldType := field.Type()
+	for i := 0; i < field.NumField(); i++ {
+		outputField := field.Field(i)
+		outputFieldName := fieldType.Field(i).Name
+		field, ok := outputLowerFields[strings.ToLower(outputFieldName)]
+		if !ok {
+			return fmt.Errorf("the field '%v' cannot be found in '%v'", outputFieldName, outputField.Type())
+		}
+
+		outputField.Set(reflect.ValueOf(field))
+	}
+	return nil
+}

--- a/common/vm/vm.go
+++ b/common/vm/vm.go
@@ -27,6 +27,7 @@ type genericVM struct {
 	os          commonos.OS
 	fileManager *command.FileManager
 	stackKey    string
+	*utils.RemoteServiceConnector[ClientData]
 }
 
 func NewGenericVM(
@@ -60,26 +61,21 @@ func NewGenericVM(
 	}
 
 	stackKey := fmt.Sprintf("%v-connection", name)
-	ctx.Export(stackKey, connection)
 
+	remoteServiceConnector := utils.NewRemoteServiceConnector(ctx, ClientData{})
+	remoteServiceConnector.Register(stackKey, "Connection", connection)
 	return &genericVM{
-		runner:      runner,
-		env:         commonEnv,
-		os:          os,
-		stackKey:    stackKey,
-		fileManager: command.NewFileManager(runner),
+		runner:                 runner,
+		env:                    commonEnv,
+		os:                     os,
+		stackKey:               stackKey,
+		fileManager:            command.NewFileManager(runner),
+		RemoteServiceConnector: remoteServiceConnector,
 	}, nil
 }
 
 type ClientData struct {
 	Connection utils.Connection
-}
-
-func (vm *genericVM) GetClientDataDeserializer() func(auto.UpResult) (*ClientData, error) {
-	return func(result auto.UpResult) (*ClientData, error) {
-		connection, err := utils.NewConnection(result, vm.stackKey)
-		return &ClientData{Connection: connection}, err
-	}
 }
 
 func (vm *genericVM) GetRunner() *command.Runner {


### PR DESCRIPTION
What does this PR do?
---------------------
This PR adds `RemoteServiceConnector` which is a convenient struct to help implementing `GetClientDataDeserializer()`.
Here is an example of usage when you want to serialize a `Connection` and a `string`.
```go
type ClientData struct {
	     MyString   string
	     Connection utils.Connection
}

type MyRemoteService {
	     // This implement GetClientDataDeserializer() func(auto.UpResult) (*ClientData, error)
	     *RemoteServiceConnector[ClientData]
}

remoteServiceConnector := utils.NewRemoteServiceConnector(ctx, ClientData{})
remoteServiceConnector.Register(stackKey, "Connection", connection)
remoteServiceConnector.Register("test", "MyString", pulumi.String("Hello"))

return &MyRemoteService{
     MyRemoteService: remoteServiceConnector
}
```

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
