### PR TITLE
Remove unused constants to fix go lint warnings

### DIFF
--- a/resources/aws/ecs/fargateService.go
+++ b/resources/aws/ecs/fargateService.go
@@ -14,12 +14,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-const (
-	oneSecond     = 1000
-	sleepInterval = 1 * oneSecond
-	maxRetries    = 120
-)
-
 func FargateService(e aws.Environment, name string, clusterArn pulumi.StringInput, taskDefArn pulumi.StringInput) (*ecs.FargateService, error) {
 	return ecs.NewFargateService(e.Ctx, e.Namer.ResourceName(name), &ecs.FargateServiceArgs{
 		Cluster:      clusterArn,


### PR DESCRIPTION
What does this PR do?
---------------------
Remove unused constants to fix golangci-lint warnings.

Which scenarios this will impact?
-------------------
None.

Motivation
----------
The CI appeared red when I merged a PR.

Additional Notes
----------------
The issue seems to come from https://github.com/DataDog/test-infra-definitions/pull/225 but the linter didn't warn anything on that PR...