### PR TITLE
[CI] slightly improve linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
       - uses: actions/setup-go@v3
         with:
           go-version-file: go.mod

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,4 +36,4 @@ jobs:
         # - https://github.com/golangci/golangci-lint-action/issues/442
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
       - name: Run golangci-lint
-        run: golangci-lint version && golangci-lint run --new
+        run: golangci-lint version && golangci-lint run --new-from-rev=HEAD~

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,4 +36,4 @@ jobs:
         # - https://github.com/golangci/golangci-lint-action/issues/442
         run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
       - name: Run golangci-lint
-        run: golangci-lint version && golangci-lint run --new-from-rev=HEAD~
+        run: golangci-lint version && golangci-lint run --new-from-rev=HEAD~ --out-format=github-actions --timeout=10m


### PR DESCRIPTION
What does this PR do?
---------------------

* uses the recommended `--new` option for the CI 
* fix diff warning
* increase golangci-lint timeout to reduce faiures

You can see it slightly reduces linter time back under 6 min 
![image](https://user-images.githubusercontent.com/45568537/233576569-0cbb196d-0734-4429-b5da-f44f9ba918fa.png)


Which scenarios this will impact?
-------------------

Motivation
----------

Linter action in the CI slowed down recently, causing timeout errors. The root cause is the go packages loading taking > 3 minutes. We could improve with a static cache\

```
level=info msg="[loader] Go packages loading at mode 575 (files|types_sizes|compiled_files|deps|exports_file|imports|name) took 3m14.498308796s"
```


Additional Notes
----------------
