### PR TITLE
Use commonConfig when aws env is not required

### DIFF
--- a/scenarios/aws/microVMs/config/config.go
+++ b/scenarios/aws/microVMs/config/config.go
@@ -1,7 +1,7 @@
 package config
 
 import (
-	"github.com/DataDog/test-infra-definitions/resources/aws"
+	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/resources/aws/ec2"
 	sdkconfig "github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 )
@@ -26,10 +26,10 @@ var SSHKeyConfigNames = map[string]string{
 
 type DDMicroVMConfig struct {
 	MicroVMConfig *sdkconfig.Config
-	aws.Environment
+	config.CommonEnvironment
 }
 
-func NewMicroVMConfig(e aws.Environment) DDMicroVMConfig {
+func NewMicroVMConfig(e config.CommonEnvironment) DDMicroVMConfig {
 	return DDMicroVMConfig{
 		sdkconfig.New(e.Ctx, ddMicroVMNamespace),
 		e,

--- a/scenarios/aws/microVMs/microvms/libvirt.go
+++ b/scenarios/aws/microVMs/microvms/libvirt.go
@@ -163,7 +163,7 @@ func (vm *VMCollection) SetupCollectionNetwork(depends []pulumi.Resource) error 
 	}
 
 	// set iptable rules for allowing ports to access NFS server
-	_, err = allowNFSPortsForBridge(vm.instance.e.Ctx, network.Bridge, vm.instance.runner, vm.instance.instanceNamer)
+	_, err = allowNFSPortsForBridge(vm.instance.e.Ctx, vm.instance.Arch == LocalVMSet, network.Bridge, vm.instance.runner, vm.instance.instanceNamer)
 	if err != nil {
 		return err
 	}

--- a/scenarios/aws/microVMs/microvms/network.go
+++ b/scenarios/aws/microVMs/microvms/network.go
@@ -73,9 +73,14 @@ func getMicroVMGroupSubnet() (string, error) {
 	return "", fmt.Errorf("getMicroVMGroupSubnet: could not find subnet")
 }
 
-func allowNFSPortsForBridge(ctx *pulumi.Context, bridge pulumi.StringOutput, runner *Runner, resourceNamer namer.Namer) ([]pulumi.Resource, error) {
+func allowNFSPortsForBridge(ctx *pulumi.Context, isLocal bool, bridge pulumi.StringOutput, runner *Runner, resourceNamer namer.Namer) ([]pulumi.Resource, error) {
+	var sudoPassword pulumi.StringOutput
 	rootConfig := config.New(ctx, "")
-	sudoPassword := rootConfig.RequireSecret("sudo-password")
+	if isLocal {
+		sudoPassword = rootConfig.RequireSecret("sudo-password-local")
+	} else {
+		sudoPassword = rootConfig.RequireSecret("sudo-password-remote")
+	}
 
 	iptablesAllowTCPArgs := command.Args{
 		Create:                   pulumi.Sprintf(iptablesTCPRule, iptablesAddRuleFlag, bridge, microVMGroupSubnet, tcpRPCInfoPorts),

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -17,8 +17,13 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
+type InstanceEnvironment struct {
+	*commonConfig.CommonEnvironment
+	*aws.Environment
+}
+
 type Instance struct {
-	e             *aws.Environment
+	e             *InstanceEnvironment
 	instance      *awsEc2.Instance
 	Connection    remote.ConnectionOutput
 	Arch          string
@@ -56,50 +61,56 @@ func getSSHKeyPairFiles(m *config.DDMicroVMConfig, arch string) sshKeyPair {
 	return pair
 }
 
-func newEC2Instance(e aws.Environment, name, ami, arch, instanceType, keyPair, userData, tenancy string) (*awsEc2.Instance, error) {
+func newEC2Instance(awsEnv aws.Environment, name, ami, arch, instanceType, keyPair, userData, tenancy string) (*awsEc2.Instance, error) {
 	var err error
+
 	if ami == "" {
-		ami, err = ec2.LatestUbuntuAMI(e, arch)
+		ami, err = ec2.LatestUbuntuAMI(awsEnv, arch)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	instance, err := awsEc2.NewInstance(e.Ctx, e.Namer.ResourceName(name), &awsEc2.InstanceArgs{
+	instance, err := awsEc2.NewInstance(awsEnv.Ctx, awsEnv.Namer.ResourceName(name), &awsEc2.InstanceArgs{
 		Ami:                 pulumi.StringPtr(ami),
-		SubnetId:            pulumi.StringPtr(e.DefaultSubnets()[0]),
+		SubnetId:            pulumi.StringPtr(awsEnv.DefaultSubnets()[0]),
 		InstanceType:        pulumi.StringPtr(instanceType),
-		VpcSecurityGroupIds: pulumi.ToStringArray(e.DefaultSecurityGroups()),
+		VpcSecurityGroupIds: pulumi.ToStringArray(awsEnv.DefaultSecurityGroups()),
 		KeyName:             pulumi.StringPtr(keyPair),
 		UserData:            pulumi.StringPtr(userData),
 		Tenancy:             pulumi.StringPtr(tenancy),
 		RootBlockDevice: awsEc2.InstanceRootBlockDeviceArgs{
-			VolumeSize: pulumi.Int(e.DefaultInstanceStorageSize()),
+			VolumeSize: pulumi.Int(awsEnv.DefaultInstanceStorageSize()),
 		},
 		Tags: pulumi.StringMap{
-			"Name": e.Namer.DisplayName(pulumi.String(name)),
+			"Name": awsEnv.Namer.DisplayName(pulumi.String(name)),
 		},
-		InstanceInitiatedShutdownBehavior: pulumi.String(e.DefaultShutdownBehavior()),
-	}, e.WithProviders(commonConfig.ProviderAWS))
+		InstanceInitiatedShutdownBehavior: pulumi.String(awsEnv.DefaultShutdownBehavior()),
+	}, awsEnv.WithProviders(commonConfig.ProviderAWS))
 	return instance, err
 }
 
-func newMetalInstance(e aws.Environment, name, arch string, m config.DDMicroVMConfig) (*Instance, error) {
+func newMetalInstance(e commonConfig.CommonEnvironment, name, arch string, m config.DDMicroVMConfig) (*Instance, error) {
 	var instanceType string
 	var ami string
 
-	namer := namer.NewNamer(e.Ctx, fmt.Sprintf("%s-%s", e.Ctx.Stack(), arch))
+	awsEnv, err := aws.NewEnvironment(e.Ctx, aws.WithCommonEnvironment(&e))
+	if err != nil {
+		return nil, err
+	}
+
+	namer := namer.NewNamer(awsEnv.Ctx, fmt.Sprintf("%s-%s", awsEnv.Ctx.Stack(), arch))
 	if arch == ec2.AMD64Arch {
-		instanceType = e.DefaultInstanceType()
+		instanceType = awsEnv.DefaultInstanceType()
 		ami = m.GetStringWithDefault(m.MicroVMConfig, config.DDMicroVMX86AmiID, "")
 	} else if arch == ec2.ARM64Arch {
-		instanceType = e.DefaultARMInstanceType()
+		instanceType = awsEnv.DefaultARMInstanceType()
 		ami = m.GetStringWithDefault(m.MicroVMConfig, config.DDMicroVMArm64AmiID, "")
 	} else {
 		return nil, fmt.Errorf("unsupported arch: %s", arch)
 	}
 
-	awsInstance, err := newEC2Instance(e, name, ami, arch, instanceType, e.DefaultKeyPairName(), "", "default")
+	awsInstance, err := newEC2Instance(awsEnv, name, ami, arch, instanceType, awsEnv.DefaultKeyPairName(), "", "default")
 	if err != nil {
 		return nil, err
 	}
@@ -107,12 +118,12 @@ func newMetalInstance(e aws.Environment, name, arch string, m config.DDMicroVMCo
 	conn := remote.ConnectionArgs{
 		Host: awsInstance.PrivateIp,
 	}
-	if err := utils.ConfigureRemoteSSH("ubuntu", e.DefaultPrivateKeyPath(), e.DefaultPrivateKeyPassword(), "", &conn); err != nil {
+	if err := utils.ConfigureRemoteSSH("ubuntu", awsEnv.DefaultPrivateKeyPath(), awsEnv.DefaultPrivateKeyPassword(), "", &conn); err != nil {
 		return nil, err
 	}
 
 	return &Instance{
-		e:             &e,
+		e:             &InstanceEnvironment{awsEnv.CommonEnvironment, &awsEnv},
 		instance:      awsInstance,
 		Connection:    conn.ToConnectionOutput(),
 		Arch:          arch,
@@ -120,7 +131,7 @@ func newMetalInstance(e aws.Environment, name, arch string, m config.DDMicroVMCo
 	}, nil
 }
 
-func newInstance(e aws.Environment, arch string, m config.DDMicroVMConfig) (*Instance, error) {
+func newInstance(e commonConfig.CommonEnvironment, arch string, m config.DDMicroVMConfig) (*Instance, error) {
 	name := e.Ctx.Stack() + "-" + arch
 	if arch != LocalVMSet {
 		return newMetalInstance(e, name, arch, m)
@@ -128,7 +139,7 @@ func newInstance(e aws.Environment, arch string, m config.DDMicroVMConfig) (*Ins
 
 	namer := namer.NewNamer(e.Ctx, fmt.Sprintf("%s-%s", e.Ctx.Stack(), arch))
 	return &Instance{
-		e:             &e,
+		e:             &InstanceEnvironment{&e, nil},
 		Arch:          arch,
 		instanceNamer: namer,
 	}, nil
@@ -240,7 +251,7 @@ func configureInstance(instance *Instance, m *config.DDMicroVMConfig) ([]pulumi.
 	return waitFor, err
 }
 
-func run(e aws.Environment) (*ScenarioDone, error) {
+func run(e commonConfig.CommonEnvironment) (*ScenarioDone, error) {
 	var waitFor []pulumi.Resource
 	var scenarioReady ScenarioDone
 
@@ -301,16 +312,16 @@ func run(e aws.Environment) (*ScenarioDone, error) {
 	return &scenarioReady, nil
 }
 
-func RunAndReturnInstances(e aws.Environment) (*ScenarioDone, error) {
+func RunAndReturnInstances(e commonConfig.CommonEnvironment) (*ScenarioDone, error) {
 	return run(e)
 }
 
 func Run(ctx *pulumi.Context) error {
-	e, err := aws.NewEnvironment(ctx)
+	commonEnv, err := commonConfig.NewCommonEnvironment(ctx)
 	if err != nil {
 		return err
 	}
 
-	_, err = run(e)
+	_, err = run(commonEnv)
 	return err
 }


### PR DESCRIPTION
What does this PR do?
---------------------
This PR uses `commonConfig`  if we are not setting up aws instances.

Which scenarios this will impact?
-------------------
The microVM scenario is used to launch local VMs. We want to avoid forcing the user to perform MFA in this case.

Motivation
----------

Additional Notes
----------------
