### PR TITLE
[golangci-lint] upgrade version and remove parallel runs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.50.1
+    rev: v1.52.2
     hooks:
     - id: golangci-lint
-      args: ["--allow-parallel-runners"]


### PR DESCRIPTION
What does this PR do?
---------------------

This change plus upgrading both `pre-commit` and `golangci-lint` dramatically improved performance on my local machine. 

Which scenarios this will impact?
-------------------

Motivation
----------

precommit-hook became super slow recently. Could not find the root cause, but this couple of changes improved its performance

Additional Notes
----------------
