### PR TITLE
[vm] add centos aws os type support

### DIFF
--- a/scenarios/aws/vm/ec2os/centos.go
+++ b/scenarios/aws/vm/ec2os/centos.go
@@ -1,0 +1,48 @@
+package ec2os
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/DataDog/test-infra-definitions/components/command"
+	"github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/DataDog/test-infra-definitions/resources/aws"
+	"github.com/DataDog/test-infra-definitions/resources/aws/ec2"
+)
+
+type centos struct {
+	*unix
+	*os.Unix
+	env aws.Environment
+}
+
+var _ OS = &centos{}
+
+func newCentos(env aws.Environment) *centos {
+	return &centos{
+		unix: &unix{},
+		env:  env,
+		Unix: os.NewUnix(&env),
+	}
+}
+func (*centos) GetSSHUser() string { return "root" }
+
+func (u *centos) GetImage(arch os.Architecture) (string, error) {
+	switch arch {
+	case os.AMD64Arch:
+		return ec2.SearchAMI(u.env, "679593333241", "CentOS-7-2111-*.x86_64*", string(arch))
+	case os.ARM64Arch:
+		// OptInRequired: In order to use this AWS Marketplace product you need to accept terms and subscribe
+		return "", errors.New("ARM64 is not supported for CentOS")
+	default:
+		return "", fmt.Errorf("%v is not supported for CentOS", arch)
+	}
+}
+
+func (*centos) GetServiceManager() *os.ServiceManager {
+	return os.NewSystemCtlServiceManager()
+}
+
+func (*centos) CreatePackageManager(runner *command.Runner) (command.PackageManager, error) {
+	return newYumManager(runner), nil
+}

--- a/scenarios/aws/vm/ec2os/centos.go
+++ b/scenarios/aws/vm/ec2os/centos.go
@@ -25,7 +25,7 @@ func newCentos(env aws.Environment) *centos {
 		Unix: os.NewUnix(&env),
 	}
 }
-func (*centos) GetSSHUser() string { return "root" }
+func (*centos) GetSSHUser() string { return "centos" }
 
 func (u *centos) GetImage(arch os.Architecture) (string, error) {
 	switch arch {

--- a/scenarios/aws/vm/ec2os/os.go
+++ b/scenarios/aws/vm/ec2os/os.go
@@ -24,6 +24,7 @@ const (
 	RedHatOS      = iota
 	SuseOS        = iota
 	FedoraOS      = iota
+	CentOS        = iota
 )
 
 func GetOS(env aws.Environment, osType Type) (OS, error) {
@@ -44,6 +45,8 @@ func GetOS(env aws.Environment, osType Type) (OS, error) {
 		return newSuse(env), nil
 	case FedoraOS:
 		return newFedora(env), nil
+	case CentOS:
+		return newCentos(env), nil
 	default:
 		return nil, fmt.Errorf("cannot find environment: %v", osType)
 	}

--- a/scenarios/aws/vm/run.go
+++ b/scenarios/aws/vm/run.go
@@ -73,6 +73,8 @@ func getOSType(commonEnv *config.CommonEnvironment) (ec2os.Type, error) {
 		osType = ec2os.SuseOS
 	case "fedora":
 		osType = ec2os.FedoraOS
+	case "centos":
+		osType = ec2os.CentOS
 	case "":
 		osType = ec2os.UbuntuOS // Default
 	default:

--- a/tasks/tool.py
+++ b/tasks/tool.py
@@ -38,6 +38,7 @@ def get_os_families() -> List[str]:
         "redhat",
         "suse",
         "fedora",
+        "centos",
     ]
 
 


### PR DESCRIPTION
What does this PR do?
---------------------

Add support for CentOS 7

Which scenarios this will impact?
-------------------

VM

Motivation
----------

We frequently have to test CentOS 7 in QA as it is one of the supported Agent OS, the image is added to both `sandbox` and `agent-sandbox` public available AMI

Additional Notes
----------------
