### PR TITLE
[install] create integration folder (if it does not exist)

### DIFF
--- a/components/command/filemanager.go
+++ b/components/command/filemanager.go
@@ -26,6 +26,7 @@ func NewFileManager(runner *Runner) *FileManager {
 	}
 }
 
+// CreateDirectory if it does not exist
 func (fm *FileManager) CreateDirectory(name string, remotePath pulumi.StringInput, useSudo bool, opts ...pulumi.ResourceOption) (*remote.Command, error) {
 	return fm.command.CreateDirectory(fm.runner, name, remotePath, useSudo, opts...)
 }

--- a/components/command/unixOSCommand.go
+++ b/components/command/unixOSCommand.go
@@ -20,6 +20,7 @@ func NewUnixOSCommand() OSCommand {
 	return unixOSCommand{}
 }
 
+// CreateDirectory if it does not exist
 func (unixOSCommand) CreateDirectory(
 	runner *Runner,
 	name string,

--- a/components/command/windowsOSCommand.go
+++ b/components/command/windowsOSCommand.go
@@ -15,6 +15,7 @@ func NewWindowsOSCommand() OSCommand {
 	return windowsOSCommand{}
 }
 
+// CreateDirectory if it does not exist
 func (fs windowsOSCommand) CreateDirectory(
 	runner *Runner,
 	name string,

--- a/components/datadog/agent/install.go
+++ b/components/datadog/agent/install.go
@@ -121,7 +121,13 @@ func installIntegrations(
 	var parts []string
 	for folderName, content := range integrations {
 		var err error
-		confPath := path.Join(configFolder, "conf.d", folderName, "conf.yaml")
+		folderPath := path.Join(configFolder, "conf.d", folderName)
+		confPath := path.Join(folderPath, "conf.yaml")
+		// create directory, if it does not exist
+		lastCommand, err = fileManager.CreateDirectory(folderName, pulumi.String(folderPath), true, utils.PulumiDependsOn(lastCommand))
+		if err != nil {
+			return nil, "", err
+		}
 		lastCommand, err = fileManager.CopyInlineFile(
 			pulumi.String(content),
 			confPath, true, utils.PulumiDependsOn(lastCommand))


### PR DESCRIPTION
What does this PR do?
---------------------

Fix integration install command, creating directory if it does not exist. The `CreateDirectory` creates a directory only if it does not exist, adding doc comment on top of them.

Which scenarios this will impact?
-------------------

vm

Motivation
----------

This is preventing installing custom integrations

Additional Notes
----------------
