### PR TITLE
Add AWS provider for EKS cluster

### DIFF
--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -108,7 +108,7 @@ func Run(ctx *pulumi.Context) error {
 			linuxNodeRole,
 		},
 		ServiceRole: clusterRole,
-	}, pulumi.Timeouts(&pulumi.CustomTimeouts{
+	}, awsEnv.ResourceProvidersOption(), pulumi.Timeouts(&pulumi.CustomTimeouts{
 		Create: "30m",
 		Update: "30m",
 		Delete: "30m",

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -82,6 +82,12 @@ func Run(ctx *pulumi.Context) error {
 		)
 	}
 
+	// Building EKS provider
+	eksProvider, err := eks.NewProvider(awsEnv.Ctx, awsEnv.Namer.ResourceName("eks-provider"), &eks.ProviderArgs{}, awsEnv.ResourceProvidersOption())
+	if err != nil {
+		return err
+	}
+
 	// Create an EKS cluster with the default configuration.
 	cluster, err := eks.NewCluster(ctx, awsEnv.Namer.ResourceName("eks"), &eks.ClusterArgs{
 		Name:                         awsEnv.CommonNamer.DisplayName(),
@@ -108,7 +114,7 @@ func Run(ctx *pulumi.Context) error {
 			linuxNodeRole,
 		},
 		ServiceRole: clusterRole,
-	}, awsEnv.ResourceProvidersOption(), pulumi.Timeouts(&pulumi.CustomTimeouts{
+	}, awsEnv.ResourceProvidersOption(), pulumi.Provider(eksProvider), pulumi.Timeouts(&pulumi.CustomTimeouts{
 		Create: "30m",
 		Update: "30m",
 		Delete: "30m",


### PR DESCRIPTION
What does this PR do?
---------------------

Add explicitly the AWS provider for the EKS cluster creation.

Which scenarios this will impact?
-------------------

* `aws/eks`

Motivation
----------

Fix the following error when trying to use from the `datadog-agent` repository:
```
@ updating.................
 +  pulumi:pulumi:Stack e2elocal-lenaic-eks-cluster creating (65s) error: an unhandled error occurred: waiting for RPCs: rpc error: code = Unknown desc = Default provider for 'eks' disabled. 'eks:index:Cluster' must use an explicit provider.
 +  pulumi:pulumi:Stack e2elocal-lenaic-eks-cluster **creating failed** 1 error
                            
Diagnostics:
  pulumi:pulumi:Stack (e2elocal-lenaic-eks-cluster):
    error: an unhandled error occurred: waiting for RPCs: rpc error: code = Unknown desc = Default provider for 'eks' disabled. 'eks:index:Cluster' must use an explicit provider.
```

Additional Notes
----------------
