### PR TITLE
Fix UTF8 char in disable default providers. Add Lazy instantiation of providers. Use invoke to run commands

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,17 +26,22 @@ jobs:
           cache-dependency-path: go.sum
       - name: Check tidy
         run: go mod tidy && git diff-files --exit-code go.mod go.sum
-      - name: Install golangci-lint
-        # Install golangci-lint from source instead of using
-        # golangci-lint-action to ensure the golangci-lint binary is built with
-        # the same Go version we're targeting.
-        # Avoids incompatibility issues such as:
-        # - https://github.com/golangci/golangci-lint/issues/2922
-        # - https://github.com/golangci/golangci-lint/issues/2673
-        # - https://github.com/golangci/golangci-lint-action/issues/442
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-      - name: Run golangci-lint
-        run: golangci-lint version && golangci-lint run --new-from-rev=HEAD~ --out-format=github-actions --timeout=10m
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Require: The version of golangci-lint to use.
+          # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
+          # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
+          version: latest
+
+          # Optional: golangci-lint command line arguments.
+          args: --timeout=10m
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          only-new-issues: true
+          
+          # Optional:The mode to install golangci-lint. It can be 'binary' or 'goinstall'.
+          install-mode: "goinstall"
   lint-python-type:
     runs-on: ubuntu-latest
     steps:

--- a/Pulumi.yaml
+++ b/Pulumi.yaml
@@ -2,4 +2,4 @@ name: dd
 runtime: go
 description: Generic scenario (check scenario variable)
 config:
-  pulumi:disable-default-providers: [“*”]
+  pulumi:disable-default-providers: ["*"]

--- a/common/config/providers.go
+++ b/common/config/providers.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/pulumi/pulumi-awsx/sdk/go/awsx"
+	"github.com/pulumi/pulumi-command/sdk/go/command"
+	"github.com/pulumi/pulumi-eks/sdk/go/eks"
+	"github.com/pulumi/pulumi-random/sdk/v4/go/random"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+type ProviderID string
+
+const (
+	ProviderRandom  ProviderID = "random"
+	ProviderCommand ProviderID = "command"
+	ProviderAWS     ProviderID = "aws"
+	ProviderAWSX    ProviderID = "awsx"
+	ProviderEKS     ProviderID = "eks"
+	ProviderAzure   ProviderID = "azure"
+)
+
+var dummyProvidersFactory = map[ProviderID]func(ctx *pulumi.Context, name string) (pulumi.ProviderResource, error){
+	ProviderRandom: func(ctx *pulumi.Context, name string) (pulumi.ProviderResource, error) {
+		provider, err := random.NewProvider(ctx, name, nil)
+		return provider, err
+	},
+	ProviderCommand: func(ctx *pulumi.Context, name string) (pulumi.ProviderResource, error) {
+		provider, err := command.NewProvider(ctx, name, nil)
+		return provider, err
+	},
+	ProviderAWSX: func(ctx *pulumi.Context, name string) (pulumi.ProviderResource, error) {
+		provider, err := awsx.NewProvider(ctx, name, nil)
+		return provider, err
+	},
+	ProviderEKS: func(ctx *pulumi.Context, name string) (pulumi.ProviderResource, error) {
+		provider, err := eks.NewProvider(ctx, name, nil)
+		return provider, err
+	},
+}
+
+type providerRegistry struct {
+	ctx       *pulumi.Context
+	providers map[ProviderID]pulumi.ProviderResource
+	lock      *sync.Mutex
+}
+
+func newProviderRegistry(ctx *pulumi.Context) providerRegistry {
+	return providerRegistry{
+		ctx:       ctx,
+		providers: make(map[ProviderID]pulumi.ProviderResource),
+		lock:      &sync.Mutex{},
+	}
+}
+
+func (p *providerRegistry) WithProvider(providerID ProviderID) pulumi.ResourceOrInvokeOption {
+	return pulumi.Provider(p.GetProvider(providerID))
+}
+
+func (p *providerRegistry) WithProviders(providerID ...ProviderID) pulumi.ResourceOption {
+	var providers []pulumi.ProviderResource
+	for _, id := range providerID {
+		providers = append(providers, p.GetProvider(id))
+	}
+	return pulumi.Providers(providers...)
+}
+
+func (p *providerRegistry) RegisterProvider(providerID ProviderID, provider pulumi.ProviderResource) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	p.providers[providerID] = provider
+}
+
+func (p *providerRegistry) GetProvider(providerID ProviderID) pulumi.ProviderResource {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if provider, found := p.providers[providerID]; found {
+		return provider
+	}
+
+	if providerFactory, found := dummyProvidersFactory[providerID]; found {
+		provider, err := providerFactory(p.ctx, string(providerID))
+		if err != nil {
+			panic(fmt.Errorf("Provider %s creation failed, err: %w", providerID, err))
+		}
+
+		p.providers[providerID] = provider
+		return provider
+	}
+
+	panic(fmt.Sprintf("Provider %s not registered", providerID))
+}

