### PR TITLE
Make the `nginx` and `redis` apps depend on the agent deployment

### DIFF
--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -179,6 +179,8 @@ func Run(ctx *pulumi.Context) error {
 		}
 	}
 
+	var dependsOnCrd pulumi.ResourceOption
+
 	// Deploy the Agent
 	if awsEnv.AgentDeploy() {
 		var fakeintake *ddfakeintake.ConnectionExporter
@@ -203,15 +205,17 @@ func Run(ctx *pulumi.Context) error {
 			ctx.Export("agent-windows-helm-install-name", helmComponent.WindowsHelmReleaseName)
 			ctx.Export("agent-windows-helm-install-status", helmComponent.WindowsHelmReleaseStatus)
 		}
+
+		dependsOnCrd = utils.PulumiDependsOn(helmComponent)
 	}
 
 	// Deploy testing workload
 	if awsEnv.TestingWorkloadDeploy() {
-		if _, err := nginx.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-nginx"); err != nil {
+		if _, err := nginx.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-nginx", dependsOnCrd); err != nil {
 			return err
 		}
 
-		if _, err := redis.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-redis"); err != nil {
+		if _, err := redis.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-redis", dependsOnCrd); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
What does this PR do?
---------------------

Make the `nginx` and `redis` apps depend on the agent deployment for the `DatadogMetric` `CRD`.
This CRD is setup by the agent Helm chart deployment and is needed for the HPA of those two apps.

Which scenarios this will impact?
-------------------

* `aws/eks`

Motivation
----------

Fix the following errors when attempting to run the `aws/eks` scenario:
```
Diagnostics:
  kubernetes:datadoghq.com/v1alpha1:DatadogMetric (nginx):
    error: creation of resource workload-nginx/nginx failed because the Kubernetes API server reported that the apiVersion for this resource does not exist. Verify that any required CRDs have been created: no matches for kind "DatadogMetric" in version "datadoghq.com/v1alpha1"

  kubernetes:datadoghq.com/v1alpha1:DatadogMetric (redis):
    error: creation of resource workload-redis/redis failed because the Kubernetes API server reported that the apiVersion for this resource does not exist. Verify that any required CRDs have been created: no matches for kind "DatadogMetric" in version "datadoghq.com/v1alpha1"

  pulumi:pulumi:Stack (dd-lenaic-eks):
    error: update failed
```

Additional Notes
----------------
