### PR TITLE
Set the default value of checkKeyPair at true

### DIFF
--- a/.test_infra_config.yaml.example
+++ b/.test_infra_config.yaml.example
@@ -36,4 +36,4 @@ options:
   # # enables checking defaultKeyPairName exists locally
   # # optional, default to false
   
-  # checkKeyPair: false
+  # checkKeyPair: true


### PR DESCRIPTION
What does this PR do?
---------------------

Set the default value of `checkKeyPair` at `true` in `.test_infra_config.yaml.example`.

Motivation
----------

It is very hard for a new user to know that the ssh key has to be added in the ssh agent.

Additional Notes
----------------