--- a/common/config/providers.go
+++ b/common/config/providers.go
@@ -22,23 +22,25 @@ const (
 	ProviderAzure   ProviderID = "azure"
 )
 
-var dummyProvidersFactory = map[ProviderID]func(ctx *pulumi.Context, name string) (pulumi.ProviderResource, error){
-	ProviderRandom: func(ctx *pulumi.Context, name string) (pulumi.ProviderResource, error) {
-		provider, err := random.NewProvider(ctx, name, nil)
-		return provider, err
-	},
-	ProviderCommand: func(ctx *pulumi.Context, name string) (pulumi.ProviderResource, error) {
-		provider, err := command.NewProvider(ctx, name, nil)
-		return provider, err
-	},
-	ProviderAWSX: func(ctx *pulumi.Context, name string) (pulumi.ProviderResource, error) {
-		provider, err := awsx.NewProvider(ctx, name, nil)
-		return provider, err
-	},
-	ProviderEKS: func(ctx *pulumi.Context, name string) (pulumi.ProviderResource, error) {
-		provider, err := eks.NewProvider(ctx, name, nil)
-		return provider, err
-	},
+func dummyProvidersFactory() map[ProviderID]func(ctx *pulumi.Context, name string) (pulumi.ProviderResource, error) {
+	return map[ProviderID]func(ctx *pulumi.Context, name string) (pulumi.ProviderResource, error){
+		ProviderRandom: func(ctx *pulumi.Context, name string) (pulumi.ProviderResource, error) {
+			provider, err := random.NewProvider(ctx, name, nil)
+			return provider, err
+		},
+		ProviderCommand: func(ctx *pulumi.Context, name string) (pulumi.ProviderResource, error) {
+			provider, err := command.NewProvider(ctx, name, nil)
+			return provider, err
+		},
+		ProviderAWSX: func(ctx *pulumi.Context, name string) (pulumi.ProviderResource, error) {
+			provider, err := awsx.NewProvider(ctx, name, nil)
+			return provider, err
+		},
+		ProviderEKS: func(ctx *pulumi.Context, name string) (pulumi.ProviderResource, error) {
+			provider, err := eks.NewProvider(ctx, name, nil)
+			return provider, err
+		},
+	}
 }
 
 type providerRegistry struct {
@@ -82,15 +84,15 @@ func (p *providerRegistry) GetProvider(providerID ProviderID) pulumi.ProviderRes
 		return provider
 	}
 
-	if providerFactory, found := dummyProvidersFactory[providerID]; found {
+	if providerFactory, found := dummyProvidersFactory()[providerID]; found {
 		provider, err := providerFactory(p.ctx, string(providerID))
 		if err != nil {
-			panic(fmt.Errorf("Provider %s creation failed, err: %w", providerID, err))
+			panic(fmt.Errorf("provider %s creation failed, err: %w", providerID, err))
 		}
 
 		p.providers[providerID] = provider
 		return provider
 	}
 
-	panic(fmt.Sprintf("Provider %s not registered", providerID))
+	panic(fmt.Sprintf("provider %s not registered", providerID))
 }

--- a/common/utils/random.go
+++ b/common/utils/random.go
@@ -28,5 +28,5 @@ func (r *RandomGenerator) RandomString(name string, length int, special bool) (*
 	return random.NewRandomString(r.e.Ctx, r.namer.ResourceName("random-string", name), &random.RandomStringArgs{
 		Length:  pulumi.Int(length),
 		Special: pulumi.Bool(special),
-	}, pulumi.Provider(r.e.RandomProvider))
+	}, r.e.WithProviders(config.ProviderRandom))
 }

--- a/components/command/runner.go
+++ b/components/command/runner.go
@@ -96,13 +96,13 @@ func (r *Runner) Command(name string, args *Args, opts ...pulumi.ResourceOption)
 	if args.Sudo && r.config.user != "" {
 		r.e.Ctx.Log.Info(fmt.Sprintf("warning: running sudo command on a runner with user %s, discarding user", r.config.user), nil)
 	}
