### PR TITLE
Add EKS invoke task

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,6 +1,7 @@
 from invoke import Collection
 
 from tasks.docker import create_docker, destroy_docker
+from tasks.eks import create_eks, destroy_eks
 from .vm import create_vm, destroy_vm
 
 ns = Collection()
@@ -8,3 +9,5 @@ ns.add_task(create_vm)
 ns.add_task(destroy_vm)
 ns.add_task(create_docker)
 ns.add_task(destroy_docker)
+ns.add_task(create_eks)
+ns.add_task(destroy_eks)

--- a/tasks/config.py
+++ b/tasks/config.py
@@ -16,6 +16,7 @@ class Config(BaseModel, extra=Extra.forbid):
 
         class Agent(BaseModel, extra=Extra.forbid):
             apiKey: Optional[str]
+            appKey: Optional[str]
         
         agent: Optional[Agent]
 
@@ -45,7 +46,8 @@ class Config(BaseModel, extra=Extra.forbid):
   
     def get_agent(self) -> Params.Agent:
         default = Config.Params.Agent(
-            apiKey=None
+            apiKey=None,
+            appKey=None
         )
         if self.configParams == None:
             return default
@@ -53,10 +55,9 @@ class Config(BaseModel, extra=Extra.forbid):
             return default
         return self.configParams.agent
     
-    def get_stack_params(self) -> Dict[str, Dict[str,str]]:
-        default = Dict[str, Dict[str,str]]
+    def get_stack_params(self) -> Dict[str, Dict[str,str]]:        
         if self.stackParams == None:
-            return default
+            return {}
         return self.stackParams
 
 

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -4,7 +4,7 @@ import os
 import invoke
 import subprocess
 from invoke.context import Context
-from typing import List, Optional, Dict, Any
+from typing import Callable, List, Optional, Dict, Any
 import pathlib
 from . import tool
 
