### PR TITLE
Optimize libvirt filesystem setup.

### DIFF
--- a/scenarios/aws/microVMs/microvms/domain.go
+++ b/scenarios/aws/microVMs/microvms/domain.go
@@ -158,7 +158,7 @@ func GenerateDomainConfigurationsForVMSet(e *config.CommonEnvironment, provider 
 					provider,
 					depends,
 					fs.baseVolumeMap[kernel.Tag].volumeKey,
-					fs.poolName,
+					fs.pool.poolName,
 					domain.domainNamer.ResourceName("volume"),
 				)
 				if err != nil {

--- a/scenarios/aws/microVMs/microvms/libvirt.go
+++ b/scenarios/aws/microVMs/microvms/libvirt.go
@@ -83,11 +83,13 @@ type VMCollection struct {
 func (vm *VMCollection) SetupCollectionFilesystems(depends []pulumi.Resource) ([]pulumi.Resource, error) {
 	var waitFor []pulumi.Resource
 
-	libvirtPoolReady, err := setupRemoteLibvirtPool(vm.pool, vm.instance.runner, depends)
-	if err != nil {
-		return []pulumi.Resource{}, err
+	if vm.instance.Arch != LocalVMSet {
+		libvirtPoolReady, err := setupRemoteLibvirtPool(vm.pool, vm.instance.runner, depends)
+		if err != nil {
+			return []pulumi.Resource{}, err
+		}
+		depends = append(depends, libvirtPoolReady...)
 	}
-	depends = append(depends, libvirtPoolReady...)
 
 	for _, set := range vm.vmsets {
 		fs, err := newLibvirtFS(vm.instance.e.Ctx, &set, vm.pool)

--- a/scenarios/aws/microVMs/microvms/libvirt.go
+++ b/scenarios/aws/microVMs/microvms/libvirt.go
@@ -104,12 +104,12 @@ func (vm *VMCollection) SetupCollectionFilesystems(depends []pulumi.Resource) ([
 	for _, fs := range vm.fs {
 		imagesToKeep := []*filesystemImage{}
 		for _, fsImage := range fs.images {
-			if present, _ := seen[fsImage.imageSource]; present {
+			if present, _ := seen[fsImage.imagePath]; present {
 				continue
 			}
 			imagesToKeep = append(imagesToKeep, fsImage)
 
-			seen[fsImage.imageSource] = true
+			seen[fsImage.imagePath] = true
 		}
 		fs.images = imagesToKeep
 	}

--- a/scenarios/aws/microVMs/microvms/libvirt.go
+++ b/scenarios/aws/microVMs/microvms/libvirt.go
@@ -111,6 +111,7 @@ func (vm *VMCollection) SetupCollectionFilesystems(depends []pulumi.Resource) ([
 
 			seen[fsImage.imageSource] = true
 		}
+		fmt.Printf("pruned: %d\n", len(fs.images)-len(imagesToKeep))
 		fs.images = imagesToKeep
 	}
 

--- a/scenarios/aws/microVMs/microvms/libvirt.go
+++ b/scenarios/aws/microVMs/microvms/libvirt.go
@@ -111,7 +111,6 @@ func (vm *VMCollection) SetupCollectionFilesystems(depends []pulumi.Resource) ([
 
 			seen[fsImage.imageSource] = true
 		}
-		fmt.Printf("pruned: %d\n", len(fs.images)-len(imagesToKeep))
 		fs.images = imagesToKeep
 	}
 

--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -300,11 +300,10 @@ func setupLibvirtVMVolume(fs *LibvirtFilesystem, runner *Runner, depends []pulum
 	return waitFor, nil
 }
 
-func (fs *LibvirtFilesystem) SetupLibvirtFilesystem(provider *libvirt.Provider, runner *Runner, arch string, depends []pulumi.Resource) ([]pulumi.Resource, error) {
-	switch arch {
-	case LocalVMSet:
+func (fs *LibvirtFilesystem) SetupLibvirtFilesystem(provider *libvirt.Provider, runner *Runner, depends []pulumi.Resource) ([]pulumi.Resource, error) {
+	if fs.isLocal {
 		return setupLocalLibvirtFilesystem(fs, provider, depends)
-	default:
+	} else {
 		return setupRemoteLibvirtFilesystem(fs, runner, depends)
 	}
 }

--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -315,9 +315,9 @@ func setupLibvirtVMVolume(fs *LibvirtFilesystem, runner *Runner, depends []pulum
 func (fs *LibvirtFilesystem) SetupLibvirtFilesystem(provider *libvirt.Provider, runner *Runner, depends []pulumi.Resource) ([]pulumi.Resource, error) {
 	if fs.isLocal {
 		return setupLocalLibvirtFilesystem(fs, provider, depends)
-	} else {
-		return setupRemoteLibvirtFilesystem(fs, runner, depends)
 	}
+
+	return setupRemoteLibvirtFilesystem(fs, runner, depends)
 }
 
 func setupRemoteLibvirtPool(pool *LibvirtPool, runner *Runner, depends []pulumi.Resource) ([]pulumi.Resource, error) {
@@ -338,7 +338,7 @@ func setupRemoteLibvirtPool(pool *LibvirtPool, runner *Runner, depends []pulumi.
 	return setupLibvirtVMPoolDone, err
 }
 
-// poolDone Resoures are passed seperately to optimize the order in which the filesystem setup is done.
+// poolDone Resoures are passed separately to optimize the order in which the filesystem setup is done.
 // This is the slowest part of the process, and the downloading of the images should begin as early as possible.
 // Therefore, we do not slow it down by waiting for the pool to become ready first.
 func setupRemoteLibvirtFilesystem(fs *LibvirtFilesystem, runner *Runner, depends []pulumi.Resource) ([]pulumi.Resource, error) {

--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -391,7 +391,7 @@ func setupLocalLibvirtFilesystem(fs *LibvirtFilesystem, provider *libvirt.Provid
 			Xml: libvirt.VolumeXmlArgs{
 				Xslt: fsImage.volumeXML,
 			},
-		}, pulumi.Provider(provider), pulumi.DependsOn(waitFor))
+		}, pulumi.Provider(provider), pulumi.DependsOn([]pulumi.Resource{poolReady}))
 		if err != nil {
 			return []pulumi.Resource{}, err
 		}

--- a/scenarios/aws/microVMs/microvms/resources/default.go
+++ b/scenarios/aws/microVMs/microvms/resources/default.go
@@ -53,7 +53,7 @@ func NewDefaultResourceCollection(recipe string) *DefaultResourceCollection {
 	}
 }
 
-func (a *DefaultResourceCollection) GetDomainXLS(args map[string]pulumi.StringInput) pulumi.StringOutput {
+func (a *DefaultResourceCollection) GetDomainXLS(_ map[string]pulumi.StringInput) pulumi.StringOutput {
 	return pulumi.Sprintf("%s", GetDefaultDomainXLS())
 }
 
@@ -65,6 +65,6 @@ func (a *DefaultResourceCollection) GetPoolXML(args map[string]pulumi.StringInpu
 	return GetDefaultPoolXML(args, a.recipe)
 }
 
-func (a *DefaultResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomainArgs) *libvirt.DomainArgs {
+func (a *DefaultResourceCollection) GetLibvirtDomainArgs(_ *RecipeLibvirtDomainArgs) *libvirt.DomainArgs {
 	return nil
 }

--- a/scenarios/aws/microVMs/microvms/resources/default.go
+++ b/scenarios/aws/microVMs/microvms/resources/default.go
@@ -4,6 +4,7 @@ import (
 	// import embed
 	_ "embed"
 
+	"github.com/pulumi/pulumi-libvirt/sdk/go/libvirt"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -40,4 +41,30 @@ func GetDefaultVolumeXML(args map[string]pulumi.StringInput, recipe string) pulu
 
 func GetDefaultPoolXML(args map[string]pulumi.StringInput, _ string) pulumi.StringOutput {
 	return formatResourceXML(defaultPoolXML, args)
+}
+
+type DefaultResourceCollection struct {
+	recipe string
+}
+
+func NewDefaultResourceCollection(recipe string) *DefaultResourceCollection {
+	return &DefaultResourceCollection{
+		recipe: recipe,
+	}
+}
+
+func (a *DefaultResourceCollection) GetDomainXLS(args map[string]pulumi.StringInput) pulumi.StringOutput {
+	return pulumi.Sprintf("%s", GetDefaultDomainXLS())
+}
+
+func (a *DefaultResourceCollection) GetVolumeXML(args map[string]pulumi.StringInput) pulumi.StringOutput {
+	return GetDefaultVolumeXML(args, a.recipe)
+}
+
+func (a *DefaultResourceCollection) GetPoolXML(args map[string]pulumi.StringInput) pulumi.StringOutput {
+	return GetDefaultPoolXML(args, a.recipe)
+}
+
+func (a *DefaultResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomainArgs) *libvirt.DomainArgs {
+	return nil
 }

--- a/scenarios/aws/microVMs/microvms/resources/default/volume.xml
+++ b/scenarios/aws/microVMs/microvms/resources/default/volume.xml
@@ -1,11 +1,7 @@
 <volume type='file'>
     <name>{imageName}</name>
     <key>{volumeKey}</key>
-  <capacity unit='bytes'>10737418240</capacity>
-  <allocation unit='bytes'>10000007168</allocation>
-  <physical unit='bytes'>10000000000</physical>
   <target>
-      <path>{volumePath}</path>
     <format type='qcow2'/>
     <permissions>
       <mode>0660</mode>
@@ -16,5 +12,9 @@
     <clusterSize unit='B'>65536</clusterSize>
     <features/>
   </target>
+  <backingStore>
+      <path>{imagePath}</path>
+    <format type='qcow2'/>
+  </backingStore>
 </volume>
 

--- a/scenarios/aws/microVMs/microvms/resources/resources.go
+++ b/scenarios/aws/microVMs/microvms/resources/resources.go
@@ -114,6 +114,8 @@ func NewResourceCollection(recipe string) ResourceCollection {
 		return NewDistroARM64ResourceCollection(recipe)
 	case vmconfig.RecipeDistroAMD64:
 		return NewDistroAMD64ResourceCollection(recipe)
+	case vmconfig.RecipeDefault:
+		return NewDefaultResourceCollection(recipe)
 	default:
 		panic("unknown recipe: " + archSpecificRecipe)
 	}

--- a/scenarios/aws/microVMs/microvms/resources/resources.go
+++ b/scenarios/aws/microVMs/microvms/resources/resources.go
@@ -17,7 +17,7 @@ const (
 	DHCPEntries   = "dhcpEntries"
 	ImageName     = "imageName"
 	VolumeKey     = "volumeKey"
-	VolumePath    = "volumePath"
+	ImagePath     = "imagePath"
 	PoolName      = "poolName"
 	PoolPath      = "poolPath"
 	Nvram         = "nvram"

--- a/scenarios/aws/microVMs/vmconfig/config.go
+++ b/scenarios/aws/microVMs/vmconfig/config.go
@@ -9,6 +9,7 @@ const (
 	RecipeDistroARM64 = "distro-arm64"
 	RecipeCustomLocal = "custom-local"
 	RecipeDistroLocal = "distro-local"
+	RecipeDefault     = "default"
 )
 
 type Kernel struct {


### PR DESCRIPTION
What does this PR do?
---------------------
This PR performs various optimizations to improve the setup time of the libvirt pools and volumes. These optimizations are done to improve the performance of the setup environment job as the number of VMs in `vmsets` increase.

The PR performs 3 main optimizations.
1. Download `qcow2` images from S3, rather than using the images already 'present' in the AMI.
2. Deduplicate the base images used to build the volumes, so that download and setup steps are not repeated when the same base volume is used to setup a VM.
3. When creating volumes specify the base image as a backing store, to avoid the expensive step of uploading the base image into the libvirt volume.

## Terminology
- Base image: The bootable `qcow2` image used to build the libvirt volumes.
- Libvirt base volume: The copy-on-write libvirt volume created from the base image. This volume is used as a shared backing store.
- Libvirt volume: The copy-on-write libvirt volume created from the base volume. This is the actual storage medium used by the VMs.

## 1. Download `qcow2` images.
When booting from an AMI, all relevant data is not immediately available on the instance. Instead the instance lazily fetches data from the backing store, as it is accessed in the disk. The idea here is to ammortize the cost of fetching all the data across the lifespan of the instance, rather than spending it all on boot time.

This model does not work for our use case because the bulk of the data (specifically the `qcow2` images) is required by our system immediately on boot. To solve this issue we were using the `fio` utility to perform concurrent reads on the `qcow2` images to begin prefetching them.
Unfortunately, this approach did not scale well with the number of unique VMs (specifically when the underlying base image is different). We do not know the mechanism by which the instance disk is refreshed so it is hard to optimize this refresh step.    
Instead this PR decides to use a concurrent downloading utility, [aria2c](https://aria2.github.io/), to download the images from S3 directly. This method is equivalent to the prefetching approach since for instances created from snapshots, the storage blocks must be pulled from S3 [[1]](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-initialize.html).

This also scaled better with the number of unique VMs because we can use the high bandwidth of our metal instances to download data in parallel.

## 2. Deduplicate base images
The goal of this optimization is to provide support for the use case of launching duplicated `vmsets`, for example when we want to parallelize tests.

This optimization basically uses a global libvirt pool rather than a per-`vmset` pool. We also take care to download `qcow2` images once. The base volumes are also only created once for each `qcow2` image. Since we have a global pool these base volumes can be shared with the volumes of VMs across `vmsets`. This significantly reduces the number of steps required to setup our environment.

## 3 Skip uploading `qcow2` to base volumes.
Uploading `qcow2` images to base volumes was one of the major bottlenecks of our approach. This PR optimizes away this step by using a libvirt facility of specifying copy-on-write backing storage for volumes. This allows us to cheaply create volumes from large underlying images. 

## Results
These optimizations together reduced the setup time by more than 50%. 
Tests were conducted on launching duplicate `vmsets` with each set containing 21 VMs. Prior to this PR the setup took 60+ minutes. Now it takes ~30 minutes.  The bottleneck is now the downloading step.   

## Future Work
There are plans to improve the download time by creating different sets of images for the CI and dev environments. Currently the images are bloated with things not strictly necessary for running the tests in the CI. The average size of a single `qcow2` image is 8-10 GB. The CI images should be much leaner to allow faster downloads and thus reduce the setup time.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