-	depends := append(opts, pulumi.Provider(r.e.CommandProvider))
+	depends := append(opts, r.e.WithProviders(config.ProviderCommand))
 	return remote.NewCommand(r.e.Ctx, r.namer.ResourceName("cmd", name), args.toRemoteCommandArgs(r.config, r.osCommand), depends...)
 }
 
 func (r *Runner) NewCopyFile(localPath, remotePath string, opts ...pulumi.ResourceOption) (*remote.CopyFile, error) {
 	opts = append(opts, r.options...)
-	depends := append(opts, pulumi.Provider(r.e.CommandProvider))
+	depends := append(opts, r.e.WithProviders(config.ProviderCommand))
 	return remote.NewCopyFile(r.e.Ctx, r.namer.ResourceName("copy", remotePath), &remote.CopyFileArgs{
 		Connection: r.config.connection,
 		LocalPath:  pulumi.String(localPath),
@@ -137,6 +137,6 @@ func NewLocalRunner(e config.CommonEnvironment, args LocalRunnerArgs) *LocalRunn
 }
 
 func (r *LocalRunner) Command(name string, args *Args, opts ...pulumi.ResourceOption) (*local.Command, error) {
-	depends := append(opts, pulumi.Provider(r.e.CommandProvider))
+	depends := append(opts, r.e.WithProviders(config.ProviderCommand))
 	return local.NewCommand(r.e.Ctx, r.namer.ResourceName("cmd", name), args.toLocalCommandArgs(r.config, r.osCommand), depends...)
 }

--- a/components/datadog/agent/ecs.go
+++ b/components/datadog/agent/ecs.go
@@ -66,7 +66,7 @@ func ECSLinuxDaemonDefinition(e aws.Environment, name string, apiKeySSMParamName
 				},
 			},
 		},
-	}, e.ResourceProvidersOption())
+	}, e.WithProviders(config.ProviderAWS, config.ProviderAWSX))
 }
 
 func ecsLinuxAgentSingleContainerDefinition(e config.CommonEnvironment, apiKeySSMParamName pulumi.StringInput) ecs.TaskDefinitionContainerDefinitionArgs {

--- a/components/datadog/fakeintake/ecsFargate.go
+++ b/components/datadog/fakeintake/ecsFargate.go
@@ -1,6 +1,7 @@
 package fakeintake
 
 import (
+	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 
 	"github.com/pulumi/pulumi-awsx/sdk/go/awsx/awsx"
@@ -31,7 +32,7 @@ func FargateLinuxTaskDefinition(e aws.Environment, name string) (*ecs.FargateTas
 			RoleArn: pulumi.StringPtr(e.ECSTaskRole()),
 		},
 		Family: e.CommonNamer.DisplayName(pulumi.String("fakeintake-ecs")),
-	}, e.ResourceProvidersOption())
+	}, e.WithProviders(config.ProviderAWS, config.ProviderAWSX))
 }
 
 func fargateLinuxContainerDefinition() *ecs.TaskDefinitionContainerDefinitionArgs {

--- a/resources/aws/ec2/ami.go
+++ b/resources/aws/ec2/ami.go
@@ -3,6 +3,7 @@ package ec2
 import (
 	"fmt"
 
+	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
@@ -46,7 +47,7 @@ func SearchAMI(e aws.Environment, owner, name, arch string) (string, error) {
 		Owners: []string{
 			owner,
 		},
-	}, e.InvokeProviderOption())
+	}, e.WithProvider(config.ProviderAWS))
 	if err != nil {
 		return "", err
 	}
@@ -65,7 +66,7 @@ func GetLatestAMI(e aws.Environment, arch os.Architecture, amd64Path string, arm
 	}
 	result, err := ssm.LookupParameter(e.Ctx, &ssm.LookupParameterArgs{
 		Name: amiParamName,
-	}, e.InvokeProviderOption())
+	}, e.WithProvider(config.ProviderAWS))
 	if err != nil {
 		return "", err
 	}

--- a/resources/aws/ec2/asg.go
+++ b/resources/aws/ec2/asg.go
@@ -3,7 +3,9 @@ package ec2
 import (
 	"strconv"
 
+	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
+
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/autoscaling"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -29,5 +31,5 @@ func NewAutoscalingGroup(e aws.Environment, name string,
 				MinHealthyPercentage: pulumi.Int(0),
 			},
 		},
