### PR TITLE
Put a load balancer in front of the fake intake

### DIFF
--- a/components/datadog/fakeintake/ecsFargate.go
+++ b/components/datadog/fakeintake/ecsFargate.go
@@ -4,8 +4,10 @@ import (
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 
+	classicECS "github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ecs"
 	"github.com/pulumi/pulumi-awsx/sdk/go/awsx/awsx"
 	"github.com/pulumi/pulumi-awsx/sdk/go/awsx/ecs"
+	"github.com/pulumi/pulumi-awsx/sdk/go/awsx/lb"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -14,41 +16,101 @@ const (
 	port          = 80
 )
 
-const (
-	DefaultFakeintakePort = 80
-)
+type Component struct {
+	pulumi.ResourceState
 
-func FargateLinuxTaskDefinition(e aws.Environment, name string) (*ecs.FargateTaskDefinition, error) {
-	return ecs.NewFargateTaskDefinition(e.Ctx, e.Namer.ResourceName(name), &ecs.FargateTaskDefinitionArgs{
-		Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
-			containerName: *fargateLinuxContainerDefinition(),
-		},
-		Cpu:    pulumi.StringPtr("256"),
-		Memory: pulumi.StringPtr("512"),
-		ExecutionRole: &awsx.DefaultRoleWithPolicyArgs{
-			RoleArn: pulumi.StringPtr(e.ECSTaskExecutionRole()),
-		},
-		TaskRole: &awsx.DefaultRoleWithPolicyArgs{
-			RoleArn: pulumi.StringPtr(e.ECSTaskRole()),
-		},
-		Family: e.CommonNamer.DisplayName(pulumi.String("fakeintake-ecs")),
-	}, e.WithProviders(config.ProviderAWS, config.ProviderAWSX))
+	Host pulumi.StringOutput
 }
 
-func fargateLinuxContainerDefinition() *ecs.TaskDefinitionContainerDefinitionArgs {
-	return &ecs.TaskDefinitionContainerDefinitionArgs{
-		Name:        pulumi.StringPtr(containerName),
-		Image:       pulumi.StringPtr("public.ecr.aws/datadog/fakeintake:latest"),
-		Essential:   pulumi.BoolPtr(true),
-		MountPoints: ecs.TaskDefinitionMountPointArray{},
-		Environment: ecs.TaskDefinitionKeyValuePairArray{},
-		PortMappings: ecs.TaskDefinitionPortMappingArray{
-			ecs.TaskDefinitionPortMappingArgs{
-				ContainerPort: pulumi.Int(port),
-				HostPort:      pulumi.Int(port),
-				Protocol:      pulumi.StringPtr("tcp"),
+func FargateLinuxComponentDefinition(e aws.Environment) (*Component, error) {
+	namer := e.Namer.WithPrefix("fakeintake")
+	opts := []pulumi.ResourceOption{e.WithProviders(config.ProviderAWS, config.ProviderAWSX)}
+
+	component := &Component{}
+	if err := e.Ctx.RegisterComponentResource("dd:fakeintake", namer.ResourceName("grp"), component, opts...); err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, pulumi.Parent(component))
+
+	alb, err := lb.NewApplicationLoadBalancer(e.Ctx, namer.ResourceName("lb"), &lb.ApplicationLoadBalancerArgs{
+		Name:           e.CommonNamer.DisplayName(pulumi.String("fakeintake")),
+		SubnetIds:      pulumi.ToStringArray(e.DefaultSubnets()),
+		Internal:       pulumi.BoolPtr(!e.ECSServicePublicIP()),
+		SecurityGroups: pulumi.ToStringArray(e.DefaultSecurityGroups()),
+		DefaultTargetGroup: &lb.TargetGroupArgs{
+			Name:       e.CommonNamer.DisplayName(pulumi.String("fakeintake")),
+			Port:       pulumi.IntPtr(port),
+			Protocol:   pulumi.StringPtr("HTTP"),
+			TargetType: pulumi.StringPtr("ip"),
+			VpcId:      pulumi.StringPtr(e.DefaultVPCID()),
+		},
+		Listener: &lb.ListenerArgs{
+			Port:     pulumi.IntPtr(port),
+			Protocol: pulumi.StringPtr("HTTP"),
+		},
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	component.Host = alb.LoadBalancer.DnsName()
+
+	if _, err := ecs.NewFargateService(e.Ctx, namer.ResourceName("srv"), &ecs.FargateServiceArgs{
+		Cluster:              pulumi.StringPtr(e.ECSFargateFakeintakeClusterArn()),
+		Name:                 e.CommonNamer.DisplayName(pulumi.String("fakeintake")),
+		DesiredCount:         pulumi.IntPtr(1),
+		EnableExecuteCommand: pulumi.BoolPtr(true),
+		NetworkConfiguration: &classicECS.ServiceNetworkConfigurationArgs{
+			AssignPublicIp: pulumi.BoolPtr(false),
+			SecurityGroups: pulumi.ToStringArray(e.DefaultSecurityGroups()),
+			Subnets:        pulumi.ToStringArray(e.DefaultSubnets()),
+		},
+		LoadBalancers: classicECS.ServiceLoadBalancerArray{
+			&classicECS.ServiceLoadBalancerArgs{
+				ContainerName:  pulumi.String(containerName),
+				ContainerPort:  pulumi.Int(port),
+				TargetGroupArn: alb.DefaultTargetGroup.Arn(),
 			},
 		},
-		VolumesFrom: ecs.TaskDefinitionVolumeFromArray{},
+		TaskDefinitionArgs: &ecs.FargateServiceTaskDefinitionArgs{
+			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
+				containerName: {
+					Name:        pulumi.StringPtr(containerName),
+					Image:       pulumi.StringPtr("public.ecr.aws/datadog/fakeintake:latest"),
+					Essential:   pulumi.BoolPtr(true),
+					MountPoints: ecs.TaskDefinitionMountPointArray{},
+					Environment: ecs.TaskDefinitionKeyValuePairArray{},
+					PortMappings: ecs.TaskDefinitionPortMappingArray{
+						ecs.TaskDefinitionPortMappingArgs{
+							ContainerPort: pulumi.Int(port),
+							HostPort:      pulumi.Int(port),
+							Protocol:      pulumi.StringPtr("tcp"),
+						},
+					},
+					VolumesFrom: ecs.TaskDefinitionVolumeFromArray{},
+				},
+			},
+			Cpu:    pulumi.StringPtr("256"),
+			Memory: pulumi.StringPtr("512"),
+			ExecutionRole: &awsx.DefaultRoleWithPolicyArgs{
+				RoleArn: pulumi.StringPtr(e.ECSTaskExecutionRole()),
+			},
+			TaskRole: &awsx.DefaultRoleWithPolicyArgs{
+				RoleArn: pulumi.StringPtr(e.ECSTaskRole()),
+			},
+			Family: e.CommonNamer.DisplayName(pulumi.String("fakeintake-ecs")),
+		},
+		ContinueBeforeSteadyState: pulumi.BoolPtr(true),
+	}, opts...); err != nil {
+		return nil, err
 	}
+
+	if err := e.Ctx.RegisterResourceOutputs(component, pulumi.Map{
+		"host": alb.LoadBalancer.DnsName(),
+	}); err != nil {
+		return nil, err
+	}
+
+	return component, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.18.27
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.27.4
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/pulumi/pulumi-aws/sdk/v5 v5.41.0
 	github.com/pulumi/pulumi-awsx/sdk v1.0.2
 	github.com/pulumi/pulumi-azure-native-sdk v1.103.0

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,6 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
-github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
-github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cheggaaa/pb v1.0.18/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=

--- a/resources/aws/ecs/fargateService.go
+++ b/resources/aws/ecs/fargateService.go
@@ -1,14 +1,12 @@
 package ecs
 
 import (
-	"fmt"
 	"reflect"
 
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
 	ddfakeintake "github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
-	"github.com/cenkalti/backoff/v4"
 
 	classicECS "github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ecs"
 	"github.com/pulumi/pulumi-awsx/sdk/go/awsx/awsx"
@@ -125,37 +123,4 @@ func getFirelensLogConfiguration(source, service, apiKeyParamName pulumi.StringI
 			},
 		},
 	}
-}
-
-// FargateServiceFakeintake deploys one fakeintake container to a dedicated Fargate cluster
-// Hardcoded on sandbox
-// TODO add new aws dedicated accounts once ready
-func FargateServiceFakeintake(e aws.Environment) (ipAddress pulumi.StringOutput, err error) {
-	taskDef, err := ddfakeintake.FargateLinuxTaskDefinition(e, e.Namer.ResourceName("fakeintake-taskdef"))
-	if err != nil {
-		return pulumi.StringOutput{}, err
-	}
-	fargateService, err := FargateService(e, e.Namer.ResourceName("fakeintake-srv"), pulumi.String(e.ECSFargateFakeintakeClusterArn()), taskDef.TaskDefinition.Arn())
-	// Hack passing taskDef.TaskDefinition.Arn() to execute apply function
-	// when taskDef has an ARN, thus it is defined on AWS side
-	ipAddress = pulumi.All(taskDef.TaskDefinition.Arn(), fargateService.Service.Name()).ApplyT(func(args []any) (string, error) {
-		var ipAddress string
-		err := backoff.Retry(func() error {
-			fmt.Println("waiting for fakeintake task private ip")
-			serviceName := args[1].(string)
-			ecsClient, err := NewECSClient(e.Ctx.Context(), e.Region())
-			if err != nil {
-				return err
-			}
-			ipAddress, err = ecsClient.GetTaskPrivateIP(e.ECSFargateFakeintakeClusterArn(), serviceName)
-			if err != nil {
-				return err
-			}
-			fmt.Printf("fakeintake task private ip found: %s\n", ipAddress)
-			return err
-		}, backoff.WithMaxRetries(backoff.NewConstantBackOff(sleepInterval), maxRetries))
-		return ipAddress, err
-	}).(pulumi.StringOutput)
-
-	return ipAddress, err
 }

--- a/scenarios/aws/fakeintake.go
+++ b/scenarios/aws/fakeintake.go
@@ -3,14 +3,13 @@ package aws
 import (
 	ddfakeintake "github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	resourcesAws "github.com/DataDog/test-infra-definitions/resources/aws"
-	"github.com/DataDog/test-infra-definitions/resources/aws/ecs"
 )
 
 func NewEcsFakeintake(env resourcesAws.Environment) (*ddfakeintake.ConnectionExporter, error) {
-	ipAddress, err := ecs.FargateServiceFakeintake(env)
+	comp, err := ddfakeintake.FargateLinuxComponentDefinition(env)
 	if err != nil {
 		return nil, err
 	}
 
-	return ddfakeintake.NewExporter(env.Ctx, ipAddress), nil
+	return ddfakeintake.NewExporter(env.Ctx, comp.Host), nil
 }

--- a/scenarios/aws/fakeintake.go
+++ b/scenarios/aws/fakeintake.go
@@ -6,10 +6,10 @@ import (
 )
 
 func NewEcsFakeintake(env resourcesAws.Environment) (*ddfakeintake.ConnectionExporter, error) {
-	comp, err := ddfakeintake.FargateLinuxComponentDefinition(env)
+	fakeintake, err := ddfakeintake.NewECSFargateInstance(env)
 	if err != nil {
 		return nil, err
 	}
 
-	return ddfakeintake.NewExporter(env.Ctx, comp.Host), nil
+	return ddfakeintake.NewExporter(env.Ctx, fakeintake.Host), nil
 }


### PR DESCRIPTION
What does this PR do?
---------------------

* Put a load balancer in front of the fake intake so that it keeps the same IP when it is OOM-killed.
* Use the `awsx` provider to define the other load balancers.

Which scenarios this will impact?
-------------------

* all

Motivation
----------

#### Put a load balancer in front of the fake intake

Although I agree that the OOM kills of the fake intake should be addressed independently of this workaround, I think there is a value to guarantee a stable IP to target the fake intake.
It will keep on working (although the data will vanish) when the fake intake will restart either involuntarily (in case of OOM kill or crash) or voluntarily (in case of deployment of a new dev version for ex.) without requiring a full rollout of the agents to update their config.

It has the side effect of removing the more or less hacky piece of code retrieving the IP of the fake intake task.

#### Use the `awsx` provider to define the other load balancers.

It simplifies a little bit our code as a single pulumi object is created to hold the three AWS objects (the load balancer itself, its listener and the target group).

Additional Notes
----------------

Load balancers are living outside of the ECS cluster.
As a consequence, they can be started to be provisioned very early, in parallel to the ECS capacity providers and the underlying VMs.
So, even if provisioning load balancers can take time, it shouldn’t impact the total elapsed time to spawn a stack because it can be provisioned in parallel with everything else and can be started at the beginning of the stack provisioning.