### PR TITLE
Schedule a shutdown if the shutdown behavior is set to 'terminate'

### DIFF
--- a/aws/scenarios/microVMs/config/config.go
+++ b/aws/scenarios/microVMs/config/config.go
@@ -16,6 +16,7 @@ const (
 	DDMicroVMArm64AmiID           = "arm64AmiID"
 	DDMicroVMConfigFile           = "microVMConfigFile"
 	DDMicroVMWorkingDirectory     = "workingDir"
+	DDMicroVMShutdownPeriod       = "shutdownPeriod"
 )
 
 var SSHKeyConfigNames = map[string]string{

--- a/aws/scenarios/microVMs/sample-vm-config.json
+++ b/aws/scenarios/microVMs/sample-vm-config.json
@@ -400,8 +400,8 @@
             }
         },
         {
-            "name": "ubuntu_amd64",
-            "recipe": "distro-amd64",
+            "name": "ubuntu_x86_64",
+            "recipe": "distro-x86_64",
             "arch": "x86_64",
             "kernels": [
                 {


### PR DESCRIPTION
What does this PR do?
---------------------
This PR schedules an automatic shutdown of the EC2 instance created for the micro-vm scenario if the shutdown behavior of the EC2 instance is set to 'terminate'. It uses the configuration value if provided or sets it to 6 hours by default.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
