### PR TITLE
Fix the cluster agent authentication token length

### DIFF
--- a/components/datadog/agent/helm.go
+++ b/components/datadog/agent/helm.go
@@ -56,7 +56,7 @@ func NewHelmInstallation(e config.CommonEnvironment, args HelmInstallationArgs, 
 	randomClusterAgentToken, err := random.NewRandomString(e.Ctx, "datadog-cluster-agent-token", &random.RandomStringArgs{
 		Lower:   pulumi.Bool(true),
 		Upper:   pulumi.Bool(true),
-		Length:  pulumi.Int(20),
+		Length:  pulumi.Int(32),
 		Numeric: pulumi.Bool(false),
 		Special: pulumi.Bool(false),
 	}, opts...)


### PR DESCRIPTION
What does this PR do?
---------------------

Fix the following error in the agents:
```
=====================
Datadog Cluster Agent
=====================

  - Could not detect the Datadog Cluster Agent's endpoint: temporary failure in clusterAgentClient, will retry later: cluster agent authentication token length must be greater than 32, curently: 20

  - Could not retrieve the version of the Datadog Cluster Agent.
```

Which scenarios this will impact?
-------------------

* `aws/eks`

Motivation
----------

Fix agent ⟷ cluster-agent communication

Additional Notes
----------------
