### PR TITLE
🐛 [fakeintake] hash LB and Target Group names

### DIFF
--- a/common/namer/namer.go
+++ b/common/namer/namer.go
@@ -1,10 +1,9 @@
 package namer
 
 import (
-	"crypto/md5"
-	"encoding/hex"
 	"strings"
 
+	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -62,21 +61,10 @@ func (n Namer) DisplayName(parts ...pulumi.StringInput) pulumi.StringInput {
 	}).(pulumi.StringOutput)
 }
 
-// HashedName return the md5 32-chars hex pulumi.StringInput of `parts` prefixed
+// DisplayNameWithMaxLen return pulumi.StringInput the concatanation of pulumi.StringInput `parts` prefixed
 // with the namer prefix
-func (n Namer) HashedName(parts ...pulumi.StringInput) pulumi.StringInput {
-	return n.DisplayName(parts...).ToStringOutput().ApplyT(func(name string) string {
-		hmd5 := md5.Sum([]byte(name))
-		return hex.EncodeToString(hmd5[:])
-	}).(pulumi.StringOutput)
-}
-
-// DisplayHashedName return the first 15 chars of the display name plus the first 16 chars
-// of the md5 32-chars hex pulumi.StringInput of display name
-func (n Namer) DisplayHashedName(parts ...pulumi.StringInput) pulumi.StringInput {
-	return pulumi.All(n.DisplayName(parts...), n.HashedName(parts...)).ApplyT(func(args []interface{}) string {
-		displayName := args[0].(string)
-		hashedName := args[1].(string)
-		return strings.Join([]string{displayName[:15], hashedName[:16]}, "-")
+func (n Namer) DisplayNameWithMaxLen(maxLen int, parts ...pulumi.StringInput) pulumi.StringInput {
+	return n.DisplayName(parts...).ToStringOutput().ApplyT(func(s string) string {
+		return utils.StrUniqueWithMaxLen(s, maxLen)
 	}).(pulumi.StringOutput)
 }

--- a/common/namer/namer.go
+++ b/common/namer/namer.go
@@ -1,6 +1,8 @@
 package namer
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -29,6 +31,8 @@ func (n Namer) WithPrefix(prefix string) Namer {
 	return childNamer
 }
 
+// ResourceName return the concatenation of `parts` prefixed
+// with namer prefix
 func (n Namer) ResourceName(parts ...string) string {
 	if len(parts) == 0 {
 		panic("Resource name requires at least one part to generate name")
@@ -42,6 +46,8 @@ func (n Namer) ResourceName(parts ...string) string {
 	return resourceName + strings.Join(parts, nameSep)
 }
 
+// DisplayName return pulumi.StringInput the concatanation of pulumi.StringInput `parts` prefixed
+// with the namer prefix
 func (n Namer) DisplayName(parts ...pulumi.StringInput) pulumi.StringInput {
 	var convertedParts []interface{}
 	for _, part := range parts {
@@ -53,5 +59,14 @@ func (n Namer) DisplayName(parts ...pulumi.StringInput) pulumi.StringInput {
 			strArgs = append(strArgs, arg.(string))
 		}
 		return n.ResourceName(strArgs...)
+	}).(pulumi.StringOutput)
+}
+
+// HashedName return the md5 32-chars hex pulumi.StringInput of `parts` prefixed
+// with the namer prefix
+func (n Namer) HashedName(parts ...pulumi.StringInput) pulumi.StringInput {
+	return n.DisplayName(parts...).ToStringOutput().ApplyT(func(name string) string {
+		hmd5 := md5.Sum([]byte(name))
+		return hex.EncodeToString(hmd5[:])
 	}).(pulumi.StringOutput)
 }

--- a/common/namer/namer.go
+++ b/common/namer/namer.go
@@ -70,3 +70,13 @@ func (n Namer) HashedName(parts ...pulumi.StringInput) pulumi.StringInput {
 		return hex.EncodeToString(hmd5[:])
 	}).(pulumi.StringOutput)
 }
+
+// DisplayHashedName return the first 15 chars of the display name plus the first 16 chars
+// of the md5 32-chars hex pulumi.StringInput of display name
+func (n Namer) DisplayHashedName(parts ...pulumi.StringInput) pulumi.StringInput {
+	return pulumi.All(n.DisplayName(parts...), n.HashedName(parts...)).ApplyT(func(args []interface{}) string {
+		displayName := args[0].(string)
+		hashedName := args[1].(string)
+		return strings.Join([]string{displayName[:15], hashedName[:16]}, "-")
+	}).(pulumi.StringOutput)
+}

--- a/common/randomgenerator/randomgenerator.go
+++ b/common/randomgenerator/randomgenerator.go
@@ -1,4 +1,4 @@
-package utils
+package randomgenerator
 
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"

--- a/common/utils/hash.go
+++ b/common/utils/hash.go
@@ -30,3 +30,20 @@ func StrHash(all ...string) string {
 
 	return fmt.Sprintf("%x", h.Sum64())
 }
+
+// StrUniqueWithMaxLen returns a best effort readable and unique string given a max size.
+// If the string is not longer than maxLen it returns the original string. If the string is
+// longer it returns (maxLen - 4) chars of the original string plus 3 chars (1 byte and 1 word)
+// of the hash of the string.
+// Example: ("totoro", 5) => "t-8bd"
+func StrUniqueWithMaxLen(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	hash := StrHash(s)
+	if maxLen <= 4 {
+		return hash[:maxLen]
+	}
+	prefix := s[:maxLen-4] + "-"
+	return fmt.Sprintf("%s%s", prefix, hash[:3])
+}

--- a/common/utils/hash_test.go
+++ b/common/utils/hash_test.go
@@ -1,0 +1,33 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_StrUniqueWithMaxLen(t *testing.T) {
+	t.Run("should return the original string when it is not longer than max len", func(t *testing.T) {
+		s := "totoro"
+		maxLen := 6
+		bestEffortHash := StrUniqueWithMaxLen(s, maxLen)
+		assert.Equal(t, "totoro", bestEffortHash)
+		assert.Equal(t, maxLen, len(bestEffortHash))
+	})
+
+	t.Run("should return first chars of the original string plus 3 chars from the hash when it is not longer than max len", func(t *testing.T) {
+		s := "totoro"
+		maxLen := 5
+		bestEffortHash := StrUniqueWithMaxLen(s, maxLen)
+		assert.Equal(t, maxLen, len(bestEffortHash))
+		assert.Equal(t, "t-8bd", bestEffortHash)
+	})
+
+	t.Run("should return a readable name with an hash when passing a long string", func(t *testing.T) {
+		s := "user-longlonglonglonglongname-aws-vm-test-with-totoro"
+		maxLen := 32
+		bestEffortHash := StrUniqueWithMaxLen(s, maxLen)
+		assert.Equal(t, maxLen, len(bestEffortHash))
+		assert.Equal(t, "user-longlonglonglonglongnam-47d", bestEffortHash)
+	})
+}

--- a/components/datadog/fakeintake/ecsFargate.go
+++ b/components/datadog/fakeintake/ecsFargate.go
@@ -34,12 +34,12 @@ func NewECSFargateInstance(e aws.Environment) (*Instance, error) {
 	opts = append(opts, pulumi.Parent(instance))
 
 	alb, err := lb.NewApplicationLoadBalancer(e.Ctx, namer.ResourceName("lb"), &lb.ApplicationLoadBalancerArgs{
-		Name:           e.CommonNamer.HashedName(pulumi.String("fakeintake")),
+		Name:           e.CommonNamer.DisplayHashedName(pulumi.String("fakeintake")),
 		SubnetIds:      pulumi.ToStringArray(e.DefaultSubnets()),
 		Internal:       pulumi.BoolPtr(!e.ECSServicePublicIP()),
 		SecurityGroups: pulumi.ToStringArray(e.DefaultSecurityGroups()),
 		DefaultTargetGroup: &lb.TargetGroupArgs{
-			Name:       e.CommonNamer.HashedName(pulumi.String("fakeintake")),
+			Name:       e.CommonNamer.DisplayHashedName(pulumi.String("fakeintake")),
 			Port:       pulumi.IntPtr(port),
 			Protocol:   pulumi.StringPtr("HTTP"),
 			TargetType: pulumi.StringPtr("ip"),

--- a/components/datadog/fakeintake/ecsFargate.go
+++ b/components/datadog/fakeintake/ecsFargate.go
@@ -34,12 +34,12 @@ func NewECSFargateInstance(e aws.Environment) (*Instance, error) {
 	opts = append(opts, pulumi.Parent(instance))
 
 	alb, err := lb.NewApplicationLoadBalancer(e.Ctx, namer.ResourceName("lb"), &lb.ApplicationLoadBalancerArgs{
-		Name:           e.CommonNamer.DisplayName(pulumi.String("fakeintake")),
+		Name:           e.CommonNamer.HashedName(pulumi.String("fakeintake")),
 		SubnetIds:      pulumi.ToStringArray(e.DefaultSubnets()),
 		Internal:       pulumi.BoolPtr(!e.ECSServicePublicIP()),
 		SecurityGroups: pulumi.ToStringArray(e.DefaultSecurityGroups()),
 		DefaultTargetGroup: &lb.TargetGroupArgs{
-			Name:       e.CommonNamer.DisplayName(pulumi.String("fakeintake")),
+			Name:       e.CommonNamer.HashedName(pulumi.String("fakeintake")),
 			Port:       pulumi.IntPtr(port),
 			Protocol:   pulumi.StringPtr("HTTP"),
 			TargetType: pulumi.StringPtr("ip"),

--- a/components/datadog/fakeintake/ecsFargate.go
+++ b/components/datadog/fakeintake/ecsFargate.go
@@ -34,12 +34,12 @@ func NewECSFargateInstance(e aws.Environment) (*Instance, error) {
 	opts = append(opts, pulumi.Parent(instance))
 
 	alb, err := lb.NewApplicationLoadBalancer(e.Ctx, namer.ResourceName("lb"), &lb.ApplicationLoadBalancerArgs{
-		Name:           e.CommonNamer.DisplayHashedName(pulumi.String("fakeintake")),
+		Name:           e.CommonNamer.DisplayNameWithMaxLen(32, pulumi.String("fakeintake")),
 		SubnetIds:      pulumi.ToStringArray(e.DefaultSubnets()),
 		Internal:       pulumi.BoolPtr(!e.ECSServicePublicIP()),
 		SecurityGroups: pulumi.ToStringArray(e.DefaultSecurityGroups()),
 		DefaultTargetGroup: &lb.TargetGroupArgs{
-			Name:       e.CommonNamer.DisplayHashedName(pulumi.String("fakeintake")),
+			Name:       e.CommonNamer.DisplayNameWithMaxLen(32, pulumi.String("fakeintake")),
 			Port:       pulumi.IntPtr(port),
 			Protocol:   pulumi.StringPtr("HTTP"),
 			TargetType: pulumi.StringPtr("ip"),

--- a/scenarios/aws/microVMs/microvms/domain.go
+++ b/scenarios/aws/microVMs/microvms/domain.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/namer"
-	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/common/randomgenerator"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/microVMs/microvms/resources"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/microVMs/vmconfig"
 	"github.com/pulumi/pulumi-libvirt/sdk/go/libvirt"
@@ -37,7 +37,7 @@ func generateDomainIdentifier(vcpu, memory int, vmsetName, tag, arch string) str
 	return fmt.Sprintf("ddvm-%s-%s-%s-%d-%d", vmsetName, arch, tag, vcpu, memory)
 }
 func generateNewUnicastMac(e config.CommonEnvironment, domainID string) (pulumi.StringOutput, error) {
-	r := utils.NewRandomGenerator(e, domainID)
+	r := randomgenerator.NewRandomGenerator(e, domainID)
 
 	pulumiRandStr, err := r.RandomString(domainID, 6, true)
 	if err != nil {


### PR DESCRIPTION
What does this PR do?
---------------------

Use md5 hash to name LB and Target Group name in fakeintake deployment

Which scenarios this will impact?
-------------------

VM

Motivation
----------

AWS Load Balancer and Target Group names must be 32 characters max and unique across an account. We were using `namer.DisplayName("fakeintake")` which was prefixing `fakeintake` with the stack name. The stack name is by default based on the environment flavour - for example `aws-vm-testsuite` - plus the username, and this is great as it creates unique resources per TestSuite / manually created environment. But it is easily longer than 32 chars. Using **md5** respects the 32 chars limit with a sufficiently low collision probability.

Additional Notes
----------------
