### PR TITLE
Allow to pass sudo password from stdin.

### DIFF
--- a/components/command/osCommand.go
+++ b/components/command/osCommand.go
@@ -29,6 +29,7 @@ type OSCommand interface {
 		command pulumi.StringInput,
 		env pulumi.StringMap,
 		sudo bool,
+		passwordFromStdin bool,
 		user string) pulumi.StringInput
 }
 

--- a/components/command/runner.go
+++ b/components/command/runner.go
@@ -12,20 +12,21 @@ import (
 )
 
 type Args struct {
-	Create      pulumi.StringInput
-	Update      pulumi.StringInput
-	Delete      pulumi.StringInput
-	Triggers    pulumi.ArrayInput
-	Stdin       pulumi.StringPtrInput
-	Environment pulumi.StringMap
-	Sudo        bool
+	Create                   pulumi.StringInput
+	Update                   pulumi.StringInput
+	Delete                   pulumi.StringInput
+	Triggers                 pulumi.ArrayInput
+	Stdin                    pulumi.StringPtrInput
+	Environment              pulumi.StringMap
+	RequirePasswordFromStdin bool
+	Sudo                     bool
 }
 
 func (args *Args) toLocalCommandArgs(config runnerConfiguration, osCommand OSCommand) *local.CommandArgs {
 	return &local.CommandArgs{
-		Create:   osCommand.BuildCommandString(args.Create, args.Environment, args.Sudo, config.user),
-		Update:   osCommand.BuildCommandString(args.Update, args.Environment, args.Sudo, config.user),
-		Delete:   osCommand.BuildCommandString(args.Delete, args.Environment, args.Sudo, config.user),
+		Create:   osCommand.BuildCommandString(args.Create, args.Environment, args.Sudo, args.RequirePasswordFromStdin, config.user),
+		Update:   osCommand.BuildCommandString(args.Update, args.Environment, args.Sudo, args.RequirePasswordFromStdin, config.user),
+		Delete:   osCommand.BuildCommandString(args.Delete, args.Environment, args.Sudo, args.RequirePasswordFromStdin, config.user),
 		Triggers: args.Triggers,
 		Stdin:    args.Stdin,
 	}
@@ -34,9 +35,9 @@ func (args *Args) toLocalCommandArgs(config runnerConfiguration, osCommand OSCom
 func (args *Args) toRemoteCommandArgs(config runnerConfiguration, osCommand OSCommand) *remote.CommandArgs {
 	return &remote.CommandArgs{
 		Connection: config.connection,
-		Create:     osCommand.BuildCommandString(args.Create, args.Environment, args.Sudo, config.user),
-		Update:     osCommand.BuildCommandString(args.Update, args.Environment, args.Sudo, config.user),
-		Delete:     osCommand.BuildCommandString(args.Delete, args.Environment, args.Sudo, config.user),
+		Create:     osCommand.BuildCommandString(args.Create, args.Environment, args.Sudo, args.RequirePasswordFromStdin, config.user),
+		Update:     osCommand.BuildCommandString(args.Update, args.Environment, args.Sudo, args.RequirePasswordFromStdin, config.user),
+		Delete:     osCommand.BuildCommandString(args.Delete, args.Environment, args.Sudo, args.RequirePasswordFromStdin, config.user),
 		Triggers:   args.Triggers,
 		Stdin:      args.Stdin,
 	}
@@ -96,6 +97,7 @@ func (r *Runner) Command(name string, args *Args, opts ...pulumi.ResourceOption)
 		r.e.Ctx.Log.Info(fmt.Sprintf("warning: running sudo command on a runner with user %s, discarding user", r.config.user), nil)
 	}
 	depends := append(opts, pulumi.Provider(r.e.CommandProvider))
+
 	return remote.NewCommand(r.e.Ctx, r.namer.ResourceName("cmd", name), args.toRemoteCommandArgs(r.config, r.osCommand), depends...)
 }
 

--- a/components/command/runner.go
+++ b/components/command/runner.go
@@ -97,7 +97,6 @@ func (r *Runner) Command(name string, args *Args, opts ...pulumi.ResourceOption)
 		r.e.Ctx.Log.Info(fmt.Sprintf("warning: running sudo command on a runner with user %s, discarding user", r.config.user), nil)
 	}
 	depends := append(opts, pulumi.Provider(r.e.CommandProvider))
