### PR TITLE
Fix running the invoke task from outside the directory

### DIFF
--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -6,7 +6,6 @@ import subprocess
 from invoke.context import Context
 from invoke.exceptions import Exit
 from typing import Callable, List, Optional, Dict, Any
-import pathlib
 from . import tool
 
 default_public_path_key_name = "ddinfra:aws/defaultPublicKeyPath"
@@ -98,7 +97,7 @@ def _deploy(ctx: Context, stack_name: Optional[str], flags: Dict[str, Any], debu
     up_flags = ""
 
     # Checking root path
-    root_path = _get_root_path()
+    root_path = tool._get_root_path()
     if root_path != os.getcwd():
         global_flags += f" -C {root_path}"
 
@@ -116,11 +115,6 @@ def _deploy(ctx: Context, stack_name: Optional[str], flags: Dict[str, Any], debu
     cmd = f"{tool.get_aws_wrapper(aws_account)} -- pulumi {global_flags} up --yes -s {stack_name} {up_flags}"
     ctx.run(cmd, pty=True)
     return stack_name
-
-
-def _get_root_path() -> str:
-    folder = pathlib.Path(__file__).parent.resolve()
-    return str(folder.parent)
 
 
 def _get_api_key(cfg: Optional[Config]) -> str:

--- a/tasks/docker.py
+++ b/tasks/docker.py
@@ -35,11 +35,11 @@ def create_docker(
         agent_version=agent_version,
         extra_flags={},
     )
-    _show_connection_message(full_stack_name)
+    _show_connection_message(ctx, full_stack_name)
 
 
-def _show_connection_message(full_stack_name: str):
-    outputs = tool.get_stack_json_outputs(full_stack_name)
+def _show_connection_message(ctx: Context, full_stack_name: str):
+    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
     connection = tool.Connection(outputs)
     host = connection.host
     user = connection.user

--- a/tasks/ecs.py
+++ b/tasks/ecs.py
@@ -51,11 +51,11 @@ def create_ecs(
         agent_version=agent_version,
         extra_flags=extra_flags,
     )
-    _show_connection_message(full_stack_name)
+    _show_connection_message(ctx, full_stack_name)
 
 
-def _show_connection_message(full_stack_name: str):
-    outputs = tool.get_stack_json_outputs(full_stack_name)
+def _show_connection_message(ctx: Context, full_stack_name: str):
+    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
     cluster_name = outputs["ecs-cluster-name"]
 
     command = f"aws-vault exec sandbox-account-admin -- aws ecs list-tasks --cluster {cluster_name}"

--- a/tasks/eks.py
+++ b/tasks/eks.py
@@ -54,11 +54,11 @@ def create_eks(
         agent_version=agent_version,
         extra_flags=extra_flags,
     )
-    _show_connection_message(full_stack_name)
+    _show_connection_message(ctx, full_stack_name)
 
 
-def _show_connection_message(full_stack_name: str):
-    outputs = tool.get_stack_json_outputs(full_stack_name)
+def _show_connection_message(ctx: Context, full_stack_name: str):
+    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
     kubeconfig = outputs["kubeconfig"]
     kubeconfig_content = yaml.dump(kubeconfig)
     config = f"{full_stack_name}-config.yaml"

--- a/tasks/tool.py
+++ b/tasks/tool.py
@@ -67,17 +67,11 @@ def get_stack_name_prefix() -> str:
 
 def get_stack_json_outputs(ctx: Context, full_stack_name: str) -> Any:
     buffer = StringIO()
-    global_flags = ""
-
-    # Checking root path
-    root_path = _get_root_path()
-    if root_path != os.getcwd():
-        global_flags += f" -C {root_path}"
-
-    ctx.run(
-        f"pulumi {global_flags} stack output --json -s {full_stack_name}",
-        out_stream=buffer,
-    )
+    with ctx.cd(_get_root_path()):
+        ctx.run(
+            f"pulumi stack output --json -s {full_stack_name}",
+            out_stream=buffer,
+        )
     return json.loads(buffer.getvalue())
 
 def get_aws_wrapper(aws_account: str) -> str:

--- a/tasks/vm.py
+++ b/tasks/vm.py
@@ -59,11 +59,11 @@ def create_vm(
         extra_flags=extra_flags,
         use_fakeintake=use_fakeintake,
     )
-    _show_connection_message(full_stack_name)
+    _show_connection_message(ctx, full_stack_name)
 
 
-def _show_connection_message(full_stack_name: str):
-    outputs = tool.get_stack_json_outputs(full_stack_name)
+def _show_connection_message(ctx: Context, full_stack_name: str):
+    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
     connection = tool.Connection(outputs)
     host = connection.host
     user = connection.user


### PR DESCRIPTION
What does this PR do?
---------------------
Fix a bug preventing using the invoke task from outside the directory.

It also uses the task's `Context` to run a command which was ran with `subprocess` previously.

Which scenarios this will impact?
-------------------
None as this is only related to the invoke task.

Motivation
----------
Being able to use the invoke task from outside the directory without having a crash.
The logic is very similar to what is done in `deploy.py`.

Additional Notes
----------------
I believe this bug started when I updated pulumi to 1.74 but I'm not 100% sure.

To reproduce the bug, run
`inv -r ~/dd/test-infra-definitions create-vm --no-install-agent --no-use-fakeintake` from outside the `test-infra-definitions` directory.

The root error is 
```error: if you're using the --stack flag, pass the fully qualified name (organization/project/stack)```
which happens because pulumi cannot find the stack file in the current directory.