### PR TITLE
[agent] skip agent config update on empty agent or extra config

### DIFF
--- a/datadog/agent/install.go
+++ b/datadog/agent/install.go
@@ -82,7 +82,7 @@ func updateAgentConfig(
 	extraAgentConfig []pulumi.StringInput,
 	os os.OS,
 	lastCommand *remote.Command) (*remote.Command, pulumi.StringInput, error) {
-	if agentConfig == "" || len(extraAgentConfig) == 0 {
+	if agentConfig == "" && len(extraAgentConfig) == 0 {
 		// no update in agent config, safely early return
 		return nil, nil, nil
 	}

--- a/datadog/agent/install.go
+++ b/datadog/agent/install.go
@@ -84,7 +84,7 @@ func updateAgentConfig(
 	lastCommand *remote.Command) (*remote.Command, pulumi.StringInput, error) {
 	if agentConfig == "" && len(extraAgentConfig) == 0 {
 		// no update in agent config, safely early return
-		return nil, nil, nil
+		return lastCommand, nil, nil
 	}
 
 	agentConfigFullPath := path.Join(os.GetAgentConfigFolder(), "datadog.yaml")


### PR DESCRIPTION
What does this PR do?
---------------------

Skip agent config update on empty agent or no extra config

Which scenarios this will impact?
-------------------

VM with agent install

Motivation
----------

This was breaking agent install `WithFakeintake` as extraconfig was not considered, and `agentConfig` was empty

Additional Notes
----------------
