### PR TITLE
Add team tag support in config file and config map

### DIFF
--- a/tasks/config.py
+++ b/tasks/config.py
@@ -14,6 +14,7 @@ class Config(BaseModel, extra=Extra.forbid):
             keyPairName: Optional[str]
             publicKeyPath: Optional[str]
             account: Optional[str]
+            teamTag: Optional[str]
 
             def get_account(self) -> str:
                 if self.account is None:
@@ -44,7 +45,7 @@ class Config(BaseModel, extra=Extra.forbid):
 
     def get_aws(self) -> Params.Aws:
         default = Config.Params.Aws(
-            keyPairName=None, publicKeyPath=None, account=None
+            keyPairName=None, publicKeyPath=None, account=None, teamTag=None
         )
         if self.configParams is None:
             return default

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -50,6 +50,10 @@ def deploy(
     aws_account = cfg.get_aws().get_account()
     flags["ddinfra:env"] = "aws/" + aws_account
 
+    if cfg.get_aws().teamTag is None:
+        raise Exit("Error in config, missing configParams.aws.teamTag. Run `inv setup` again and provide a valid team name")
+    flags["ddinfra:resourcesTags"] = f"TEAM={cfg.get_aws().teamTag}"
+
     if install_agent:
         flags["ddagent:apiKey"] = _get_api_key(cfg)
 

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -31,30 +31,44 @@ def setup(_: Context) -> None:
     except Exception:
         config = Config.parse_obj({})
         
+    
+    # AWS config
+    setupAWSConfig(config)
+    # Agent config
+    setupAgentConfig(config)
 
+    config.save_to_local_config()
+    cat_profile_command = f"cat {get_full_profile_path()}"
+    pyperclip.copy(cat_profile_command)
+    print(
+        f"\nYou can run the following command to print your configuration: `{cat_profile_command}`. This command was copied to the clipboard\n"
+    )
+
+def setupAWSConfig(config: Config):
     if config.configParams is None:
         config.configParams = Config.Params(
             aws=None,
             agent=None
         )
-    
-    # AWS config
     if config.configParams.aws is None:
         config.configParams.aws = Config.Params.Aws(
             keyPairName=None,
             publicKeyPath= None,
-            account=None
+            account=None,
+            teamTag=None
         )
 
-    
     if config.configParams.aws.account is None: 
         config.configParams.aws.account = "agent-sandbox"
+    default_aws_account = config.configParams.aws.account
     while True:
+        config.configParams.aws.account = default_aws_account
         aws_account = ask(f"Which aws account do you want to create instances on? Default [{config.configParams.aws.account}], available [agent-sandbox|sandbox]: ")
-        if aws_account in available_aws_accounts:
+        if len(aws_account) > 0:
             config.configParams.aws.account = aws_account
+        if config.configParams.aws.account in available_aws_accounts:
             break
-        warn(f"{aws_account} is not a valid aws account")
+        warn(f"{config.configParams.aws.account} is not a valid aws account")
         
         
     if config.configParams.aws.keyPairName is None: 
@@ -67,8 +81,8 @@ def setup(_: Context) -> None:
         config.options = Config.Options(
             checkKeyPair=False
         )
-    default = "Y" if config.options.checkKeyPair else "N"
-    checkKeyPair = ask(f"Did you create your SSH key on AWS and want me to check it is loaded on your ssh agent when creating manual environments or running e2e tests [Y/N]? Default [{default}]: ")
+    default_check_key_pair = "Y" if config.options.checkKeyPair else "N"
+    checkKeyPair = ask(f"Did you create your SSH key on AWS and want me to check it is loaded on your ssh agent when creating manual environments or running e2e tests [Y/N]? Default [{default_check_key_pair}]: ")
     if len(checkKeyPair) > 0:
         config.options.checkKeyPair = checkKeyPair.lower() == "y" or checkKeyPair.lower() == "yes"
 
@@ -84,7 +98,22 @@ def setup(_: Context) -> None:
             break
         warn(f"{config.configParams.aws.publicKeyPath} is not a valid ssh key")
     
-    # Agent config
+    checkKeyPair = ask(f"Did you create your SSH key on AWS and want me to check it is loaded on your ssh agent when creating manual environments or running e2e tests [Y/N]? Default [{default_check_key_pair}]: ")
+    if len(checkKeyPair) > 0:
+        config.options.checkKeyPair = checkKeyPair.lower() == "y" or checkKeyPair.lower() == "yes"
+
+    if config.configParams.aws.teamTag is None:
+        config.configParams.aws.teamTag = ""
+    while True:
+        teamTag = ask(f"🔖 What is your team? It will tag all your resources by `TEAM:<team>`. Default [{config.configParams.aws.teamTag}]: ")
+        if len(teamTag) > 0:
+            config.configParams.aws.teamTag = teamTag
+        if len(config.configParams.aws.teamTag) > 0:
+            break
+        warn("Provide a non-empty team")
+
+
+def setupAgentConfig(config):
     if config.configParams.agent is None:
         config.configParams.agent = Config.Params.Agent(
             apiKey=None,
@@ -114,15 +143,7 @@ def setup(_: Context) -> None:
             config.configParams.agent.appKey = app_Key
         if len(config.configParams.agent.appKey) == 40:
             break
-        warn(f"Expecting APP key of length 40, got {len(config.configParams.agent.appKey)}")
-
-    config.save_to_local_config()
-    cat_profile_command = f"cat {get_full_profile_path()}"
-    pyperclip.copy(cat_profile_command)
-    print(
-        f"\nYou can run the following command to print your configuration: `{cat_profile_command}`. This command was copied to the clipboard\n"
-    )
-    
+        warn(f"Expecting APP key of length 40, got {len(config.configParams.agent.appKey)}")  
       
 def _get_safe_dd_key(key: str) -> str: 
     if key == '0' * len(key):


### PR DESCRIPTION
What does this PR do?
---------------------

- Add config map tags parameter (could not find any existing yet, can remove if it duplicates another parameter)
- Tag resources with config map tags
- Add team tag in tasks
 
Which scenarios this will impact?
-------------------

All

Motivation
----------

Add team tag to any AWS instance managed by pulumi and created locally

Additional Notes
----------------