-	}, e.ResourceProvidersOption())
+	}, e.WithProviders(config.ProviderAWS))
 }

--- a/resources/aws/ec2/vm.go
+++ b/resources/aws/ec2/vm.go
@@ -1,6 +1,7 @@
 package ec2
 
 import (
+	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
@@ -31,6 +32,6 @@ func NewEC2Instance(e aws.Environment, name, ami, arch, instanceType, keyPair, u
 			"Name": e.Namer.DisplayName(pulumi.String(name)),
 		},
 		InstanceInitiatedShutdownBehavior: pulumi.String(e.DefaultShutdownBehavior()),
-	}, e.ResourceProvidersOption())
+	}, e.WithProviders(config.ProviderAWS))
 	return instance, err
 }

--- a/resources/aws/ec2/vmtemplate.go
+++ b/resources/aws/ec2/vmtemplate.go
@@ -1,6 +1,7 @@
 package ec2
 
 import (
+	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
@@ -29,6 +30,6 @@ func CreateLaunchTemplate(e aws.Environment, name string, ami, instanceType, iam
 		KeyName:              keyPair,
 		UserData:             userData,
 		UpdateDefaultVersion: pulumi.BoolPtr(true),
-	}, e.ResourceProvidersOption())
+	}, e.WithProviders(config.ProviderAWS))
 	return launchTemplate, err
 }

--- a/resources/aws/ecs/capacityProviders.go
+++ b/resources/aws/ecs/capacityProviders.go
@@ -1,6 +1,7 @@
 package ecs
 
 import (
+	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ecs"
@@ -17,12 +18,12 @@ func NewCapacityProvider(e aws.Environment, name string, asgArn pulumi.StringInp
 			},
 			ManagedTerminationProtection: aws.DisabledString,
 		},
-	}, e.ResourceProvidersOption())
+	}, e.WithProviders(config.ProviderAWS))
 }
 
 func NewClusterCapacityProvider(e aws.Environment, name string, clusterName pulumi.StringInput, capacityProviders pulumi.StringArray) (*ecs.ClusterCapacityProviders, error) {
 	return ecs.NewClusterCapacityProviders(e.Ctx, e.Namer.ResourceName(name), &ecs.ClusterCapacityProvidersArgs{
 		ClusterName:       clusterName,
 		CapacityProviders: capacityProviders,
-	}, e.ResourceProvidersOption())
+	}, e.WithProviders(config.ProviderAWS))
 }

--- a/resources/aws/ecs/cluster.go
+++ b/resources/aws/ecs/cluster.go
@@ -1,6 +1,7 @@
 package ecs
 
 import (
+	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ecs"
@@ -15,5 +16,5 @@ func CreateEcsCluster(e aws.Environment, name string) (*ecs.Cluster, error) {
 				KmsKeyId: pulumi.StringPtr(e.ECSExecKMSKeyID()),
 			},
 		},
-	}, e.ResourceProvidersOption())
+	}, e.WithProviders(config.ProviderAWS))
 }

--- a/resources/aws/ecs/fargateService.go
+++ b/resources/aws/ecs/fargateService.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
 	ddfakeintake "github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
@@ -34,7 +35,7 @@ func FargateService(e aws.Environment, name string, clusterArn pulumi.StringInpu
 		TaskDefinition:            taskDefArn,
 		EnableExecuteCommand:      pulumi.BoolPtr(true),
 		ContinueBeforeSteadyState: pulumi.BoolPtr(true),
-	}, e.ResourceProvidersOption())
+	}, e.WithProviders(config.ProviderAWS, config.ProviderAWSX))
 }
 
 func FargateTaskDefinitionWithAgent(e aws.Environment, name string, family pulumi.StringInput, containers []*ecs.TaskDefinitionContainerDefinitionArgs, apiKeySSMParamName pulumi.StringInput) (*ecs.FargateTaskDefinition, error) {
@@ -62,7 +63,7 @@ func FargateTaskDefinitionWithAgent(e aws.Environment, name string, family pulum
 				Name: pulumi.String("dd-sockets"),
 			},
 		},