-
 	return remote.NewCommand(r.e.Ctx, r.namer.ResourceName("cmd", name), args.toRemoteCommandArgs(r.config, r.osCommand), depends...)
 }
 

--- a/components/command/unixOSCommand.go
+++ b/components/command/unixOSCommand.go
@@ -60,7 +60,7 @@ func (fs unixOSCommand) GetTemporaryDirectory() string {
 
 // BuildCommandString properly format the command string
 // command can be nil
-func (fs unixOSCommand) BuildCommandString(command pulumi.StringInput, env pulumi.StringMap, sudo, password bool, user string) pulumi.StringInput {
+func (fs unixOSCommand) BuildCommandString(command pulumi.StringInput, env pulumi.StringMap, sudo bool, password bool, user string) pulumi.StringInput {
 	formattedCommand := formatCommandIfNeeded(command, sudo, password, user)
 
 	var envVars pulumi.StringArray
@@ -73,7 +73,7 @@ func (fs unixOSCommand) BuildCommandString(command pulumi.StringInput, env pulum
 	})
 }
 
-func formatCommandIfNeeded(command pulumi.StringInput, sudo bool, user string) pulumi.StringInput {
+func formatCommandIfNeeded(command pulumi.StringInput, sudo bool, password bool, user string) pulumi.StringInput {
 	if command == nil {
 		return nil
 	}

--- a/components/command/unixOSCommand.go
+++ b/components/command/unixOSCommand.go
@@ -60,8 +60,8 @@ func (fs unixOSCommand) GetTemporaryDirectory() string {
 
 // BuildCommandString properly format the command string
 // command can be nil
-func (fs unixOSCommand) BuildCommandString(command pulumi.StringInput, env pulumi.StringMap, sudo bool, user string) pulumi.StringInput {
-	formattedCommand := formatCommandIfNeeded(command, sudo, user)
+func (fs unixOSCommand) BuildCommandString(command pulumi.StringInput, env pulumi.StringMap, sudo, password bool, user string) pulumi.StringInput {
+	formattedCommand := formatCommandIfNeeded(command, sudo, password, user)
 
 	var envVars pulumi.StringArray
 	for varName, varValue := range env {
@@ -82,7 +82,9 @@ func formatCommandIfNeeded(command pulumi.StringInput, sudo bool, user string) p
 		return command
 	}
 	var formattedCommand pulumi.StringInput
-	if sudo {
+	if sudo && password {
+		formattedCommand = pulumi.Sprintf("sudo -S %v", command)
+	} else if sudo {
 		formattedCommand = pulumi.Sprintf("sudo %v", command)
 	} else if user != "" {
 		formattedCommand = command.ToStringOutput().ApplyT(func(cmd string) string {

--- a/components/command/windowsOSCommand.go
+++ b/components/command/windowsOSCommand.go
@@ -57,6 +57,7 @@ func (fs windowsOSCommand) BuildCommandString(
 	command pulumi.StringInput,
 	env pulumi.StringMap,
 	_ bool,
+	_ bool,
 	_ string) pulumi.StringInput {
 	var envVars pulumi.StringArray
 	for varName, varValue := range env {


### PR DESCRIPTION
What does this PR do?
---------------------
This PR adds a new parameter to `command.Args` which passes the `-S` flag to sudo. This allows us to pass the password for `sudo` from stdin.

Which scenarios this will impact?
-------------------

Motivation
----------
The micro-vms scenario runs some commands locally with `sudo`. We need some way to pass the password.

Additional Notes
----------------
