### PR TITLE
Manually setup EFI files

### DIFF
--- a/scenarios/aws/microVMs/microvms/domain.go
+++ b/scenarios/aws/microVMs/microvms/domain.go
@@ -97,17 +97,22 @@ func newDomainConfiguration(e *config.CommonEnvironment, cfg domainConfiguration
 	domain.RecipeLibvirtDomainArgs.Vcpu = cfg.vcpu
 	domain.RecipeLibvirtDomainArgs.Memory = cfg.memory
 	domain.RecipeLibvirtDomainArgs.KernelPath = filepath.Join(GetWorkingDirectory(), "kernel-packages", cfg.kernel.Dir, "bzImage")
+
+	domainName := libvirtResourceName(e.Ctx.Stack(), domain.domainID)
+	varstore := filepath.Join(GetWorkingDirectory(), fmt.Sprintf("varstore.%s", domainName))
+	efi := filepath.Join(GetWorkingDirectory(), "efi.fd")
 	domain.RecipeLibvirtDomainArgs.Xls = rc.GetDomainXLS(
 		map[string]pulumi.StringInput{
 			resources.SharedFSMount: pulumi.String(sharedFSMountPoint),
 			resources.DomainID:      pulumi.String(domain.domainID),
 			resources.MACAddress:    domain.mac,
+			resources.Nvram:         pulumi.String(varstore),
+			resources.Efi:           pulumi.String(efi),
 		},
 	)
 	domain.RecipeLibvirtDomainArgs.Machine = cfg.machine
 	domain.RecipeLibvirtDomainArgs.ExtraKernelParams = cfg.kernel.ExtraParams
-	domain.RecipeLibvirtDomainArgs.DomainName = libvirtResourceName(e.Ctx.Stack(), domain.domainID)
-	domain.RecipeLibvirtDomainArgs.WorkingDirectory = GetWorkingDirectory()
+	domain.RecipeLibvirtDomainArgs.DomainName = domainName
 
 	return domain, nil
 }

--- a/scenarios/aws/microVMs/microvms/libvirt.go
+++ b/scenarios/aws/microVMs/microvms/libvirt.go
@@ -283,6 +283,8 @@ func LaunchVMCollections(vmCollections []*VMCollection, depends []pulumi.Resourc
 				pulumi.ReplaceOnChanges([]string{"*"}),
 				pulumi.DeleteBeforeReplace(true),
 				pulumi.DependsOn(depends),
+				// Pulumi incorrectly detects these as changing everytime.
+				pulumi.IgnoreChanges([]string{"filesystems", "firmware", "nvram"}),
 			)
 			if err != nil {
 				return libvirtDomains, err

--- a/scenarios/aws/microVMs/microvms/resources/distro.go
+++ b/scenarios/aws/microVMs/microvms/resources/distro.go
@@ -3,8 +3,6 @@ package resources
 import (
 	// import embed
 	_ "embed"
-	"fmt"
-	"path/filepath"
 
 	"github.com/pulumi/pulumi-libvirt/sdk/go/libvirt"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -90,8 +88,6 @@ func (a *DistroARM64ResourceCollection) GetPoolXML(args map[string]pulumi.String
 }
 
 func (a *DistroARM64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomainArgs) *libvirt.DomainArgs {
-	efi := filepath.Join(args.WorkingDirectory, "efi.fd")
-	varstore := filepath.Join(args.WorkingDirectory, fmt.Sprintf("varstore.%s", args.DomainName))
 	domainArgs := libvirt.DomainArgs{
 		Name: pulumi.String(args.DomainName),
 		Consoles: libvirt.DomainConsoleArray{
@@ -106,13 +102,9 @@ func (a *DistroARM64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirt
 				VolumeId: args.Volume.ID(),
 			},
 		},
-		Memory:   pulumi.Int(args.Memory),
-		Vcpu:     pulumi.Int(args.Vcpu),
-		Machine:  pulumi.String("virt"),
-		Firmware: pulumi.String(efi),
-		Nvram: libvirt.DomainNvramArgs{
-			File: pulumi.String(varstore),
-		},
+		Memory:  pulumi.Int(args.Memory),
+		Vcpu:    pulumi.Int(args.Vcpu),
+		Machine: pulumi.String("virt"),
 		Xml: libvirt.DomainXmlArgs{
 			Xslt: args.Xls,
 		},

--- a/scenarios/aws/microVMs/microvms/resources/distro/domain-arm64.xls
+++ b/scenarios/aws/microVMs/microvms/resources/distro/domain-arm64.xls
@@ -4,6 +4,7 @@
   <xsl:output omit-xml-declaration="yes" indent="yes"/>
   <xsl:template match="@firmware" />
 
+  
   <xsl:template match="node()|@*">
       <xsl:copy>
          <xsl:apply-templates select="node()|@*"/>
@@ -18,6 +19,14 @@
        </cpu>
   </xsl:template>
 
+  <xsl:template match="/domain/os">
+        <xsl:copy>
+            <xsl:copy-of select="@*"/>
+            <xsl:copy-of select="node()"/>
+            <loader readonly='yes' secure='no' type='pflash'>{efi}</loader>
+            <nvram>{nvram}</nvram>
+        </xsl:copy>
+  </xsl:template>
 
   <xsl:template match="/domain/devices/disk">
       <filesystem type='mount' accessmode='passthrough'>

--- a/scenarios/aws/microVMs/microvms/resources/resources.go
+++ b/scenarios/aws/microVMs/microvms/resources/resources.go
@@ -20,6 +20,8 @@ const (
 	VolumePath    = "volumePath"
 	PoolName      = "poolName"
 	PoolPath      = "poolPath"
+	Nvram         = "nvram"
+	Efi           = "efi"
 )
 
 var kernelCmdlines = []map[string]interface{}{
@@ -47,7 +49,6 @@ type RecipeLibvirtDomainArgs struct {
 	Resources         ResourceCollection
 	ExtraKernelParams map[string]string
 	Machine           string
-	WorkingDirectory  string
 }
 
 func formatResourceXML(xml string, args map[string]pulumi.StringInput) pulumi.StringOutput {


### PR DESCRIPTION
What does this PR do?
---------------------
This PR changes how the files for the EFI firmware and non-volatile RAM are passed to the domain.
Previously the files were setup using the pulumi-libvirt sdk. However, the sdk would delete the nvram files everytime on delete.
If any feature of the domain changed, the nvram files would get deleted and subsequent updates would fail.

This PR takes the management of the EFI files out of the purview of the libvirt sdk and manually adds them to the xml of the relevant domains.

Moreover, this PR also add the `pulumi.IgnoreChanges` attribute to the domains for any changes to the filesystems, nvram, or firmware definitions. Pulumi detects these to change on every update, and as a result incorrectly deletes and restarts the domains.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
