### PR TITLE
Add ami_id as input option of create_vm

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -24,6 +24,8 @@ const (
 	DDInfraEnvironment       = "env"
 	DDInfraKubernetesVersion = "kubernetesVersion"
 	DDInfraOSFamily          = "osFamily"
+	DDInfraOSArchitecture    = "osArchitecture"
+	DDInfraOSAmiID           = "osAmiId"
 
 	// Agent Namespace
 	DDAgentDeployParamName               = "deploy"
@@ -75,6 +77,14 @@ func (e *CommonEnvironment) InfraEnvironmentNames() []string {
 
 func (e *CommonEnvironment) InfraOSFamily() string {
 	return e.GetStringWithDefault(e.InfraConfig, DDInfraOSFamily, "")
+}
+
+func (e *CommonEnvironment) InfraOSArchitecture() string {
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraOSArchitecture, "")
+}
+
+func (e *CommonEnvironment) InfraOSAmiID() string {
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraOSAmiID, "")
 }
 
 func (e *CommonEnvironment) KubernetesVersion() string {

--- a/scenarios/aws/vm/run.go
+++ b/scenarios/aws/vm/run.go
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	"github.com/DataDog/test-infra-definitions/components/os"
 	resourcesAws "github.com/DataDog/test-infra-definitions/resources/aws"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/vm/ec2os"
@@ -26,7 +27,13 @@ func Run(ctx *pulumi.Context) error {
 	if err != nil {
 		return err
 	}
-	vm, err := ec2vm.NewEC2VMWithEnv(env, ec2params.WithOS(osType))
+	amiID := env.InfraOSAmiID()
+	var vm *ec2vm.EC2VM
+	if amiID != "" {
+		vm, err = ec2vm.NewEC2VMWithEnv(env, ec2params.WithImageName(amiID, os.Architecture(env.InfraOSArchitecture()), osType))
+	} else {
+		vm, err = ec2vm.NewEC2VMWithEnv(env, ec2params.WithOS(osType))
+	}
 	if err != nil {
 		return err
 	}

--- a/tasks/doc.py
+++ b/tasks/doc.py
@@ -3,7 +3,9 @@ from . import tool
 install_agent: str = f"Install the Agent (default {tool.get_default_agent_install()})."
 pipeline_id: str = "The pipeline id of the custom Agent build for example '16497585' (may be taken form the gitlab url)'"
 agent_version: str = "The version of the Agent for example '7.42.0~rc.1-1' or '6.39.0 (default `latest`)'"
-container_agent_version: str = "The container version of the Agent for example '7.45.0-rc.3' (default `latest`)'"
+container_agent_version: str = (
+    "The container version of the Agent for example '7.45.0-rc.3' (default `latest`)'"
+)
 stack_name: str = "An optional name for the stack. This parameter is useful when you need to create several environments. Note: 'invoke destroy' may not work properly"
 debug: str = "Launch pulumi with debug mode. Default False"
 stack_name: str = "An optional name for the stack. This parameter is useful when you need to create several environments."
@@ -14,3 +16,4 @@ bottlerocket_node_group: str = "Install a bottlerocket node group (default False
 windows_node_group: str = "Install a Windows node group (default False)"
 use_fargate: str = "Use Fargate (default True)"
 fakeintake: str = "Use a dedicated fake Datadog intake (default True)"
+ami_id: str = "A full Amazon Machine Image (AMI) id (e.g. ami-0123456789abcdef0)"

--- a/tasks/tool.py
+++ b/tasks/tool.py
@@ -2,14 +2,20 @@ import getpass
 import json
 import platform
 import subprocess
+from io import StringIO
 from termcolor import colored
 from typing import Any, List, Optional
+from invoke.context import Context
+from invoke.exceptions import Exit
+
 
 def ask(question: str) -> str:
     return input(colored(question, "blue"))
 
+
 def debug(msg: str):
     print(colored(msg, "white"))
+
 
 def info(msg: str):
     print(colored(msg, "green"))
@@ -53,7 +59,7 @@ def get_stack_name(stack_name: Optional[str], scenario_name: str) -> str:
 
 def get_stack_name_prefix() -> str:
     user_name = f"{getpass.getuser()}-"
-    return user_name.replace(".", "-") # EKS doesn't support '.'
+    return user_name.replace(".", "-")  # EKS doesn't support '.'
 
 
 def get_stack_json_outputs(full_stack_name: str) -> Any:
@@ -65,7 +71,20 @@ def get_stack_json_outputs(full_stack_name: str) -> Any:
 
 
 def is_windows():
-    return platform.system() == 'Windows'
+    return platform.system() == "Windows"
+
+
+def get_image_description(ctx: Context, ami_id: str) -> Any:
+    buffer = StringIO()
+    ctx.run(
+        f"aws-vault exec sso-agent-sandbox-account-admin -- aws ec2 describe-images --image-ids {ami_id}",
+        out_stream=buffer,
+    )
+    result = json.loads(buffer.getvalue())
+    if len(result["Images"]) > 1:
+        raise Exit(f"The AMI id {ami_id} returns more than one definition.")
+    else:
+        return result["Images"][0]
 
 
 class Connection:

--- a/tasks/vm.py
+++ b/tasks/vm.py
@@ -3,7 +3,7 @@ from invoke.tasks import task
 from .destroy import destroy
 from .deploy import deploy
 from . import doc
-from typing import Optional
+from typing import Optional, Tuple
 from invoke.context import Context
 from invoke.exceptions import Exit
 from . import tool
@@ -20,7 +20,8 @@ scenario_name = "aws/vm"
         "stack_name": doc.stack_name,
         "debug": doc.debug,
         "os_family": doc.os_family,
-        "use_fakeintake": doc.fakeintake, 
+        "use_fakeintake": doc.fakeintake,
+        "ami_id": doc.ami_id,
     }
 )
 def create_vm(
@@ -32,14 +33,18 @@ def create_vm(
     debug: Optional[bool] = False,
     os_family: Optional[str] = None,
     use_fakeintake: Optional[bool] = True,
+    ami_id: Optional[str] = None,
 ) -> None:
     """
     Create a new virtual machine on the cloud.
     """
 
     extra_flags = {}
-    os_family = _get_os_family(os_family)
+    os_family, os_arch = _get_os_information(ctx, os_family, ami_id)
     extra_flags["ddinfra:osFamily"] = os_family
+    if ami_id is not None:
+        extra_flags["ddinfra:osArchitecture"] = os_arch
+        extra_flags["ddinfra:osAmiId"] = ami_id
 
     full_stack_name = deploy(
         ctx,
@@ -91,3 +96,29 @@ def _get_os_family(os_family: Optional[str]) -> str:
             f"The os family '{os_family}' is not supported. Possibles values are {', '.join(os_families)}"
         )
     return os_family
+
+
+def _get_os_information(
+    ctx: Context,
+    os_family: Optional[str],
+    ami_id: Optional[str]
+) -> Tuple[str, Optional[str]]:
+    family, architecture = os_family, None
+    if ami_id is not None:
+        image = tool.get_image_description(ctx, ami_id)
+        if family is None:  # Try to guess the distribution
+            os_families = tool.get_os_families()
+            try:
+                family = next(
+                    os
+                    for os in os_families
+                    if os in image["Description"].lower().replace(" ", "")
+                )
+            except StopIteration:
+                raise Exit(
+                    f"We failed to guess the family of your AMI ID. Please provide it with option -o"
+                )
+        architecture = image["Architecture"]
+    else:
+        family = _get_os_family(os_family)
+    return (family, architecture)


### PR DESCRIPTION
What does this PR do?
---------------------
Add a new option in invoke task to pass an AMI id as input
Replaces #151 

Which scenarios this will impact?
-------------------
Creation of AWS VM

Motivation
----------
Possibility to run on older distribution than the ones we get by default today, and reach even more distributions (rockylinux for instance)

Additional Notes
----------------
Uses AMI ID today even is this should be generalized to other cloud providers
