### PR TITLE
fix(destroy-task): allow destroying the selected stack

### DIFF
--- a/tasks/destroy.py
+++ b/tasks/destroy.py
@@ -56,7 +56,8 @@ def _get_existing_stacks() -> Tuple[List[str], List[str]]:
     full_stacks: List[str] = []
     stack_name_prefix = get_stack_name_prefix()
     for line in lines:
-        stack_name = line.split(" ")[0]
+        # the stack has an asterisk if it is currently selected
+        stack_name = line.split(" ")[0].rstrip('*')
         if stack_name.startswith(stack_name_prefix):
             full_stacks.append(stack_name)
             stack_name = stack_name[len(stack_name_prefix):]


### PR DESCRIPTION
What does this PR do?
---------------------
Fix a bug in the `destroy-vm` task, which prevented destroying the selected stack.

Which scenarios this will impact?
-------------------
None as this is invoke-task specific.

Motivation
----------
Being able to destroy the selected stack.

Stacks created by the invoke-tasks are currently not selected but creating it beforehand using `pulumi stack init` automatically selects it.

Additional Notes
----------------
How to reproduce the issue (without this fix):
```
# create a vm, it will also create a stack named eg. pierre-gimalac-aws-vm
inv create-vm -o ubuntu --no-install-agent --no-use-fakeintake
pulumi stack select pierre-gimalac-aws-vm
inv destroy-vm
```

The last command will error with
```
Unknown stack 'pierre-gimalac-aws-vm'
Run this command with '--stack-name MY_STACK_NAME'. Available stacks are:
 aws-vm*
```

`inv destroy-vm -s 'aws-vm*'` will error with
```
error: stack names are limited to 100 characters and may only contain alphanumeric, hyphens, underscores, or periods: "pierre-gimalac-aws-vm*"
```