### PR TITLE
[task] ignore Task error

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,5 +1,4 @@
 from invoke.collection import Collection
-from invoke.tasks import Task
 
 from tasks.docker import create_docker, destroy_docker
 from tasks.ecs import create_ecs, destroy_ecs
@@ -8,12 +7,12 @@ from .vm import create_vm, destroy_vm
 from .setup import setup
 
 ns = Collection()
-ns.add_task(Task(create_vm))
-ns.add_task(Task(destroy_vm))
-ns.add_task(Task(create_docker))
-ns.add_task(Task(destroy_docker))
-ns.add_task(Task(create_eks))
-ns.add_task(Task(destroy_eks))
-ns.add_task(Task(create_ecs))
-ns.add_task(Task(destroy_ecs))
-ns.add_task(Task(setup))
+ns.add_task(create_vm)      # pyright: ignore [reportGeneralTypeIssues]
+ns.add_task(destroy_vm)     # pyright: ignore [reportGeneralTypeIssues]
+ns.add_task(create_docker)  # pyright: ignore [reportGeneralTypeIssues]
+ns.add_task(destroy_docker) # pyright: ignore [reportGeneralTypeIssues]
+ns.add_task(create_eks)     # pyright: ignore [reportGeneralTypeIssues]
+ns.add_task(destroy_eks)    # pyright: ignore [reportGeneralTypeIssues]
+ns.add_task(create_ecs)     # pyright: ignore [reportGeneralTypeIssues]
+ns.add_task(destroy_ecs)    # pyright: ignore [reportGeneralTypeIssues]
+ns.add_task(setup)          # pyright: ignore [reportGeneralTypeIssues]


### PR DESCRIPTION
What does this PR do?
---------------------

Ignore general type issue in tasks collection

Which scenarios this will impact?
-------------------

None

Motivation
----------

This error seems to be on invoke side: `task` decorator does not return the proper type and does dynamic casting, which is not working well with pyright static type checking

Additional Notes
----------------