-	}, e.ResourceProvidersOption())
+	}, e.WithProviders(config.ProviderAWS, config.ProviderAWSX))
 }
 
 func FargateRedisContainerDefinition(apiKeySSMParamName pulumi.StringInput) *ecs.TaskDefinitionContainerDefinitionArgs {

--- a/resources/aws/ecs/nodeGroups.go
+++ b/resources/aws/ecs/nodeGroups.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 	"github.com/DataDog/test-infra-definitions/resources/aws/ec2"
 
@@ -41,7 +42,7 @@ func NewECSOptimizedNodeGroup(e aws.Environment, clusterName pulumi.StringInput,
 
 	ecsAmi, err := ssm.LookupParameter(e.Ctx, &ssm.LookupParameterArgs{
 		Name: amiParamName,
-	}, e.InvokeProviderOption())
+	}, e.WithProvider(config.ProviderAWS))
 	if err != nil {
 		return pulumi.StringOutput{}, err
 	}
@@ -52,7 +53,7 @@ func NewECSOptimizedNodeGroup(e aws.Environment, clusterName pulumi.StringInput,
 func NewBottlerocketNodeGroup(e aws.Environment, clusterName pulumi.StringInput) (pulumi.StringOutput, error) {
 	bottlerocketAmi, err := ssm.LookupParameter(e.Ctx, &ssm.LookupParameterArgs{
 		Name: "/aws/service/bottlerocket/aws-ecs-1/x86_64/latest/image_id",
-	}, e.InvokeProviderOption())
+	}, e.WithProvider(config.ProviderAWS))
 	if err != nil {
 		return pulumi.StringOutput{}, err
 	}
@@ -63,7 +64,7 @@ func NewBottlerocketNodeGroup(e aws.Environment, clusterName pulumi.StringInput)
 func NewWindowsNodeGroup(e aws.Environment, clusterName pulumi.StringInput) (pulumi.StringOutput, error) {
 	winAmi, err := ssm.LookupParameter(e.Ctx, &ssm.LookupParameterArgs{
 		Name: "/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-ECS_Optimized/image_id",
-	}, e.InvokeProviderOption())
+	}, e.WithProvider(config.ProviderAWS))
 	if err != nil {
 		return pulumi.StringOutput{}, err
 	}

--- a/resources/aws/eks/nodeGroups.go
+++ b/resources/aws/eks/nodeGroups.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 
 	awsEks "github.com/pulumi/pulumi-aws/sdk/v5/go/aws/eks"
@@ -55,13 +56,13 @@ func newManagedNodeGroup(e aws.Environment, name string, cluster *eks.Cluster, n
 			Ec2SshKey:              pulumi.String(e.DefaultKeyPairName()),
 			SourceSecurityGroupIds: pulumi.ToStringArray(e.EKSAllowedInboundSecurityGroups()),
 		},
-	}, e.ResourceProvidersOption())
+	}, e.WithProviders(config.ProviderAWS, config.ProviderEKS))
 }
 
 func NewWindowsUnmanagedNodeGroup(e aws.Environment, cluster *eks.Cluster, nodeRole *awsIam.Role) (*eks.NodeGroup, error) {
 	windowsAmi, err := ssm.LookupParameter(e.Ctx, &ssm.LookupParameterArgs{
 		Name: fmt.Sprintf("/aws/service/ami-windows-latest/Windows_Server-2022-English-Core-EKS_Optimized-%s/image_id", e.KubernetesVersion()),
-	}, e.InvokeProviderOption())
+	}, e.WithProvider(config.ProviderAWS))
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +74,7 @@ func newUnmanagedNodeGroup(e aws.Environment, name string, cluster *eks.Cluster,
 	instanceProfile, err := awsIam.NewInstanceProfile(e.Ctx, e.Namer.ResourceName(name), &awsIam.InstanceProfileArgs{
 		Name: e.CommonNamer.DisplayName(pulumi.String(name)),
 		Role: nodeRole.Name,
-	}, e.ResourceProvidersOption())
+	}, e.WithProviders(config.ProviderAWS))
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +91,7 @@ func newUnmanagedNodeGroup(e aws.Environment, name string, cluster *eks.Cluster,
 		NodeRootVolumeSize:           pulumi.Int(80),
 		NodeAssociatePublicIpAddress: pulumi.BoolRef(false),
 		InstanceProfile:              instanceProfile,
-	}, e.ResourceProvidersOption())
+	}, e.WithProviders(config.ProviderAWS, config.ProviderEKS))
 }
 
 func getUserData(userData string, clusterName pulumi.StringInput) pulumi.StringInput {

--- a/resources/aws/eks/role.go
+++ b/resources/aws/eks/role.go
@@ -1,6 +1,7 @@
 package eks
 
 import (
+	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 	"github.com/DataDog/test-infra-definitions/resources/aws/iam"
 
@@ -24,7 +25,7 @@ func GetNodeRole(e aws.Environment, name string) (*awsIam.Role, error) {
 			"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
 		}),
 		AssumeRolePolicy: pulumi.String(assumeRolePolicy.Json),
-	}, e.ResourceProvidersOption())
+	}, e.WithProviders(config.ProviderAWS))
 }
 
 func GetClusterRole(e aws.Environment, name string) (*awsIam.Role, error) {
@@ -41,5 +42,5 @@ func GetClusterRole(e aws.Environment, name string) (*awsIam.Role, error) {
 			"arn:aws:iam::aws:policy/AmazonEKSVPCResourceController",
 		}),
 		AssumeRolePolicy: pulumi.String(assumeRolePolicy.Json),
