### PR TITLE
Enable possibility to give an AMI id to launch a specific VM

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -26,6 +26,8 @@ const (
 	DDInfraEnvironment       = "env"
 	DDInfraKubernetesVersion = "kubernetesVersion"
 	DDInfraOSFamily          = "osFamily"
+	DDInfraOSArchitecture    = "osArchitecture"
+	DDInfraOSAmiID           = "osAmiId"
 
 	// Agent Namespace
 	DDAgentDeployParamName               = "deploy"
@@ -86,6 +88,14 @@ func (e *CommonEnvironment) InfraEnvironmentNames() []string {
 
 func (e *CommonEnvironment) InfraOSFamily() string {
 	return e.GetStringWithDefault(e.InfraConfig, DDInfraOSFamily, "")
+}
+
+func (e *CommonEnvironment) InfraOSArchitecture() string {
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraOSArchitecture, "")
+}
+
+func (e *CommonEnvironment) InfraOSAmiId() string {
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraOSAmiID, "")
 }
 
 func (e *CommonEnvironment) KubernetesVersion() string {

--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -94,7 +94,7 @@ func (e *CommonEnvironment) InfraOSArchitecture() string {
 	return e.GetStringWithDefault(e.InfraConfig, DDInfraOSArchitecture, "")
 }
 
-func (e *CommonEnvironment) InfraOSAmiId() string {
+func (e *CommonEnvironment) InfraOSAmiID() string {
 	return e.GetStringWithDefault(e.InfraConfig, DDInfraOSAmiID, "")
 }
 

--- a/scenarios/aws/vm/ec2VM/params.go
+++ b/scenarios/aws/vm/ec2VM/params.go
@@ -38,13 +38,15 @@ func newParams(env aws.Environment, options ...func(*Params) error) (*Params, er
 		common: commonParams,
 	}
 
-	amiID := env.InfraOSAmiId()
+	amiID := env.InfraOSAmiID()
 	if amiID != "" {
 		osType, err := params.getOSType()
 		if err != nil {
 			return nil, err
 		}
-		WithImageName(amiID, commonos.Architecture(env.InfraOSArchitecture()), osType)(params)
+		if err := WithImageName(amiID, commonos.Architecture(env.InfraOSArchitecture()), osType)(params); err != nil {
+			return nil, err
+		}
 	} else if err := params.useDefaultOS(); err != nil { // Can be overrided later if the caller uses WithOS.
 		return nil, err
 	}

--- a/tasks/doc.py
+++ b/tasks/doc.py
@@ -14,3 +14,4 @@ bottlerocket_node_group: str = "Install a bottlerocket node group (default False
 windows_node_group: str = "Install a Windows node group (default False)"
 use_fargate: str = "Use Fargate (default True)"
 fakeintake: str = "Use a dedicated fake Datadog intake (default True)"
+ami_id: str = "A full Amazon Machine Image (AMI) id (e.g. ami-0123456789abcdef0)"

--- a/tasks/tool.py
+++ b/tasks/tool.py
@@ -74,7 +74,7 @@ def is_windows():
 
 def get_image_description(ami_id: str) -> Any:
     r = subprocess.run(
-        f"aws-vault exec build-stable-developer -- aws ec2 describe-images --image-ids {ami_id}".split(),
+        f"aws-vault exec sso-agent-sandbox-account-admin -- aws ec2 describe-images --image-ids {ami_id}".split(),
         capture_output=True,
     )
     result = json.loads(r.stdout)

--- a/tasks/tool.py
+++ b/tasks/tool.py
@@ -4,12 +4,16 @@ import platform
 import subprocess
 from termcolor import colored
 from typing import Any, List, Optional
+from invoke import Exit
+
 
 def ask(question: str) -> str:
     return input(colored(question, "blue"))
 
+
 def debug(msg: str):
     print(colored(msg, "white"))
+
 
 def info(msg: str):
     print(colored(msg, "green"))
@@ -53,7 +57,7 @@ def get_stack_name(stack_name: Optional[str], scenario_name: str) -> str:
 
 def get_stack_name_prefix() -> str:
     user_name = f"{getpass.getuser()}-"
-    return user_name.replace(".", "-") # EKS doesn't support '.'
+    return user_name.replace(".", "-")  # EKS doesn't support '.'
 
 
 def get_stack_json_outputs(full_stack_name: str) -> Any:
@@ -66,6 +70,18 @@ def get_stack_json_outputs(full_stack_name: str) -> Any:
 
 def is_windows():
     return platform.system() == 'Windows'
+
+
+def get_image_description(ami_id: str) -> Any:
+    r = subprocess.run(
+        f"aws-vault exec build-stable-developer -- aws ec2 describe-images --image-ids {ami_id}".split(),
+        capture_output=True,
+    )
+    result = json.loads(r.stdout)
+    if len(result["Images"]) > 1:
+        raise Exit(f"The AMI id {ami_id} returns more than one definition.")
+    else:
+        return result["Images"][0]
 
 
 class Connection:


### PR DESCRIPTION
What does this PR do?
---------------------
Add a new option in invoke task to pass an AMI id as input

Which scenarios this will impact?
-------------------
AWS/VM

Motivation
----------
Possibility to run on older distribution than the ones we get by default today

Additional Notes
----------------
