### PR TITLE
Add xsltproc to the list of dependencies in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,9 @@ RUN apt-get update -y && \
   docker-ce \
   google-cloud-sdk \
   google-cloud-sdk-gke-gcloud-auth-plugin \
-  kubectl && \
+  kubectl 
+  # xsltproc is required by libvirt-sdk used in the micro-vms scenario
+  xsltproc && \
   # Clean up the lists work
   rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get update -y && \
   docker-ce \
   google-cloud-sdk \
   google-cloud-sdk-gke-gcloud-auth-plugin \
-  kubectl 
+  kubectl \
   # xsltproc is required by libvirt-sdk used in the micro-vms scenario
   xsltproc && \
   # Clean up the lists work


### PR DESCRIPTION
What does this PR do?
---------------------
Adds `xsltproc` to the list of dependencies in the Dockerfile. `xsltproc` is used by the libvirt-sdk to modify the XML files defining the VM environment.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
