### PR TITLE
 [env] 🐛  define provider per common environment instance

### DIFF
--- a/aws/environment.go
+++ b/aws/environment.go
@@ -61,7 +61,10 @@ type Environment struct {
 }
 
 func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
-	commonEnv := config.NewCommonEnvironment(ctx)
+	commonEnv, err := config.NewCommonEnvironment(ctx)
+	if err != nil {
+		return Environment{}, err
+	}
 
 	env := Environment{
 		CommonEnvironment: &commonEnv,
@@ -70,7 +73,6 @@ func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
 		envDefault:        getEnvironmentDefault(config.FindEnvironmentName(commonEnv.InfraEnvironmentNames(), awsConfigNamespace)),
 	}
 
-	var err error
 	env.awsProvider, err = sdkaws.NewProvider(ctx, "aws", &sdkaws.ProviderArgs{
 		Region: pulumi.String(env.Region()),
 		DefaultTags: sdkaws.ProviderDefaultTagsArgs{

--- a/aws/scenarios/dockerVM/run.go
+++ b/aws/scenarios/dockerVM/run.go
@@ -14,7 +14,10 @@ func Run(ctx *pulumi.Context) error {
 		return err
 	}
 
-	env := config.NewCommonEnvironment(ctx)
+	env, err := config.NewCommonEnvironment(ctx)
+	if err != nil {
+		return err
+	}
 	var options []func(*docker.Params) error
 	if env.AgentDeploy() {
 		options = append(options, docker.WithAgent())

--- a/aws/scenarios/vm/run.go
+++ b/aws/scenarios/vm/run.go
@@ -13,7 +13,10 @@ import (
 )
 
 func Run(ctx *pulumi.Context) error {
-	env := config.NewCommonEnvironment(ctx)
+	env, err := config.NewCommonEnvironment(ctx)
+	if err != nil {
+		return err
+	}
 	var osType ec2os.Type
 
 	osTypeStr := strings.ToLower(env.InfraOSFamily())

--- a/azure/environment.go
+++ b/azure/environment.go
@@ -34,7 +34,10 @@ type Environment struct {
 }
 
 func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
-	commonEnv := config.NewCommonEnvironment(ctx)
+	commonEnv, err := config.NewCommonEnvironment(ctx)
+	if err != nil {
+		return Environment{}, err
+	}
 
 	env := Environment{
 		CommonEnvironment: &commonEnv,
@@ -42,7 +45,6 @@ func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
 		envDefault:        getEnvironmentDefault(config.FindEnvironmentName(commonEnv.InfraEnvironmentNames(), azNamerNamespace)),
 	}
 
-	var err error
 	env.Provider, err = sdkazure.NewProvider(ctx, "azure", &sdkazure.ProviderArgs{
 		DisablePulumiPartnerId: pulumi.BoolPtr(true),
 		SubscriptionId:         pulumi.StringPtr(env.envDefault.azure.subscriptionID),

--- a/command/runner.go
+++ b/command/runner.go
@@ -86,11 +86,7 @@ func (r *Runner) Command(name string, args *Args, opts ...pulumi.ResourceOption)
 	if args.Sudo && r.config.user != "" {
 		r.e.Ctx.Log.Info(fmt.Sprintf("warning: running sudo command on a runner with user %s, discarding user", r.config.user), nil)
 	}
-	provider, err := r.e.CommandProvider()
-	if err != nil {
-		panic(fmt.Sprintf("failed to get command provider %s", err))
-	}
-	depends := append(opts, pulumi.Provider(provider))
+	depends := append(opts, pulumi.Provider(r.e.CommandProvider))
 	return remote.NewCommand(r.e.Ctx, r.namer.ResourceName("cmd", name), args.toRemoteCommandArgs(r.config, r.osCommand), depends...)
 }
 
@@ -132,10 +128,6 @@ func (args *Args) toLocalCommandArgs(config runnerConfiguration, osCommand OSCom
 }
 
 func (r *LocalRunner) Command(name string, args *Args, opts ...pulumi.ResourceOption) (*local.Command, error) {
-	provider, err := r.e.CommandProvider()
-	if err != nil {
-		panic(fmt.Sprintf("failed to get command provider %s", err))
-	}
-	depends := append(opts, pulumi.Provider(provider))
+	depends := append(opts, pulumi.Provider(r.e.CommandProvider))
 	return local.NewCommand(r.e.Ctx, r.namer.ResourceName("cmd", name), args.toLocalCommandArgs(r.config, r.osCommand), depends...)
 }

--- a/common/utils/random.go
+++ b/common/utils/random.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"fmt"
-
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/namer"
 	"github.com/pulumi/pulumi-random/sdk/v4/go/random"
@@ -27,12 +25,8 @@ func NewRandomGenerator(e config.CommonEnvironment, name string, options ...func
 }
 
 func (r *RandomGenerator) RandomString(name string, length int, special bool) (*random.RandomString, error) {
-	provider, err := r.e.RandomProvider()
-	if err != nil {
-		panic(fmt.Sprintf("failed to get random provider %s", err))
-	}
 	return random.NewRandomString(r.e.Ctx, r.namer.ResourceName("random-string", name), &random.RandomStringArgs{
 		Length:  pulumi.Int(length),
 		Special: pulumi.Bool(special),
-	}, pulumi.Provider(provider))
+	}, pulumi.Provider(r.e.RandomProvider))
 }


### PR DESCRIPTION
What does this PR do?
---------------------

Define one providers per environment instance

Which scenarios this will impact?
-------------------

All

Motivation
----------

Default singleton providers are causing a bug when updating the environment, as pulumi keeps re-using the same instance of provider while creating a new environment instance

Additional Notes
----------------
