### PR TITLE
Make the Helm agent deployment also deploy it on Windows nodes

### DIFF
--- a/components/datadog/agent/helm.go
+++ b/components/datadog/agent/helm.go
@@ -24,11 +24,28 @@ type HelmInstallationArgs struct {
 	ValuesYAML   pulumi.AssetOrArchiveArrayInput
 }
 
-func NewHelmInstallation(e config.CommonEnvironment, args HelmInstallationArgs, opts ...pulumi.ResourceOption) (*kubeHelm.Release, error) {
+type HelmComponent struct {
+	pulumi.ResourceState
+
+	LinuxHelmReleaseName   pulumi.StringPtrOutput
+	LinuxHelmReleaseStatus kubeHelm.ReleaseStatusOutput
+
+	WindowsHelmReleaseName   pulumi.StringPtrOutput
+	WindowsHelmReleaseStatus kubeHelm.ReleaseStatusOutput
+}
+
+func NewHelmInstallation(e config.CommonEnvironment, args HelmInstallationArgs, opts ...pulumi.ResourceOption) (*HelmComponent, error) {
 	apiKey := e.AgentAPIKey()
 	appKey := e.AgentAPPKey()
 	installName := "dda"
 	opts = append(opts, pulumi.Provider(args.KubeProvider), pulumi.Parent(args.KubeProvider), pulumi.DeletedWith(args.KubeProvider))
+
+	helmComponent := &HelmComponent{}
+	if err := e.Ctx.RegisterComponentResource("dd:agent", "dda", helmComponent, opts...); err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, pulumi.Parent(helmComponent))
 
 	// Create namespace if necessary
 	ns, err := corev1.NewNamespace(e.Ctx, args.Namespace, &corev1.NamespaceArgs{
@@ -39,6 +56,8 @@ func NewHelmInstallation(e config.CommonEnvironment, args HelmInstallationArgs, 
 	if err != nil {
 		return nil, err
 	}
+
+	opts = append(opts, utils.PulumiDependsOn(ns))
 
 	// Create secret if necessary
 	secret, err := corev1.NewSecret(e.Ctx, "datadog-credentials", &corev1.SecretArgs{
@@ -55,6 +74,8 @@ func NewHelmInstallation(e config.CommonEnvironment, args HelmInstallationArgs, 
 		return nil, err
 	}
 
+	opts = append(opts, utils.PulumiDependsOn(secret))
+
 	// Compute some values
 	agentImagePath := DockerAgentFullImagePath(&e, "")
 	agentImagePath, agentImageTag := utils.ParseImageReference(agentImagePath)
@@ -62,18 +83,47 @@ func NewHelmInstallation(e config.CommonEnvironment, args HelmInstallationArgs, 
 	clusterAgentImagePath := DockerClusterAgentFullImagePath(&e, "")
 	clusterAgentImagePath, clusterAgentImageTag := utils.ParseImageReference(clusterAgentImagePath)
 
-	opts = append(opts, utils.PulumiDependsOn(ns, secret))
-	return helm.NewInstallation(e, helm.InstallArgs{
+	linux, err := helm.NewInstallation(e, helm.InstallArgs{
 		RepoURL:     DatadogHelmRepo,
 		ChartName:   "datadog",
-		InstallName: installName,
+		InstallName: installName + "-linux",
 		Namespace:   args.Namespace,
 		ValuesYAML:  args.ValuesYAML,
-		Values:      buildDefaultHelmValues(installName, agentImagePath, agentImageTag, clusterAgentImagePath, clusterAgentImageTag),
+		Values:      buildLinuxHelmValues(installName, agentImagePath, agentImageTag, clusterAgentImagePath, clusterAgentImageTag),
 	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	helmComponent.LinuxHelmReleaseName = linux.Name
+	helmComponent.LinuxHelmReleaseStatus = linux.Status
+
+	windows, err := helm.NewInstallation(e, helm.InstallArgs{
+		RepoURL:     DatadogHelmRepo,
+		ChartName:   "datadog",
+		InstallName: installName + "-windows",
+		Namespace:   args.Namespace,
+		ValuesYAML:  args.ValuesYAML,
+		Values:      buildWindowsHelmValues(installName, agentImagePath, agentImageTag, clusterAgentImagePath, clusterAgentImageTag),
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	helmComponent.WindowsHelmReleaseName = windows.Name
+	helmComponent.WindowsHelmReleaseStatus = windows.Status
+
+	e.Ctx.RegisterResourceOutputs(helmComponent, pulumi.Map{
+		"linuxHelmReleaseName":     linux.Name,
+		"linuxHelmReleaseStatus":   linux.Status,
+		"windowsHelmReleaseName":   windows.Name,
+		"windowsHelmReleaseStatus": windows.Status,
+	})
+
+	return helmComponent, nil
 }
 
-func buildDefaultHelmValues(installName string, agentImagePath, agentImageTag, clusterAgentImagePath, clusterAgentImageTag string) pulumi.Map {
+func buildLinuxHelmValues(installName string, agentImagePath, agentImageTag, clusterAgentImagePath, clusterAgentImageTag string) pulumi.Map {
 	return pulumi.Map{
 		"datadog": pulumi.Map{
 			"apiKeyExistingSecret": pulumi.String(installName + "-datadog-credentials"),
@@ -124,6 +174,49 @@ func buildDefaultHelmValues(installName string, agentImagePath, agentImageTag, c
 				"tag":           pulumi.String(agentImageTag),
 				"doNotCheckTag": pulumi.Bool(true),
 			},
+		},
+	}
+}
+
+func buildWindowsHelmValues(installName string, agentImagePath, agentImageTag, clusterAgentImagePath, clusterAgentImageTag string) pulumi.Map {
+	return pulumi.Map{
+		"targetSystem": pulumi.String("windows"),
+		"datadog": pulumi.Map{
+			"apiKeyExistingSecret": pulumi.String(installName + "-datadog-credentials"),
+			"appKeyExistingSecret": pulumi.String(installName + "-datadog-credentials"),
+			"checksCardinality":    pulumi.String("high"),
+			"logs": pulumi.Map{
+				"enabled":             pulumi.Bool(true),
+				"containerCollectAll": pulumi.Bool(true),
+			},
+			"dogstatsd": pulumi.Map{
+				"originDetection": pulumi.Bool(true),
+				"tagCardinality":  pulumi.String("high"),
+				"useHostPort":     pulumi.Bool(true),
+			},
+			"apm": pulumi.Map{
+				"portEnabled": pulumi.Bool(true),
+			},
+			"processAgent": pulumi.Map{
+				"processCollection": pulumi.Bool(true),
+			},
+		},
+		"agents": pulumi.Map{
+			"image": pulumi.Map{
+				"repository":    pulumi.String(agentImagePath),
+				"tag":           pulumi.String(agentImageTag),
+				"doNotCheckTag": pulumi.Bool(true),
+			},
+		},
+		// Make the Windows node agents target the Linux cluster agent
+		"clusterAgent": pulumi.Map{
+			"enabled": pulumi.Bool(false),
+		},
+		"existingClusterAgent": pulumi.Map{
+			"join":                 pulumi.Bool(true),
+			"serviceName":          pulumi.String(installName + "-linux-datadog-cluster-agent"),
+			"tokenSecretName":      pulumi.String(installName + "-linux-datadog-cluster-agent"),
+			"clusterchecksEnabled": pulumi.Bool(false),
 		},
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/pulumi/pulumi-random/sdk/v4 v4.11.2
 	github.com/pulumi/pulumi/sdk/v3 v3.55.0
 	github.com/stretchr/testify v1.8.2
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -393,6 +393,8 @@ golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4
 golang.org/x/crypto v0.6.0 h1:qfktjS5LUO+fFKeJXZ+ikTRijMmljikvG68fpMMruSc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -177,8 +177,9 @@ func Run(ctx *pulumi.Context) error {
 	// Deploy the Agent
 	if awsEnv.AgentDeploy() {
 		helmComponent, err := agent.NewHelmInstallation(*awsEnv.CommonEnvironment, agent.HelmInstallationArgs{
-			KubeProvider: eksKubeProvider,
-			Namespace:    "datadog",
+			KubeProvider:  eksKubeProvider,
+			Namespace:     "datadog",
+			DeployWindows: awsEnv.EKSWindowsNodeGroup(),
 		}, nil)
 		if err != nil {
 			return err
@@ -186,8 +187,10 @@ func Run(ctx *pulumi.Context) error {
 
 		ctx.Export("agent-linux-helm-install-name", helmComponent.LinuxHelmReleaseName)
 		ctx.Export("agent-linux-helm-install-status", helmComponent.LinuxHelmReleaseStatus)
-		ctx.Export("agent-windows-helm-install-name", helmComponent.WindowsHelmReleaseName)
-		ctx.Export("agent-windows-helm-install-status", helmComponent.WindowsHelmReleaseStatus)
+		if awsEnv.EKSWindowsNodeGroup() {
+			ctx.Export("agent-windows-helm-install-name", helmComponent.WindowsHelmReleaseName)
+			ctx.Export("agent-windows-helm-install-status", helmComponent.WindowsHelmReleaseStatus)
+		}
 	}
 
 	return nil

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -176,7 +176,7 @@ func Run(ctx *pulumi.Context) error {
 
 	// Deploy the Agent
 	if awsEnv.AgentDeploy() {
-		helmRelease, err := agent.NewHelmInstallation(*awsEnv.CommonEnvironment, agent.HelmInstallationArgs{
+		helmComponent, err := agent.NewHelmInstallation(*awsEnv.CommonEnvironment, agent.HelmInstallationArgs{
 			KubeProvider: eksKubeProvider,
 			Namespace:    "datadog",
 		}, nil)
@@ -184,8 +184,10 @@ func Run(ctx *pulumi.Context) error {
 			return err
 		}
 
-		ctx.Export("agent-helm-install-name", helmRelease.Name)
-		ctx.Export("agent-helm-install-status", helmRelease.Status)
+		ctx.Export("agent-linux-helm-install-name", helmComponent.LinuxHelmReleaseName)
+		ctx.Export("agent-linux-helm-install-status", helmComponent.LinuxHelmReleaseStatus)
+		ctx.Export("agent-windows-helm-install-name", helmComponent.WindowsHelmReleaseName)
+		ctx.Export("agent-windows-helm-install-status", helmComponent.WindowsHelmReleaseStatus)
 	}
 
 	return nil


### PR DESCRIPTION
What does this PR do?
---------------------

Make the Helm datadog agent deployment method also deploy the agent on Windows nodes.

Which scenarios this will impact?
-------------------

* `aws/eks`

Motivation
----------

We want to be able to validate the Windows support.

Additional Notes
----------------
