### PR TITLE
[filemanager] add provider to CopyFile

### DIFF
--- a/components/command/filemanager.go
+++ b/components/command/filemanager.go
@@ -38,12 +38,7 @@ func (fm *FileManager) TempDirectory(resourceName string, opts ...pulumi.Resourc
 }
 
 func (fm *FileManager) CopyFile(localPath, remotePath string, opts ...pulumi.ResourceOption) (*remote.CopyFile, error) {
-	return remote.NewCopyFile(fm.runner.e.Ctx, fm.runner.namer.ResourceName("copy", remotePath), &remote.CopyFileArgs{
-		Connection: fm.runner.config.connection,
-		LocalPath:  pulumi.String(localPath),
-		RemotePath: pulumi.String(remotePath),
-		Triggers:   pulumi.Array{pulumi.String(localPath), pulumi.String(remotePath)},
-	}, opts...)
+	return fm.runner.NewCopyFile(localPath, remotePath, opts...)
 }
 
 func (fm *FileManager) CopyInlineFile(fileContent pulumi.StringInput, remotePath string, useSudo bool, opts ...pulumi.ResourceOption) (*remote.Command, error) {

--- a/components/command/runner.go
+++ b/components/command/runner.go
@@ -99,6 +99,17 @@ func (r *Runner) Command(name string, args *Args, opts ...pulumi.ResourceOption)
 	return remote.NewCommand(r.e.Ctx, r.namer.ResourceName("cmd", name), args.toRemoteCommandArgs(r.config, r.osCommand), depends...)
 }
 
+func (r *Runner) NewCopyFile(localPath, remotePath string, opts ...pulumi.ResourceOption) (*remote.CopyFile, error) {
+	opts = append(opts, r.options...)
+	depends := append(opts, pulumi.Provider(r.e.CommandProvider))
+	return remote.NewCopyFile(r.e.Ctx, r.namer.ResourceName("copy", remotePath), &remote.CopyFileArgs{
+		Connection: r.config.connection,
+		LocalPath:  pulumi.String(localPath),
+		RemotePath: pulumi.String(remotePath),
+		Triggers:   pulumi.Array{pulumi.String(localPath), pulumi.String(remotePath)},
+	}, depends...)
+}
+
 type LocalRunner struct {
 	e         config.CommonEnvironment
 	namer     namer.Namer


### PR DESCRIPTION
What does this PR do?
---------------------

Assign a provider to `CopyFile`

Which scenarios this will impact?
-------------------

VM

Motivation
----------

Since we remove default providers, each command requires an explicit one. We fixed it for `remote.Command` but not for `remote.NewCopyFile`. 

Additional Notes
----------------
