### PR TITLE
Simplify the deserialisation of remote service

### DIFF
--- a/common/utils/remoteServiceConnector.go
+++ b/common/utils/remoteServiceConnector.go
@@ -55,11 +55,7 @@ func (c *RemoteServiceConnector[T]) Register(stackKeyName string, outputFieldNam
 	c.stackKeyFieldNameMap[stackKeyName] = outputFieldName
 }
 
-func (c *RemoteServiceConnector[T]) GetClientDataDeserializer() func(auto.UpResult) (*T, error) {
-	return c.deserializeFromUpResult
-}
-
-func (c *RemoteServiceConnector[T]) deserializeFromUpResult(upResult auto.UpResult) (*T, error) {
+func (c *RemoteServiceConnector[T]) Deserialize(upResult auto.UpResult) (*T, error) {
 	value := reflect.ValueOf(&c.value).Elem()
 	if value.Kind() != reflect.Struct {
 		return nil, fmt.Errorf("the generic type T must be 'struct' whereas it is '%v'", value.Kind())

--- a/common/utils/remoteServiceDeserializer.go
+++ b/common/utils/remoteServiceDeserializer.go
@@ -1,0 +1,7 @@
+package utils
+
+import "github.com/pulumi/pulumi/sdk/v3/go/auto"
+
+type RemoteServiceDeserializer[T any] interface {
+	Deserialize(auto.UpResult) (*T, error)
+}

--- a/common/vm/vm.go
+++ b/common/vm/vm.go
@@ -9,15 +9,14 @@ import (
 	"github.com/DataDog/test-infra-definitions/common/utils"
 
 	"github.com/pulumi/pulumi-command/sdk/go/command/remote"
-	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 type VM interface {
+	utils.RemoteServiceDeserializer[ClientData]
 	GetRunner() *command.Runner
 	GetCommonEnvironment() *config.CommonEnvironment
 	GetOS() commonos.OS
-	GetClientDataDeserializer() func(auto.UpResult) (*ClientData, error)
 	GetFileManager() *command.FileManager
 }
 

--- a/datadog/agent/install.go
+++ b/datadog/agent/install.go
@@ -13,6 +13,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
+var _ utils.RemoteServiceDeserializer[ClientData] = (*Installer)(nil)
+
 type Installer struct {
 	dependsOn pulumi.Resource
 	vm        vm.VM
@@ -134,15 +136,11 @@ type ClientData struct {
 	Connection utils.Connection
 }
 
-func (installer *Installer) GetClientDataDeserializer() func(auto.UpResult) (*ClientData, error) {
-	vmDataDeserializer := installer.vm.GetClientDataDeserializer()
-	return func(result auto.UpResult) (*ClientData, error) {
-		vmData, err := vmDataDeserializer(result)
-
-		if err != nil {
-			return nil, err
-		}
-
-		return &ClientData{Connection: vmData.Connection}, nil
+func (installer *Installer) Deserialize(result auto.UpResult) (*ClientData, error) {
+	vmData, err := installer.vm.Deserialize(result)
+	if err != nil {
+		return nil, err
 	}
+
+	return &ClientData{Connection: vmData.Connection}, nil
 }

--- a/datadog/fakeintake/connectionExporter.go
+++ b/datadog/fakeintake/connectionExporter.go
@@ -23,19 +23,16 @@ type ClientData struct {
 	URL string
 }
 
-// GetClientDataDeserializer
-func (exporter *ConnectionExporter) GetClientDataDeserializer() func(auto.UpResult) (*ClientData, error) {
-	return func(result auto.UpResult) (*ClientData, error) {
-		outputs, found := result.Outputs[exporter.stackKey]
-		if !found {
-			return nil, fmt.Errorf("cannot find %v in the stack result", exporter.stackKey)
-		}
-		url, ok := outputs.Value.(string)
-		if !ok {
-			return nil, fmt.Errorf("the type %v is not valid for the key %v", reflect.TypeOf(outputs.Value), exporter.stackKey)
-		}
-		return &ClientData{URL: url}, nil
+func (exporter *ConnectionExporter) Deserialize(result auto.UpResult) (*ClientData, error) {
+	outputs, found := result.Outputs[exporter.stackKey]
+	if !found {
+		return nil, fmt.Errorf("cannot find %v in the stack result", exporter.stackKey)
 	}
+	url, ok := outputs.Value.(string)
+	if !ok {
+		return nil, fmt.Errorf("the type %v is not valid for the key %v", reflect.TypeOf(outputs.Value), exporter.stackKey)
+	}
+	return &ClientData{URL: url}, nil
 }
 
 // NewExporter registers a fakeintake url into a Pulumi context.


### PR DESCRIPTION
What does this PR do?
---------------------

Simplify the deserialisation of remote service. Change from `GetClientDataDeserializer() func(auto.UpResult) (*T, error)` to `Deserialize(upResult auto.UpResult) (*T, error)`
