### PR TITLE
Create unique Nvram file for each ARM64 distro VM.

### DIFF
--- a/scenarios/aws/microVMs/microvms/domain.go
+++ b/scenarios/aws/microVMs/microvms/domain.go
@@ -107,6 +107,7 @@ func newDomainConfiguration(e *config.CommonEnvironment, cfg domainConfiguration
 	domain.RecipeLibvirtDomainArgs.Machine = cfg.machine
 	domain.RecipeLibvirtDomainArgs.ExtraKernelParams = cfg.kernel.ExtraParams
 	domain.RecipeLibvirtDomainArgs.DomainName = libvirtResourceName(e.Ctx.Stack(), domain.domainID)
+	domain.RecipeLibvirtDomainArgs.WorkingDirectory = GetWorkingDirectory()
 
 	return domain, nil
 }

--- a/scenarios/aws/microVMs/microvms/resources/distro.go
+++ b/scenarios/aws/microVMs/microvms/resources/distro.go
@@ -3,6 +3,8 @@ package resources
 import (
 	// import embed
 	_ "embed"
+	"fmt"
+	"path/filepath"
 
 	"github.com/pulumi/pulumi-libvirt/sdk/go/libvirt"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -88,6 +90,8 @@ func (a *DistroARM64ResourceCollection) GetPoolXML(args map[string]pulumi.String
 }
 
 func (a *DistroARM64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomainArgs) *libvirt.DomainArgs {
+	efi := filepath.Join(args.WorkingDirectory, "efi.fd")
+	varstore := filepath.Join(args.WorkingDirectory, fmt.Sprintf("varstore.%s", args.DomainName))
 	domainArgs := libvirt.DomainArgs{
 		Name: pulumi.String(args.DomainName),
 		Consoles: libvirt.DomainConsoleArray{
@@ -105,9 +109,9 @@ func (a *DistroARM64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirt
 		Memory:   pulumi.Int(args.Memory),
 		Vcpu:     pulumi.Int(args.Vcpu),
 		Machine:  pulumi.String("virt"),
-		Firmware: pulumi.String("/home/kernel-version-testing/efi.fd"),
+		Firmware: pulumi.String(efi),
 		Nvram: libvirt.DomainNvramArgs{
-			File: pulumi.String("/home/kernel-version-testing/varstore.fd"),
+			File: pulumi.String(varstore),
 		},
 		Xml: libvirt.DomainXmlArgs{
 			Xslt: args.Xls,

--- a/scenarios/aws/microVMs/microvms/resources/resources.go
+++ b/scenarios/aws/microVMs/microvms/resources/resources.go
@@ -47,6 +47,7 @@ type RecipeLibvirtDomainArgs struct {
 	Resources         ResourceCollection
 	ExtraKernelParams map[string]string
 	Machine           string
+	WorkingDirectory  string
 }
 
 func formatResourceXML(xml string, args map[string]pulumi.StringInput) pulumi.StringOutput {
@@ -76,7 +77,7 @@ func isLocalRecipe(recipe string) bool {
 	return (recipe == vmconfig.RecipeCustomLocal) || (recipe == vmconfig.RecipeDistroLocal)
 }
 
-func getLocalArchRecipe(recipe string) string {
+func GetLocalArchRecipe(recipe string) string {
 	var prefix string
 
 	if !isLocalRecipe(recipe) {
@@ -101,7 +102,7 @@ func getLocalArchRecipe(recipe string) string {
 }
 
 func NewResourceCollection(recipe string) ResourceCollection {
-	archSpecificRecipe := getLocalArchRecipe(recipe)
+	archSpecificRecipe := GetLocalArchRecipe(recipe)
 
 	switch archSpecificRecipe {
 	case vmconfig.RecipeCustomARM64:


### PR DESCRIPTION
What does this PR do?
---------------------
Create a unique Nvram file for each arm64 distribution VM, using EFI to boot.

Which scenarios this will impact?
-------------------

Motivation
----------
Sharing the Nvram file occasionally causes bugs when the initialization operation of each VM corrupts data.

Additional Notes
----------------
