### PR TITLE
[ecs] fakeintake needs an ec2vm

### DIFF
--- a/aws/scenarios/ecs/fakeintake.go
+++ b/aws/scenarios/ecs/fakeintake.go
@@ -8,7 +8,7 @@ import (
 
 // NewEcsFakeintake creates a new instance of fakeintake service on a dedicated fargate cluster
 // and registers it into the pulumi context
-func NewEcsFakeintake(vm *ec2vm.EC2UnixVM) (exporter *ddfakeintake.ConnectionExporter, err error) {
+func NewEcsFakeintake(vm *ec2vm.EC2VM) (exporter *ddfakeintake.ConnectionExporter, err error) {
 	ipAddress, err := ecs.FargateServiceFakeintake(vm.GetAwsEnvironment())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
What does this PR do?
---------------------

Have fakeintake helper accepting an ec2.VM instead of a unix vm

Which scenarios this will impact?
-------------------

None

Motivation
----------

Fakeintake can work with any ec2 vm

Additional Notes
----------------