-	}, e.ResourceProvidersOption())
+	}, e.WithProviders(config.ProviderAWS))
 }

--- a/resources/aws/environment.go
+++ b/resources/aws/environment.go
@@ -5,7 +5,6 @@ import (
 	"github.com/DataDog/test-infra-definitions/common/namer"
 
 	sdkaws "github.com/pulumi/pulumi-aws/sdk/v5/go/aws"
-	sdkawsx "github.com/pulumi/pulumi-awsx/sdk/go/awsx"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	sdkconfig "github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
@@ -54,10 +53,8 @@ type Environment struct {
 
 	Namer namer.Namer
 
-	awsProvider  *sdkaws.Provider
-	awsxProvider *sdkawsx.Provider
-	awsConfig    *sdkconfig.Config
-	envDefault   environmentDefault
+	awsConfig  *sdkconfig.Config
+	envDefault environmentDefault
 }
 
 func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
@@ -73,7 +70,7 @@ func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
 		envDefault:        getEnvironmentDefault(config.FindEnvironmentName(commonEnv.InfraEnvironmentNames(), awsConfigNamespace)),
 	}
 
-	env.awsProvider, err = sdkaws.NewProvider(ctx, "aws", &sdkaws.ProviderArgs{
+	awsProvider, err := sdkaws.NewProvider(ctx, string(config.ProviderAWS), &sdkaws.ProviderArgs{
 		Region: pulumi.String(env.Region()),
 		DefaultTags: sdkaws.ProviderDefaultTagsArgs{
 			Tags: commonEnv.ResourcesTags(),
@@ -84,25 +81,9 @@ func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
 	if err != nil {
 		return Environment{}, err
 	}
-
-	env.awsxProvider, err = sdkawsx.NewProvider(ctx, "awsx", &sdkawsx.ProviderArgs{})
-	if err != nil {
-		return Environment{}, err
-	}
+	env.RegisterProvider(config.ProviderAWS, awsProvider)
 
 	return env, nil
-}
-
-// InvokeOption are used in non-resources methods (like LookupXXX or GetXXX)
-// These methods only allow for a single provider.
-func (e *Environment) InvokeProviderOption() pulumi.InvokeOption {
-	return pulumi.Provider(e.awsProvider)
-}
-
-// ResourceOption are used in resources methods (like NewXXX)
-// These methods can use multiple providers (like awsx with aws)
-func (e *Environment) ResourceProvidersOption() pulumi.ResourceOption {
-	return pulumi.Providers(e.awsProvider, e.awsxProvider)
 }
 
 // Common

--- a/resources/aws/iam/role.go
+++ b/resources/aws/iam/role.go
@@ -1,6 +1,7 @@
 package iam
 
 import (
+	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/iam"
 )
@@ -25,5 +26,5 @@ func GetAWSPrincipalAssumeRole(e aws.Environment, serviceName []string) (*iam.Ge
 				},
 			},
 		},
-	}, nil, e.InvokeProviderOption())
+	}, nil, e.WithProvider(config.ProviderAWS))
 }

