### PR TITLE
Remove AWS from disable default providers until EKS plugin is fixed

### DIFF
--- a/Pulumi.yaml
+++ b/Pulumi.yaml
@@ -2,4 +2,7 @@ name: dd
 runtime: go
 description: Generic scenario (check scenario variable)
 config:
-  pulumi:disable-default-providers: ["*"]
+  # we have to disable default providers * again when
+  # https://github.com/pulumi/pulumi-eks/pull/886
+  # is merged
+  pulumi:disable-default-providers: ["kubernetes", "azure-native", "awsx", "eks"]


### PR DESCRIPTION
What does this PR do?
---------------------

Disable all important default providers **except** AWS as it's used by `eks` plugin, which is broken until https://github.com/pulumi/pulumi-eks/pull/886 is merged.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
