### PR TITLE
[unix] properly format linux command with sudo or user

### DIFF
--- a/command/docker.go
+++ b/command/docker.go
@@ -127,13 +127,24 @@ func (d *DockerManager) Install(opts ...pulumi.ResourceOption) (*remote.Command,
 		return nil, err
 	}
 
+	whoami, err := d.runner.Command(
+		d.namer.ResourceName("whoami"),
+		&Args{
+			Create: pulumi.String("whoami"),
+			Sudo:   false,
+		},
+		pulumi.DependsOn([]pulumi.Resource{dockerInstall}))
+	if err != nil {
+		return nil, err
+	}
+
 	usermod, err := d.runner.Command(
 		d.namer.ResourceName("group"),
 		&Args{
-			Create: pulumi.String("usermod -a -G docker $(whoami)"),
+			Create: pulumi.Sprintf("usermod -a -G docker %s", whoami),
 			Sudo:   true,
 		},
-		pulumi.DependsOn([]pulumi.Resource{dockerInstall}))
+		pulumi.DependsOn([]pulumi.Resource{whoami}))
 	if err != nil {
 		return nil, err
 	}

--- a/command/runner.go
+++ b/command/runner.go
@@ -1,6 +1,8 @@
 package command
 
 import (
+	"fmt"
+
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/namer"
 	"github.com/pulumi/pulumi-command/sdk/go/command/local"
@@ -81,7 +83,9 @@ func (r *Runner) Command(name string, args *Args, opts ...pulumi.ResourceOption)
 	if r.waitCommand != nil {
 		opts = append(opts, pulumi.DependsOn([]pulumi.Resource{r.waitCommand}))
 	}
-
+	if args.Sudo && r.config.user != "" {
+		r.e.Ctx.Log.Info(fmt.Sprintf("warning: running sudo command on a runner with user %s, discarding user", r.config.user), nil)
+	}
 	return remote.NewCommand(r.e.Ctx, r.namer.ResourceName("cmd", name), args.toRemoteCommandArgs(r.config, r.osCommand), opts...)
 }
 


### PR DESCRIPTION
What does this PR do?
---------------------

Fix sudo command execution by properly formatting, handling separately `sudo` and `sudo -u`


Which scenarios this will impact?
-------------------

dockerVM, all

Motivation
----------

https://github.com/DataDog/test-infra-definitions/pull/44 broke docker vm scenario and docker commands, as it prefixed command with `sudo bash -c '<command>'` instead of `sudo <command>`

This ended up in running subshell commands as `root` user instead of default user as we were expecting

```
ubuntu@ip:~$ sudo  bash -c 'echo $(whoami)'
root
ubuntu@ip:~$ bash -c 'sudo echo $(whoami)'
ubuntu
```

Additional Notes
----------------