@@ -16,6 +16,7 @@ def deploy(
     scenario_name: str,
     key_pair_required: bool = False,
     public_key_required: bool = False,
+    app_key_required: bool = False,
     stack_name: Optional[str] = None,
     install_agent: Optional[bool] = None,
     agent_version: Optional[str] = None,
@@ -50,6 +51,10 @@ def deploy(
     for namespace in stackParams:
         for key, value in stackParams[namespace].items():
             flags[f"{namespace}:{key}"] = value
+
+
+    if app_key_required:
+        flags["ddagent:appKey"] = _get_app_key(cfg)
 
     return _deploy(stack_name, flags, debug)
 
@@ -100,17 +105,28 @@ def _get_root_path() -> str:
 
 
 def _get_api_key(cfg: Optional[Config]) -> str:
+    return _get_key("API KEY", cfg, lambda c: c.get_agent().apiKey, "E2E_API_KEY", 32)
+    
+
+
+def _get_app_key(cfg: Optional[Config]) -> str:
+    return _get_key("APP KEY", cfg, lambda c: c.get_agent().appKey, "E2E_APP_KEY", 40)
+
+
+def _get_key(key_name: str, cfg: Optional[Config], get_key: Callable[[Config], Optional[str]], env_key_name: str, expected_size: int) -> str:
+    key: Optional[str] = None
+
     # first try in config
-    if cfg is not None and cfg.get_agent().apiKey is not None:
-        return cfg.get_agent().apiKey
-    # the try in env var
-    api_key = os.getenv("E2E_API_KEY")
-    if api_key is None or len(api_key) != 32:
+    if cfg is not None:
+        key = get_key(cfg)
+    if key is None or len(key) == 0:
+        # the try in env var
+        key = os.getenv(env_key_name)
+    if key is None or len(key) != expected_size:
         raise invoke.Exit(
-            "Invalid API KEY. You must define the environment variable 'E2E_API_KEY'. "
-            + "If you don't want an agent installation add '--no-install-agent'."
+            f"The scenario requires a valid {key_name} with a length of {expected_size} characters but none was found. You must define it in the config file"
         )
-    return api_key
+    return key
 
 
 def _check_key_pair(key_pair_to_search: Optional[str]):

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -106,7 +106,6 @@ def _get_root_path() -> str:
 
 def _get_api_key(cfg: Optional[Config]) -> str:
     return _get_key("API KEY", cfg, lambda c: c.get_agent().apiKey, "E2E_API_KEY", 32)
-    
 
 
 def _get_app_key(cfg: Optional[Config]) -> str:

--- a/tasks/doc.py
+++ b/tasks/doc.py
@@ -2,8 +2,12 @@ from . import tool
 
 install_agent: str = f"Install the Agent (default {tool.get_default_agent_install()})."
 agent_version: str = "The version of the Agent for example '7.42.0~rc.1-1' or '6.39.0 (default `latest`)'"
-agent_docker_version: str = "The docker version of the Agent for example '7.45.0-rc.3' (default `latest`)'"
+container_agent_version: str = "The container version of the Agent for example '7.45.0-rc.3' (default `latest`)'"
 stack_name: str = "An optional name for the stack. This parameter is useful when you need to create several environments. Note: 'invoke destroy' may not work properly"
 debug: str = "Launch pulumi with debug mode. Default False"
 stack_name: str = "An optional name for the stack. This parameter is useful when you need to create several environments."
 os_family: str = f"The operating system. Possible values are {tool.get_os_families()}. Default '{tool.get_default_os_family()}'"
+linux_node_group: str = "Install a Linux node group (default True)"
+linux_arm_node_group: str = "Install a Linux ARM node group (default False)"
+bottlerocket_node_group: str = "Install a bottlerocket node group (default False)"
+windows_node_group: str = "Install a Windows node group (default False)"

--- a/tasks/docker.py
+++ b/tasks/docker.py
@@ -20,7 +20,7 @@ scenario_name = "aws/dockervm"
 def create_docker(
     ctx: Context,
     stack_name: Optional[str] = None,
-    install_agent: Optional[bool] = False,
+    install_agent: Optional[bool] = True,
     agent_version: Optional[str] = None,
 ):
     """

--- a/tasks/docker.py
+++ b/tasks/docker.py
@@ -13,7 +13,7 @@ scenario_name = "aws/dockervm"
 @task(
     help={
         "install_agent": doc.install_agent,
-        "agent_version": doc.agent_docker_version,
+        "agent_version": doc.container_agent_version,
         "stack_name": doc.stack_name,
     }
 )

--- a/tasks/eks.py
+++ b/tasks/eks.py
@@ -61,14 +61,14 @@ def _show_connection_message(full_stack_name: str):
     outputs = tool.get_stack_json_outputs(full_stack_name)
     kubeconfig = outputs["kubeconfig"]
     kubeconfig_content = yaml.dump(kubeconfig)
-
+    config = f"{full_stack_name}-config.yaml"
     f = os.open(
-        path="config.yaml", flags=(os.O_WRONLY | os.O_CREAT | os.O_TRUNC), mode=0o600
+        path=config, flags=(os.O_WRONLY | os.O_CREAT | os.O_TRUNC), mode=0o600
     )
     with open(f, "w") as f:
         f.write(kubeconfig_content)
 
-    command = "KUBECONFIG=config.yaml aws-vault exec sandbox-account-admin -- kubectl get nodes"
+    command = f"KUBECONFIG={config} aws-vault exec sandbox-account-admin -- kubectl get nodes"
     pyperclip.copy(command)
     print(
         f"\nYou can run the following command to connect to the EKS cluster\n\n{command}\n\nThis command was copied to the clipboard\n"

--- a/tasks/eks.py
+++ b/tasks/eks.py
@@ -26,7 +26,7 @@ scenario_name = "aws/eks"
 def create_eks(
     ctx: Context,
     stack_name: Optional[str] = None,
-    install_agent: Optional[bool] = False,
+    install_agent: Optional[bool] = True,
     agent_version: Optional[str] = None,
     eks_linux_node_group: bool = True,
     eks_linux_arm_node_group: bool = False,

--- a/tasks/eks.py
+++ b/tasks/eks.py
@@ -1,0 +1,87 @@
+import os
+from invoke import task
+import yaml
+from .destroy import destroy
+from .deploy import deploy
+from . import doc
+from typing import Optional
+from invoke.context import Context
+from . import tool
+import pyperclip
+
+scenario_name = "aws/eks"
+
+
+@task(
+    help={
+        "install_agent": doc.install_agent,
+        "agent_version": doc.container_agent_version,
+        "stack_name": doc.stack_name,
+        "eks_linux_node_group": doc.linux_node_group,
+        "eks_linux_arm_node_group": doc.linux_arm_node_group,
+        "eks_bottlerocket_node_group": doc.bottlerocket_node_group,
+        "eks_windows_node_group": doc.windows_node_group,
+    }
+)
+def create_eks(
+    ctx: Context,
+    stack_name: Optional[str] = None,
+    install_agent: Optional[bool] = False,
+    agent_version: Optional[str] = None,
+    eks_linux_node_group: bool = True,
+    eks_linux_arm_node_group: bool = False,
+    eks_bottlerocket_node_group: bool = False,
+    eks_windows_node_group: bool = False,
+):
+    """
+    Create a new EKS environment. It lasts around 20 minutes.
+    """
+
+    extra_flags = {}
+    extra_flags["ddinfra:aws/eks/linuxNodeGroup"] = eks_linux_node_group
+    extra_flags["ddinfra:aws/eks/linuxARMNodeGroup"] = eks_linux_arm_node_group
+    extra_flags[
+        "ddinfra:aws/eks/linuxBottlerocketNodeGroup"
+    ] = eks_bottlerocket_node_group
+    extra_flags["ddinfra:aws/eks/windowsNodeGroup"] = eks_windows_node_group
+
+    full_stack_name = deploy(
+        ctx,
+        scenario_name,
+        app_key_required=True,
+        stack_name=stack_name,
+        install_agent=install_agent,
+        agent_version=agent_version,
+        extra_flags=extra_flags,
+    )
+    _show_connection_message(full_stack_name)
+
+
+def _show_connection_message(full_stack_name: str):
+    outputs = tool.get_stack_json_outputs(full_stack_name)
+    kubeconfig = outputs["kubeconfig"]
+    kubeconfig_content = yaml.dump(kubeconfig)
+
+    f = os.open(
+        path="config.yaml", flags=(os.O_WRONLY | os.O_CREAT | os.O_TRUNC), mode=0o600
+    )
+    with open(f, "w") as f:
+        f.write(kubeconfig_content)
+
+    command = "KUBECONFIG=config.yaml aws-vault exec sandbox-account-admin -- kubectl get nodes"
+    pyperclip.copy(command)
+    print(
+        f"\nYou can run the following command to connect to the EKS cluster\n\n{command}\n\nThis command was copied to the clipboard\n"
+    )
+
+
+@task(
+    help={
+        "stack_name": doc.stack_name,
+    }
+)
+def destroy_eks(ctx: Context, stack_name: Optional[str] = None):
+    """
+    Destroy a EKS environment created with invoke create-eks.
+    """
+    destroy(scenario_name, stack_name)

--- a/tasks/tool.py
+++ b/tasks/tool.py
@@ -44,7 +44,8 @@ def get_stack_name(stack_name: Optional[str], scenario_name: str) -> str:
 
 
 def get_stack_name_suffix() -> str:
-    return f"-{getpass.getuser()}"
+    user_name = f"-{getpass.getuser()}"
+    return user_name.replace(".", "-") # EKS doesn't support '.'
 
 
 def get_stack_json_outputs(full_stack_name: str) -> str:

--- a/tasks/tool.py
+++ b/tasks/tool.py
@@ -34,7 +34,7 @@ def get_default_os_family() -> str:
 
 
 def get_default_agent_install() -> bool:
-    return False
+    return True
 
 
 def get_stack_name(stack_name: Optional[str], scenario_name: str) -> str:

--- a/tasks/vm.py
+++ b/tasks/vm.py
@@ -24,7 +24,7 @@ scenario_name = "aws/vm"
 def create_vm(
     ctx: Context,
     stack_name: Optional[str] = None,
-    install_agent: Optional[bool] = False,
+    install_agent: Optional[bool] = True,
     agent_version: Optional[str] = None,
     debug: Optional[bool] = False,
     os_family: Optional[str] = None,


### PR DESCRIPTION
What does this PR do?
---------------------

Add the invoke task `create-eks`.
Note: Installing the agent doesn't work.
```
Usage: inv[oke] [--core-opts] create-eks [--options] [other tasks here ...]

Docstring:
  Create a new EKS environment. It lasts around 20 minutes.

Options:
  --, --eks-bottlerocket-node-group   Install a bottlerocket node group (default False)
  -a STRING, --agent-version=STRING   The container version of the Agent for example '7.45.0-rc.3' (default `latest`)'
  -e, --[no-]eks-linux-node-group     Install a Linux node group (default True)
  -i, --install-agent                 Install the Agent (default False).
  -k, --eks-linux-arm-node-group      Install a Linux ARM node group (default False)
  -s STRING, --stack-name=STRING      An optional name for the stack. This parameter is useful when you need to create several environments.
  -w, --eks-windows-node-group        Install a Windows node group (default False)
```
