### PR TITLE
Add pipieline ID tag

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -107,7 +107,7 @@ func (e *CommonEnvironment) ResourcesTags() pulumi.StringMap {
 	// Map environment variables
 	lookupVars := []string{"TEAM", "PIPELINE_ID"}
 	for _, varName := range lookupVars {
-		if val, ok := os.LookupEnv(varName); ok {
+		if val := os.Getenv(varName); val != "" {
 			defaultTags[strings.ReplaceAll(
 				strings.ToLower(varName), "_", "-")] = pulumi.String(val)
 		}

--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -105,10 +105,11 @@ func (e *CommonEnvironment) ResourcesTags() pulumi.StringMap {
 	defaultTags["username"] = pulumi.String(user.Username)
 
 	// Map environment variables
-	lookupVars := []string{"DD_TEAM"}
+	lookupVars := []string{"TEAM", "PIPELINE_ID"}
 	for _, varName := range lookupVars {
-		if val := os.Getenv(varName); val != "" {
-			defaultTags[strings.ToLower(varName)] = pulumi.String(val)
+		if val, ok := os.LookupEnv(varName); ok {
+			defaultTags[strings.ReplaceAll(
+				strings.ToLower(varName), "_", "-")] = pulumi.String(val)
 		}
 	}
 

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -77,7 +77,6 @@ func newEC2Instance(e aws.Environment, name, ami, arch, instanceType, keyPair, u
 		},
 		Tags: pulumi.StringMap{
 			"Name": e.Namer.DisplayName(pulumi.String(name)),
-			"Team": pulumi.String("ebpf-platform"),
 		},
 		InstanceInitiatedShutdownBehavior: pulumi.String(e.DefaultShutdownBehavior()),
 	}, e.ResourceProvidersOption())


### PR DESCRIPTION
What does this PR do?
---------------------
This PR allows to add pipeline-id as a tag to an ec2 instance, if the appropriate environment variable is present.
It also makes the tags more consistent by always using dash ("-") instead of underscore ("_").

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
