### PR TITLE
[task] Add cleanup task

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,6 +1,7 @@
 from invoke.collection import Collection
 from invoke.tasks import Task
 
+from tasks.clean import clean
 from tasks.docker import create_docker, destroy_docker
 from tasks.ecs import create_ecs, destroy_ecs
 from tasks.eks import create_eks, destroy_eks
@@ -17,3 +18,4 @@ ns.add_task(Task(destroy_eks))
 ns.add_task(Task(create_ecs))
 ns.add_task(Task(destroy_ecs))
 ns.add_task(Task(setup))
+ns.add_task(Task(clean))

--- a/tasks/clean.py
+++ b/tasks/clean.py
@@ -1,0 +1,31 @@
+import os
+import os.path
+from pathlib import Path
+
+from invoke.tasks import task
+from invoke.context import Context
+
+from .destroy import destroy
+from .tool import info, is_windows, warn
+
+@task
+def clean(_: Context) -> None:
+    """
+    Clean any environment created with invoke tasks or e2e tests
+    """
+    info("🧹 Clean up lock files")
+
+    if is_windows():
+        warn(f"This task is not supported yet on Windows. Want to help supporting it ? Let's go to {__file__} and be the change !")
+        return
+    
+    lock_dir = os.path.join(Path.home(), ".pulumi", "locks")
+    for filename in os.listdir(Path(lock_dir)):
+        file_path = os.path.join(lock_dir, filename)
+        if os.path.isfile(file_path):
+            os.remove(file_path)
+            print(f"🗑️ Deleted file: {file_path}")
+
+    info("🧹 Clean up stacks")
+    destroy("*")
+

--- a/tasks/ecs.py
+++ b/tasks/ecs.py
@@ -70,7 +70,7 @@ def _show_connection_message(full_stack_name: str):
         "stack_name": doc.stack_name,
     }
 )
-def destroy_ecs(ctx: Context, stack_name: Optional[str] = None):
+def destroy_ecs(_: Context, stack_name: Optional[str] = None):
     """
     Destroy a ECS environment created with invoke create-ecs.
     """

--- a/tasks/vm.py
+++ b/tasks/vm.py
@@ -72,7 +72,7 @@ def _show_connection_message(full_stack_name: str):
         "stack_name": doc.stack_name,
     }
 )
-def destroy_vm(ctx: Context, stack_name: Optional[str] = None):
+def destroy_vm(_: Context, stack_name: Optional[str] = None):
     """
     Destroy a new virtual machine on the cloud.
     """


### PR DESCRIPTION
What does this PR do?
---------------------

Add a task to clean pulumi stacks and lock files accidentally broken. It will remove any lock files and destroy and remove any stack prefixed by username, standard used in our tasks and in e2e tests to prefix stacks.

Stacks manually created with pulumi and not prefixed by the username will be skipped, to be discussed if we want to add them to the cleanup too.

Which scenarios this will impact?
-------------------

None

Motivation
----------

During our workshop one of the most requested feature was a cleanup script to unlock stacks that accidentally break during setup. This can happen for various reasons, most common cause is the aws token expired, or breaking a test execution while in timeout.

Additional Notes
----------------
