### PR TITLE
[invoke] use python 3.8 compatible remove suffix

### DIFF
--- a/tasks/destroy.py
+++ b/tasks/destroy.py
@@ -56,6 +56,6 @@ def _get_existing_stacks() -> List[str]:
     for line in lines:
         stack_name = line.split(" ")[0]
         if stack_name.endswith(stack_name_suffix):
-            stack_name = stack_name.removesuffix(stack_name_suffix)
+            stack_name = stack_name[:-len(stack_name_suffix)]
             stacks.append(stack_name)
     return stacks


### PR DESCRIPTION
What does this PR do?
---------------------

Use 3.8 compatible `str[:-len(suffix)]` to remove stack name suffix instead of 3.9 `removesuffix`

Which scenarios this will impact?
-------------------

Motivation
----------

`removesuffix` is available in 3.9 while Datadog Agent repo is based on 3.7+

Source: https://peps.python.org/pep-0616/

Additional Notes
----------------
