### PR TITLE
Fix error when using the invoke task from outside the repository

### DIFF
--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -80,8 +80,9 @@ def _deploy(ctx: Context, stack_name: Optional[str], flags: Dict[str, Any], debu
     up_flags = ""
 
     # Checking root path
-    if _get_root_path() != os.getcwd():
-        global_flags += f" -C {_get_root_path}"
+    root_path = _get_root_path()
+    if root_path != os.getcwd():
+        global_flags += f" -C {root_path}"
 
     # Building run func parameters
     for key, value in flags.items():


### PR DESCRIPTION
What does this PR do?
---------------------
Fix a typo with an uncalled function when using the invoke task from outside the repository.

Which scenarios this will impact?
-------------------
None as this is specifically for the invoke task.

Motivation
----------
Being able to use the invoke task from outside the repository.

Additional Notes
----------------
The `_get_root_path` function wasn't called in the argument list, which resulted in a corrupted command being executed, eg.
```
pulumi  -C <function _get_root_path at 0x1057d75e0> stack ls
```
which resulted in an error like
```
/bin/bash: function: No such file or directory
```