--- a/resources/azure/aks/cluster.go
+++ b/resources/azure/aks/cluster.go
@@ -3,8 +3,10 @@ package aks
 import (
 	"encoding/base64"
 
+	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/resources/azure"
+
 	"github.com/pulumi/pulumi-azure-native-sdk/containerservice"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -22,7 +24,7 @@ func NewCluster(e azure.Environment, name string, nodePool containerservice.Mana
 	// Warning: we're modifying passed array as it should normally never be used anywhere else
 	nodePool = append(nodePool, systemNodePool(e, "system"))
 
-	opts = append(opts, pulumi.Provider(e.Provider))
+	opts = append(opts, e.WithProviders(config.ProviderAzure))
 	cluster, err := containerservice.NewManagedCluster(e.Ctx, e.Namer.ResourceName(name), &containerservice.ManagedClusterArgs{
 		ResourceName:      e.CommonNamer.DisplayName(pulumi.String(name)),
 		ResourceGroupName: pulumi.String(e.DefaultResourceGroup()),
@@ -62,7 +64,7 @@ func NewCluster(e azure.Environment, name string, nodePool containerservice.Mana
 		containerservice.ListManagedClusterUserCredentialsOutputArgs{
 			ResourceGroupName: pulumi.String(e.DefaultResourceGroup()),
 			ResourceName:      cluster.Name,
-		}, pulumi.Provider(e.Provider),
+		}, e.WithProvider(config.ProviderAzure),
 	)
 
 	kubeconfig := creds.Kubeconfigs().Index(pulumi.Int(0)).Value().

--- a/resources/azure/compute/vm.go
+++ b/resources/azure/compute/vm.go
@@ -3,6 +3,7 @@ package compute
 import (
 	"fmt"
 
+	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/resources/azure"
 
@@ -91,7 +92,7 @@ func newVMInstance(e azure.Environment, name, imageUrn, instanceType string, osP
 		ResourceGroupName:        pulumi.String(e.DefaultResourceGroup()),
 		PublicIPAllocationMethod: pulumi.String(network.IPAllocationMethodStatic),
 		Tags:                     e.ResourcesTags(),
-	}, pulumi.Provider(e.Provider))
+	}, e.WithProviders(config.ProviderAzure))
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -112,7 +113,7 @@ func newVMInstance(e azure.Environment, name, imageUrn, instanceType string, osP
 			},
 		},
 		Tags: e.ResourcesTags(),
-	}, pulumi.Provider(e.Provider))
+	}, e.WithProviders(config.ProviderAzure))
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -144,7 +145,7 @@ func newVMInstance(e azure.Environment, name, imageUrn, instanceType string, osP
 		},
 		OsProfile: osProfile,
 		Tags:      e.ResourcesTags(),
-	}, pulumi.Provider(e.Provider))
+	}, e.WithProviders(config.ProviderAzure))
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/resources/azure/environment.go
+++ b/resources/azure/environment.go
@@ -27,8 +27,7 @@ const (
 type Environment struct {
 	*config.CommonEnvironment
 
-	Provider *sdkazure.Provider
-	Namer    namer.Namer
+	Namer namer.Namer
 
 	envDefault environmentDefault
 }
@@ -45,7 +44,7 @@ func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
 		envDefault:        getEnvironmentDefault(config.FindEnvironmentName(commonEnv.InfraEnvironmentNames(), azNamerNamespace)),
 	}
 
-	env.Provider, err = sdkazure.NewProvider(ctx, "azure", &sdkazure.ProviderArgs{
+	azureProvider, err := sdkazure.NewProvider(ctx, string(config.ProviderAzure), &sdkazure.ProviderArgs{
 		DisablePulumiPartnerId: pulumi.BoolPtr(true),
 		SubscriptionId:         pulumi.StringPtr(env.envDefault.azure.subscriptionID),
 		TenantId:               pulumi.StringPtr(env.envDefault.azure.tenantID),
@@ -53,6 +52,7 @@ func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
 	if err != nil {
 		return Environment{}, err
 	}
+	env.RegisterProvider(config.ProviderAzure, azureProvider)
 
 	return env, nil
 }

--- a/scenarios/aws/ecs/run.go
+++ b/scenarios/aws/ecs/run.go
@@ -1,6 +1,7 @@
 package ecs
 
 import (
+	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 	"github.com/DataDog/test-infra-definitions/resources/aws/ecs"
@@ -80,7 +81,7 @@ func Run(ctx *pulumi.Context) error {
 			Name:  awsEnv.CommonNamer.DisplayName(pulumi.String("agent-apikey")),
 			Type:  ssm.ParameterTypeSecureString,
 			Value: awsEnv.AgentAPIKey(),
-		}, awsEnv.ResourceProvidersOption())
+		}, awsEnv.WithProviders(config.ProviderAWS))
 		if err != nil {
 			return err
 		}

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -1,6 +1,7 @@
 package eks
 
 import (
+	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/dogstatsd"
@@ -46,7 +47,7 @@ func Run(ctx *pulumi.Context) error {
 			},
 		},
 		VpcId: pulumi.StringPtr(awsEnv.DefaultVPCID()),
-	}, awsEnv.ResourceProvidersOption())
+	}, awsEnv.WithProviders(config.ProviderAWS))
 	if err != nil {
 		return err
 	}
