### PR TITLE
[filemanager] fix create directory and copy inline file

### DIFF
--- a/command/osCommand.go
+++ b/command/osCommand.go
@@ -43,7 +43,6 @@ func createDirectory(
 	name string,
 	createCmd string,
 	deleteCmd string,
-	remotePath pulumi.StringInput,
 	useSudo bool,
 	opts ...pulumi.ResourceOption) (*remote.Command, error) {
 	// If the folder was previously created, make sure to delete it before creating it.
@@ -53,7 +52,7 @@ func createDirectory(
 			Create:   pulumi.String(createCmd),
 			Delete:   pulumi.String(deleteCmd),
 			Sudo:     useSudo,
-			Triggers: pulumi.Array{remotePath, pulumi.BoolPtr(useSudo)},
+			Triggers: pulumi.Array{pulumi.String(createCmd), pulumi.BoolPtr(useSudo)},
 		}, opts...)
 }
 

--- a/command/osCommand.go
+++ b/command/osCommand.go
@@ -46,13 +46,12 @@ func createDirectory(
 	remotePath pulumi.StringInput,
 	useSudo bool,
 	opts ...pulumi.ResourceOption) (*remote.Command, error) {
-
 	// If the folder was previously created, make sure to delete it before creating it.
 	opts = append(opts, pulumi.DeleteBeforeReplace(true))
 	return runner.Command(name,
 		&Args{
-			Create:   pulumi.Sprintf(createCmd, remotePath),
-			Delete:   pulumi.Sprintf(deleteCmd, remotePath),
+			Create:   pulumi.String(createCmd),
+			Delete:   pulumi.String(deleteCmd),
 			Sudo:     useSudo,
 			Triggers: pulumi.Array{remotePath, pulumi.BoolPtr(useSudo)},
 		}, opts...)

--- a/command/unixOSCommand.go
+++ b/command/unixOSCommand.go
@@ -66,7 +66,7 @@ func (fs unixOSCommand) BuildCommandString(command pulumi.StringInput, env pulum
 
 	var envVars pulumi.StringArray
 	for varName, varValue := range env {
-		envVars = append(envVars, pulumi.Sprintf(`%s="%s"`, varName, varValue))
+		envVars = append(envVars, pulumi.Sprintf(`%v="%v"`, varName, varValue))
 	}
 
 	return buildCommandString(formattedCommand, envVars, func(envVarsStr pulumi.StringOutput) pulumi.StringInput {
@@ -84,10 +84,10 @@ func formatCommandIfNeeded(command pulumi.StringInput, sudo bool, user string) p
 	}
 	var formattedCommand pulumi.StringInput
 	if sudo {
-		formattedCommand = pulumi.Sprintf("sudo %s", command)
+		formattedCommand = pulumi.Sprintf("sudo %v", command)
 	} else if user != "" {
 		formattedCommand = command.ToStringOutput().ApplyT(func(cmd string) string {
-			return fmt.Sprintf("sudo -u %s bash -c %s", user, shellescape.Quote(cmd))
+			return fmt.Sprintf("sudo -u %v bash -c %v", user, shellescape.Quote(cmd))
 		}).(pulumi.StringOutput)
 	}
 	return formattedCommand

--- a/command/unixOSCommand.go
+++ b/command/unixOSCommand.go
@@ -26,11 +26,15 @@ func (unixOSCommand) CreateDirectory(
 	remotePath pulumi.StringInput,
 	useSudo bool,
 	opts ...pulumi.ResourceOption) (*remote.Command, error) {
+
+	createCmd := fmt.Sprintf("mkdir -p %v", remotePath)
+	deleteCmd := fmt.Sprintf("bash -c 'if [ -z '$(ls -A %v)' ]; then rm -d %v; fi'", remotePath, remotePath)
+	// check if directory already exist
 	return createDirectory(
 		runner,
 		name,
-		"mkdir -p %s",
-		"rm -rf %s",
+		createCmd,
+		deleteCmd,
 		remotePath,
 		useSudo,
 		opts...)

--- a/command/unixOSCommand.go
+++ b/command/unixOSCommand.go
@@ -35,7 +35,6 @@ func (unixOSCommand) CreateDirectory(
 		name,
 		createCmd,
 		deleteCmd,
-		remotePath,
 		useSudo,
 		opts...)
 }

--- a/command/unixOSCommand.go
+++ b/command/unixOSCommand.go
@@ -47,14 +47,10 @@ func (unixOSCommand) CopyInlineFile(
 	useSudo bool,
 	opts ...pulumi.ResourceOption) (*remote.Command, error) {
 
-	sudo := ""
-	if useSudo {
-		sudo = "sudo"
-	}
 	backupPath := remotePath + "." + backupExtension
-	backupCmd := fmt.Sprintf("if [ -f '%v' ]; then %v mv -f '%v' '%v'; fi", remotePath, sudo, remotePath, backupPath)
-	createCmd := fmt.Sprintf("(%v) && cat - | %s tee %s > /dev/null", backupCmd, sudo, remotePath)
-	deleteCmd := fmt.Sprintf("if [ -f '%v' ]; then %v mv -f '%v' '%v'; else %v rm -f '%v'; fi", backupPath, sudo, backupPath, remotePath, sudo, remotePath)
+	backupCmd := fmt.Sprintf("if [ -f '%v' ]; then mv -f '%v' '%v'; fi", remotePath, remotePath, backupPath)
+	createCmd := fmt.Sprintf("bash -c '(%v) && cat - | tee %v > /dev/null'", backupCmd, remotePath)
+	deleteCmd := fmt.Sprintf("bash -c 'if [ -f '%v' ]; then mv -f '%v' '%v'; else rm -f '%v'; fi'", backupPath, backupPath, remotePath, remotePath)
 	opts = append(opts, pulumi.ReplaceOnChanges([]string{"*"}), pulumi.DeleteBeforeReplace(true))
 	return copyInlineFile(remotePath, runner, fileContent, useSudo, createCmd, deleteCmd, opts...)
 }

--- a/command/windowsOSCommand.go
+++ b/command/windowsOSCommand.go
@@ -25,8 +25,8 @@ func (fs windowsOSCommand) CreateDirectory(
 	return createDirectory(
 		runner,
 		name,
-		"New-Item -Path %s -ItemType Directory -Force",
-		"Remove-Item -Path %s -Force -ErrorAction SilentlyContinue -Recurse",
+		fmt.Sprintf("New-Item -Path %v -ItemType Directory", remotePath),
+		fmt.Sprintf("if (-not (Test-Path -Path %v/*)) { Remove-Item -Path %v -ErrorAction SilentlyContinue }", remotePath, remotePath),
 		remotePath,
 		useSudo,
 		opts...)

--- a/command/windowsOSCommand.go
+++ b/command/windowsOSCommand.go
@@ -27,7 +27,6 @@ func (fs windowsOSCommand) CreateDirectory(
 		name,
 		fmt.Sprintf("New-Item -Path %v -ItemType Directory", remotePath),
 		fmt.Sprintf("if (-not (Test-Path -Path %v/*)) { Remove-Item -Path %v -ErrorAction SilentlyContinue }", remotePath, remotePath),
-		remotePath,
 		useSudo,
 		opts...)
 }


### PR DESCRIPTION
What does this PR do?
---------------------

* On delete remove directory only when it is empty
* Wrap create and delete commands for copy inline file in a separate shell 

Which scenarios this will impact?
-------------------

VM

Motivation
----------

`CreateDirectory` configures a delete action that is execute when the directory resource is removed from the stack, for example when calling `pulumi down`. When `CreateDirectory` is called on an existing directory, the `create` command does nothing, but the delete command removes it. This is unexpected for users and can cause issues. As an example, if we create the agent config directory, removing the directory resource would delete the configuration directory and mess up with the agent install.

In this PR I suggest removing only empty directories, as when we create files within pulumi, the create file command takes care of removing those files. The directory will be empty by the time `pulumi down` reaches the directory resource.

Caveat: if files are created out of pulumi, with ssh command, and not cleaned up, pulumi won't delete the directory. I consider this can be tolerated as we deal with ephemeral instances, that would be terminated at the end of manual or automated tests.

While working on this task I realised that `CopyInlineFile` was broken by https://github.com/DataDog/test-infra-definitions/pull/79 😢 . The underlying `runner.Command` on Linux prefixes command content by `sudo` when `useSudo` is true. Before https://github.com/DataDog/test-infra-definitions/pull/79 it was wrapping the command in a new shell, and prefixing the new shell with `sudo`. This had some unexpected behaviours: what would you expect to get running the following command with user "ubuntu" ?  

```bash
sudo echo $(whoami)
```

Now what would you expect pulumi to run when running the following instruction ?

```golang
runner.Command("echo whoami", &Args{Create:   "echo $(whoami), Sudo:     useSudo})
``` 

1. You expect "root"
2. You expect "ubuntu"

In linux running

```
sudo echo $(whoami)
```

runs `whoami` in a subshell, as "ubuntu" and `echo` as `sudo`. If you expect `root`, then we should go back to wrapping command in a new shell with `bash -c '<command>'`.  The bug fixed by https://github.com/DataDog/test-infra-definitions/pull/79 was caused by expecting `2`.

See the following example:

```
1. formatComand(command, useSudo=true) => sudo command

formatCommand("echo $(whoami)", true) => sudo echo $(whoami) ====> ubuntu

formatCommand("if true; then whoami; fi", true) => sudo if true; then whoami; fi ====> "This command is broken, syntax error"

formatCommand("bash -c 'if true; then whoami; fi'", true) ==> root

2. formatComand(command, useSudo=true) => sudo bash -c 'command'

formatCommand("echo $(whoami)", true) => sudo bash -c 'echo $(whoami)' ====> root

formatCommand("if true; then whoami; fi", true) => sudo bash -c if true; then whoami; fi ====> root
```

Additional Notes
----------------
