### PR TITLE
Make the k8s fake apps children of the k8s provider like the k8s agent

### DIFF
--- a/components/datadog/apps/dogstatsd/k8s.go
+++ b/components/datadog/apps/dogstatsd/k8s.go
@@ -16,7 +16,7 @@ type K8sComponent struct {
 }
 
 func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
-	opts = append(opts, pulumi.Provider(kubeProvider))
+	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &K8sComponent{}
 	if err := e.Ctx.RegisterComponentResource("dd:apps", "dogstatsd", k8sComponent, opts...); err != nil {

--- a/components/datadog/apps/nginx/k8s.go
+++ b/components/datadog/apps/nginx/k8s.go
@@ -21,7 +21,7 @@ type K8sComponent struct {
 }
 
 func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
-	opts = append(opts, pulumi.Provider(kubeProvider))
+	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &K8sComponent{}
 	if err := e.Ctx.RegisterComponentResource("dd:apps", "nginx", k8sComponent, opts...); err != nil {

--- a/components/datadog/apps/prometheus/k8s.go
+++ b/components/datadog/apps/prometheus/k8s.go
@@ -16,7 +16,7 @@ type K8sComponent struct {
 }
 
 func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
-	opts = append(opts, pulumi.Provider(kubeProvider))
+	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &K8sComponent{}
 	if err := e.Ctx.RegisterComponentResource("dd:apps", "prometheus", k8sComponent, opts...); err != nil {

--- a/components/datadog/apps/redis/k8s.go
+++ b/components/datadog/apps/redis/k8s.go
@@ -21,7 +21,7 @@ type K8sComponent struct {
 }
 
 func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
-	opts = append(opts, pulumi.Provider(kubeProvider))
+	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &K8sComponent{}
 	if err := e.Ctx.RegisterComponentResource("dd:apps", "redis", k8sComponent, opts...); err != nil {


### PR DESCRIPTION
What does this PR do?
---------------------

Make the kubernetes fake applications children of the kubernetes provider like it is already the case for the agent deployed with Helm.

Which scenarios this will impact?
-------------------

* `aws/eks`

Motivation
----------

Fix dependencies and allow Pulumi to skip the deletion the kubernetes resources when it is deleting the kubernetes cluster.

Additional Notes
----------------
