### PR TITLE
Let pulumi assign LB name itself to avoid name too long error

### DIFF
--- a/components/datadog/fakeintake/ecsFargate.go
+++ b/components/datadog/fakeintake/ecsFargate.go
@@ -34,12 +34,12 @@ func NewECSFargateInstance(e aws.Environment) (*Instance, error) {
 	opts = append(opts, pulumi.Parent(instance))
 
 	alb, err := lb.NewApplicationLoadBalancer(e.Ctx, namer.ResourceName("lb"), &lb.ApplicationLoadBalancerArgs{
-		Name:           e.CommonNamer.DisplayName(pulumi.String("fakeintake")),
+		// Name:           e.CommonNamer.DisplayName(pulumi.String("fakeintake")),
 		SubnetIds:      pulumi.ToStringArray(e.DefaultSubnets()),
 		Internal:       pulumi.BoolPtr(!e.ECSServicePublicIP()),
 		SecurityGroups: pulumi.ToStringArray(e.DefaultSecurityGroups()),
 		DefaultTargetGroup: &lb.TargetGroupArgs{
-			Name:       e.CommonNamer.DisplayName(pulumi.String("fakeintake")),
+			// Name:       e.CommonNamer.DisplayName(pulumi.String("fakeintake")),
 			Port:       pulumi.IntPtr(port),
 			Protocol:   pulumi.StringPtr("HTTP"),
 			TargetType: pulumi.StringPtr("ip"),


### PR DESCRIPTION
What does this PR do?
---------------------

Let pulumi assign LB name itself.

Which scenarios this will impact?
-------------------

* all

Motivation
----------

Our current logic to build smart resource names can exceed the maximum name size allowed.

Additional Notes
----------------

This PR will generate LB named like this:
![image](https://github.com/DataDog/test-infra-definitions/assets/1437785/e5d5a192-abd0-4133-a9cf-24361bf4c76d)