### PR TITLE
Truncate the EKS node group name prefix if longer than 37 characters

### DIFF
--- a/resources/aws/eks/nodeGroups.go
+++ b/resources/aws/eks/nodeGroups.go
@@ -45,7 +45,13 @@ func nodeGroupNamePrefix(stack, name string) string {
 		return prefix
 	}
 
-	return stack[:len(stack)-nbExceeding/2] + "-" + name[:len(name)-nbExceeding/2-nbExceeding%2] + "-ng"
+	newStackLen := len(stack) - nbExceeding*len(stack)/(len(stack)+len(name))
+	newNameLen := len(name) - nbExceeding*len(name)/(len(stack)+len(name))
+	if newStackLen+newNameLen+4 == 38 { // because of integer rounding
+		newNameLen--
+	}
+
+	return stack[:newStackLen] + "-" + name[:newNameLen] + "-ng"
 }
 
 func newManagedNodeGroup(e aws.Environment, name string, cluster *eks.Cluster, nodeRole *awsIam.Role, amiType, instanceType string) (*eks.ManagedNodeGroup, error) {

--- a/resources/aws/eks/nodeGroups_test.go
+++ b/resources/aws/eks/nodeGroups_test.go
@@ -1,0 +1,63 @@
+package eks
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNodeGroupNamePrefix(t *testing.T) {
+	for i, tt := range []struct {
+		stack    string
+		name     string
+		expected string
+	}{
+		{
+			stack:    "short",
+			name:     "short",
+			expected: "short-short-ng",
+		},
+		{
+			stack:    "ci-17317712-4670-eks-cluster",
+			name:     "linux",
+			expected: "ci-17317712-4670-eks-cluster-linux-ng",
+		},
+		{
+			stack:    "ci-17317712-4670-eks-cluster",
+			name:     "linux-arm",
+			expected: "ci-17317712-4670-eks-clus-linux-ar-ng",
+		},
+		{
+			stack:    "ci-17317712-4670-eks-cluster",
+			name:     "bottlerocket",
+			expected: "ci-17317712-4670-eks-clu-bottleroc-ng",
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			prefix := nodeGroupNamePrefix(tt.stack, tt.name)
+			assert.Equal(t, tt.expected, prefix)
+			assert.LessOrEqual(t, len(prefix), 37)
+		})
+	}
+}
+
+func FuzzNodeGroupNamePrefix(f *testing.F) {
+	f.Add("short", "short")
+	f.Add("ci-17317712-4670-eks-cluster", "linux")
+	f.Add("ci-17317712-4670-eks-cluster", "linux-arm")
+	f.Add("ci-17317712-4670-eks-cluster", "bottlerocket")
+	f.Add("crazy-long-stack-name-crazy-long-stack-name", "x")
+	f.Add("x", "crazy-long-node-group-name-crazy-long-node-group-name")
+
+	f.Fuzz(func(t *testing.T, stack, name string) {
+		untruncatedPrefix := stack + "-" + name + "-ng"
+		prefix := nodeGroupNamePrefix(stack, name)
+		assert.Conditionf(t, func() bool {
+			if len(untruncatedPrefix) <= 37 {
+				return prefix == untruncatedPrefix
+			}
+			return len(prefix) == 37
+		}, "nodeGroupNamePrefix(%q, %q) => %q (len=%d)", stack, name, prefix, len(prefix))
+	})
+}


### PR DESCRIPTION
What does this PR do?
---------------------

Truncate the EKS node group name prefix if was supposed to be longer than 37 characters.

Which scenarios this will impact?
-------------------

* `aws/eks`

Motivation
----------

The [`datadog-agent` is currently failing](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/289311691) with the following error:
```
aws:eks:NodeGroup aws-bottlerocket-ng  error: aws:eks/nodeGroup:NodeGroup resource 'aws-bottlerocket-ng' has a problem: expected length of node_group_name_prefix to be in the range (0 - 37), got ci-17317712-4670-eks-cluster-bottlerocket-ng. Examine values at 'NodeGroup.NodeGroupNamePrefix'.
```

Additional Notes
----------------

In the case of the CI, with this change, the node group name prefixes will become:
```
ci-17317712-4670-eks-cluster-linux-ng
ci-17317712-4670-eks-clust-linux-a-ng
ci-17317712-4670-eks-clus-bottlero-ng
```
See https://go.dev/play/p/7WiUMh_MQwd