### PR TITLE
[docker] fix agent install not working after instance restart

### DIFF
--- a/components/command/docker.go
+++ b/components/command/docker.go
@@ -78,7 +78,7 @@ func (d *DockerManager) ComposeStrUp(name string, composeManifests []DockerCompo
 		return nil, err
 	}
 
-	tempCmd, tempDirPath, err := d.fileManager.TempDirectory(name + "compose-tmp")
+	homeCmd, composePath, err := d.fileManager.HomeDirectory(name + "compose-tmp")
 	if err != nil {
 		return nil, err
 	}
@@ -87,14 +87,14 @@ func (d *DockerManager) ComposeStrUp(name string, composeManifests []DockerCompo
 	runCommandTriggers := pulumi.Array{envVars}
 	runCommandDeps := []pulumi.Resource{installCommand}
 	for _, manifest := range composeManifests {
-		remoteComposePath := path.Join(tempDirPath, fmt.Sprintf("docker-compose-%s.yml", manifest.Name))
+		remoteComposePath := path.Join(composePath, fmt.Sprintf("docker-compose-%s.yml", manifest.Name))
 		remoteComposePaths = append(remoteComposePaths, remoteComposePath)
 
 		writeCommand, err := d.fileManager.CopyInlineFile(
 			manifest.Content,
 			remoteComposePath,
 			false,
-			pulumi.DependsOn([]pulumi.Resource{tempCmd}),
+			pulumi.DependsOn([]pulumi.Resource{homeCmd}),
 		)
 		if err != nil {
 			return nil, err

--- a/components/command/filemanager.go
+++ b/components/command/filemanager.go
@@ -39,6 +39,8 @@ func (fm *FileManager) TempDirectory(resourceName string, opts ...pulumi.Resourc
 }
 
 // HomeDirectory creates a directory in home directory, if it does not exist
+// A home directory is a file system directory on a multi-user operating system containing files for a given user of the system.
+// It does not require sudo, using sudo in home directory allows to change default ownership and it is discouraged.
 func (fm *FileManager) HomeDirectory(resourceName string, opts ...pulumi.ResourceOption) (*remote.Command, string, error) {
 	homeDir := path.Join(fm.command.GetHomeDirectory(), resourceName)
 	folderCmd, err := fm.CreateDirectory("create-home-folder-"+resourceName, pulumi.String(homeDir), false, opts...)

--- a/components/command/filemanager.go
+++ b/components/command/filemanager.go
@@ -31,11 +31,18 @@ func (fm *FileManager) CreateDirectory(name string, remotePath pulumi.StringInpu
 	return fm.command.CreateDirectory(fm.runner, name, remotePath, useSudo, opts...)
 }
 
+// TempDirectory creates a temporary directory
 func (fm *FileManager) TempDirectory(resourceName string, opts ...pulumi.ResourceOption) (*remote.Command, string, error) {
 	tempDir := path.Join(fm.command.GetTemporaryDirectory(), resourceName)
 	folderCmd, err := fm.CreateDirectory("create-temporary-folder-"+resourceName, pulumi.String(tempDir), false, opts...)
 	return folderCmd, tempDir, err
+}
 
+// HomeDirectory creates a directory in home directory, if it does not exist
+func (fm *FileManager) HomeDirectory(resourceName string, opts ...pulumi.ResourceOption) (*remote.Command, string, error) {
+	homeDir := path.Join(fm.command.GetHomeDirectory(), resourceName)
+	folderCmd, err := fm.CreateDirectory("create-home-folder-"+resourceName, pulumi.String(homeDir), false, opts...)
+	return folderCmd, homeDir, err
 }
 
 func (fm *FileManager) CopyFile(localPath, remotePath string, opts ...pulumi.ResourceOption) (*remote.CopyFile, error) {

--- a/components/command/osCommand.go
+++ b/components/command/osCommand.go
@@ -10,6 +10,7 @@ import (
 // OSCommand defines the commands which are OS specifics
 type OSCommand interface {
 	GetTemporaryDirectory() string
+	GetHomeDirectory() string
 
 	CreateDirectory(
 		runner *Runner,

--- a/components/command/unixOSCommand.go
+++ b/components/command/unixOSCommand.go
@@ -10,6 +10,7 @@ import (
 
 const (
 	linuxTempDir = "/tmp"
+	linuxHomeDir = "$HOME"
 )
 
 var _ OSCommand = (*unixOSCommand)(nil)
@@ -57,6 +58,10 @@ func (unixOSCommand) CopyInlineFile(
 
 func (fs unixOSCommand) GetTemporaryDirectory() string {
 	return linuxTempDir
+}
+
+func (fs unixOSCommand) GetHomeDirectory() string {
+	return linuxHomeDir
 }
 
 // BuildCommandString properly format the command string

--- a/components/command/windowsOSCommand.go
+++ b/components/command/windowsOSCommand.go
@@ -55,7 +55,9 @@ func (fs windowsOSCommand) GetTemporaryDirectory() string {
 }
 
 func (fs windowsOSCommand) GetHomeDirectory() string {
-	return "$env:HOMEPATH\\$env:HOMEPATH"
+	// %HOMEDRIVE% returns the disk drive where home directory is located
+	// %HOMEPATH% returns the path to the home directory related to HOMEDRIVE
+	return "$env:HOMEDRIVE$env:HOMEPATH"
 }
 
 func (fs windowsOSCommand) BuildCommandString(

--- a/components/command/windowsOSCommand.go
+++ b/components/command/windowsOSCommand.go
@@ -54,6 +54,10 @@ func (fs windowsOSCommand) GetTemporaryDirectory() string {
 	return "$env:TEMP"
 }
 
+func (fs windowsOSCommand) GetHomeDirectory() string {
+	return "$env:HOMEPATH\\$env:HOMEPATH"
+}
+
 func (fs windowsOSCommand) BuildCommandString(
 	command pulumi.StringInput,
 	env pulumi.StringMap,


### PR DESCRIPTION
What does this PR do?
---------------------

Install docker agent storing agent compose in home directory rather than in temporary directory

Which scenarios this will impact?
-------------------

docker

Motivation
----------

Temporary folder is cleaned up at reboot. Thus after the reboot of an instance where we installed agent on docker, the compose file created at deployment time was gone, like the container. Saving the compose file on home has the advantage of 
* not needing sudo powers
* allowing persistency of the file after reboot
* being available cross-platform

The helper can be used elsewhere.

Additional Notes
----------------