@@ -112,7 +113,7 @@ func Run(ctx *pulumi.Context) error {
 		Create: "30m",
 		Update: "30m",
 		Delete: "30m",
-	}))
+	}), awsEnv.WithProvider(config.ProviderEKS), awsEnv.WithProvider(config.ProviderAWS))
 	if err != nil {
 		return err
 	}
@@ -158,7 +159,7 @@ func Run(ctx *pulumi.Context) error {
 	eksKubeProvider, err := kubernetes.NewProvider(awsEnv.Ctx, awsEnv.Namer.ResourceName("k8s-provider"), &kubernetes.ProviderArgs{
 		EnableServerSideApply: pulumi.BoolPtr(true),
 		Kubeconfig:            utils.KubeconfigToJSON(cluster.Kubeconfig),
-	}, awsEnv.ResourceProvidersOption(), pulumi.DependsOn(nodeGroups))
+	}, awsEnv.WithProviders(config.ProviderAWS), pulumi.DependsOn(nodeGroups))
 	if err != nil {
 		return err
 	}

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -26,7 +26,7 @@ func Run(ctx *pulumi.Context) error {
 	kindKubeProvider, err := kubernetes.NewProvider(ctx, awsEnv.Namer.ResourceName("k8s-provider"), &kubernetes.ProviderArgs{
 		EnableServerSideApply: pulumi.BoolPtr(true),
 		Kubeconfig:            kubeConfig,
-	}, awsEnv.ResourceProvidersOption(), utils.PulumiDependsOn(kubeConfigCommand))
+	}, utils.PulumiDependsOn(kubeConfigCommand))
 	if err != nil {
 		return err
 	}

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	commonConfig "github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/namer"
 	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/components/command"
@@ -79,7 +80,7 @@ func newEC2Instance(e aws.Environment, name, ami, arch, instanceType, keyPair, u
 			"Name": e.Namer.DisplayName(pulumi.String(name)),
 		},
 		InstanceInitiatedShutdownBehavior: pulumi.String(e.DefaultShutdownBehavior()),
-	}, e.ResourceProvidersOption())
+	}, e.WithProviders(commonConfig.ProviderAWS))
 	return instance, err
 }
 

--- a/tasks/eks.py
+++ b/tasks/eks.py
@@ -25,6 +25,7 @@ scenario_name = "aws/eks"
 )
 def create_eks(
     ctx: Context,
+    debug: Optional[bool] = False,
     stack_name: Optional[str] = None,
     install_agent: Optional[bool] = True,
     agent_version: Optional[str] = None,
@@ -40,14 +41,13 @@ def create_eks(
     extra_flags = {}
     extra_flags["ddinfra:aws/eks/linuxNodeGroup"] = linux_node_group
     extra_flags["ddinfra:aws/eks/linuxARMNodeGroup"] = linux_arm_node_group
-    extra_flags[
-        "ddinfra:aws/eks/linuxBottlerocketNodeGroup"
-    ] = bottlerocket_node_group
+    extra_flags["ddinfra:aws/eks/linuxBottlerocketNodeGroup"] = bottlerocket_node_group
     extra_flags["ddinfra:aws/eks/windowsNodeGroup"] = windows_node_group
 
     full_stack_name = deploy(
         ctx,
         scenario_name,
+        debug=debug,
         app_key_required=True,
         stack_name=stack_name,
         install_agent=install_agent,
@@ -62,9 +62,7 @@ def _show_connection_message(full_stack_name: str):
     kubeconfig = outputs["kubeconfig"]
     kubeconfig_content = yaml.dump(kubeconfig)
     config = f"{full_stack_name}-config.yaml"
-    f = os.open(
-        path=config, flags=(os.O_WRONLY | os.O_CREAT | os.O_TRUNC), mode=0o600
-    )
+    f = os.open(path=config, flags=(os.O_WRONLY | os.O_CREAT | os.O_TRUNC), mode=0o600)
     with open(f, "w") as f:
         f.write(kubeconfig_content)
 


### PR DESCRIPTION
What does this PR do?
---------------------

Fix UTF8 character in `Pulumi.yaml` that prevented `disable-default-providers` to work.
Provision providers lazily and provide helpers to set them in resources.
Use `invoke` runner to run commands instead of directly `subprocess`, make `debug` work for `eks`.

Which scenarios this will impact?
-------------------

All.

Motivation
----------

Additional Notes
----------------
