### PR TITLE
Prevent unnecessary network update

### DIFF
--- a/aws/scenarios/microVMs/microvms/domain.go
+++ b/aws/scenarios/microVMs/microvms/domain.go
@@ -93,7 +93,7 @@ func newDomainConfiguration(e *config.CommonEnvironment, vcpu, memory int, setNa
 	)
 	domain.RecipeLibvirtDomainArgs.Machine = machine
 	domain.RecipeLibvirtDomainArgs.ExtraKernelParams = kernel.ExtraParams
-	domain.RecipeLibvirtDomainArgs.DomainName = domain.domainID
+	domain.RecipeLibvirtDomainArgs.DomainName = fmt.Sprintf("%s-%s", e.Ctx.Stack(), domain.domainID)
 
 	return domain, nil
 }

--- a/aws/scenarios/microVMs/microvms/libvirt.go
+++ b/aws/scenarios/microVMs/microvms/libvirt.go
@@ -17,7 +17,6 @@ const (
 	// The microvm subnet changed from /16 to /24 because the underlying libvirt sdk would identify
 	// the incorrect network interface. It looks like it does not respect the subnet range when the subnet
 	// used is /16.
-	// Moreover the gateway ip address is xxx.yyy.zzz.1. So the first VM should have address xxx.yyy.zzz.2
 	// TODO: this problem only manifests when setting up VMs locally. Investigate the root cause to see what can
 	// be done. This solution may no longer work when the number of VMs exceeds the ips available in this subnet.
 	microVMGroupSubnet    = "169.254.0.0/24"
@@ -210,6 +209,9 @@ func BuildVMCollections(instances map[string]*Instance, vmsets []vmconfig.VMSet,
 	// Setup filesystems, domain configurations, and network
 	// for each collection.
 	ip, _, _ := net.ParseCIDR(microVMGroupSubnet)
+	// The first ip address is derived from the microvm subnet.
+	// The gateway ip address is xxx.yyy.zzz.1. So the first VM should have address xxx.yyy.zzz.2
+	// Therefore we call getNextVMIP to move start from xxx.yyy.zzz.2
 	ip = getNextVMIP(&ip)
 	for _, collection := range vmCollections {
 		// setup libvirt filesystem for each collection

--- a/aws/scenarios/microVMs/microvms/libvirt.go
+++ b/aws/scenarios/microVMs/microvms/libvirt.go
@@ -20,7 +20,7 @@ const (
 	// Moreover the gateway ip address is xxx.yyy.zzz.1. So the first VM should have address xxx.yyy.zzz.2
 	// TODO: this problem only manifests when setting up VMs locally. Investigate the root cause to see what can
 	// be done. This solution may no longer work when the number of VMs exceeds the ips available in this subnet.
-	microVMGroupSubnet    = "169.254.0.1/24"
+	microVMGroupSubnet    = "169.254.0.0/24"
 	domainSocketCreateCmd = `rm -f /tmp/%s.sock && python3 -c "import socket as s; sock = s.socket(s.AF_UNIX); sock.bind('/tmp/%s.sock')"`
 )
 
@@ -210,6 +210,7 @@ func BuildVMCollections(instances map[string]*Instance, vmsets []vmconfig.VMSet,
 	// Setup filesystems, domain configurations, and network
 	// for each collection.
 	ip, _, _ := net.ParseCIDR(microVMGroupSubnet)
+	ip = getNextVMIP(&ip)
 	for _, collection := range vmCollections {
 		// setup libvirt filesystem for each collection
 		wait, err := collection.SetupCollectionFilesystems(depends)

--- a/aws/scenarios/microVMs/microvms/resources/amd64/domain.xls
+++ b/aws/scenarios/microVMs/microvms/resources/amd64/domain.xls
@@ -11,7 +11,7 @@
    <xsl:template match="/domain/name"><name>{domainID}</name></xsl:template>
 
   <xsl:template match="/domain/features">
-       <cpu mode='host-model' check='none'>
+       <cpu mode='host-passthrough' check='none'>
            <model fallback='forbid'>qemu64</model>
        </cpu>
   </xsl:template>

--- a/aws/scenarios/microVMs/microvms/resources/distro/domain-amd64.xls
+++ b/aws/scenarios/microVMs/microvms/resources/distro/domain-amd64.xls
@@ -10,7 +10,7 @@
 
    <xsl:template match="/domain/name"><name>{domainID}</name></xsl:template>
   <xsl:template match="/domain/features">
-       <cpu mode='host-model' check='none'>
+       <cpu mode='host-passthrough' check='none'>
            <model fallback='forbid'>qemu64</model>
        </cpu>
   </xsl:template>


### PR DESCRIPTION
What does this PR do?
---------------------
This PR addresses the issue of spurious network updates, when updating the pulumi stack.
This was stemming from the fact that the network subnet was incorrectly being set to 169.254.0.1/24. This is wrong because the specified subnet implies the start of the address range to be 169.254.0.0. The libvirt sdk correctly derives the subnet from the provided one, but as a result on every update pulumi would detect a "change" from 169.254.0.1/24 => 169.254.0.0/24 as the subnet. This would result in an unnecessary network update, followed by a restart of all running VMs. 

This PR also add `host-passthrough` as the cpu mode for `amd64` VMs. This is an optimization. `host-passthrough` allows qemu to tell KVM to pass through to the host CPU without any modifications.

Finally, the PR appends the stack name to the domain name. This is used to assist in the lifecycle management of local VMs.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
