### PR TITLE
Reduce the number of IP needed per LB and better spread VM on subnets

### DIFF
--- a/components/datadog/apps/nginx/ecs.go
+++ b/components/datadog/apps/nginx/ecs.go
@@ -28,7 +28,7 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...
 
 	alb, err := lb.NewApplicationLoadBalancer(e.Ctx, namer.ResourceName("lb"), &lb.ApplicationLoadBalancerArgs{
 		Name:           e.CommonNamer.DisplayName(pulumi.String("nginx")),
-		SubnetIds:      pulumi.ToStringArray(e.DefaultSubnets()),
+		SubnetIds:      e.RandomSubnets(),
 		Internal:       pulumi.BoolPtr(true),
 		SecurityGroups: pulumi.ToStringArray(e.DefaultSecurityGroups()),
 		DefaultTargetGroup: &lb.TargetGroupArgs{

--- a/components/datadog/apps/redis/ecs.go
+++ b/components/datadog/apps/redis/ecs.go
@@ -28,7 +28,7 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...
 
 	nlb, err := lb.NewNetworkLoadBalancer(e.Ctx, namer.ResourceName("lb"), &lb.NetworkLoadBalancerArgs{
 		Name:      e.CommonNamer.DisplayName(pulumi.String("redis")),
-		SubnetIds: pulumi.ToStringArray(e.DefaultSubnets()),
+		SubnetIds: e.RandomSubnets(),
 		Internal:  pulumi.BoolPtr(true),
 		DefaultTargetGroup: &lb.TargetGroupArgs{
 			Name:       e.CommonNamer.DisplayName(pulumi.String("redis")),

--- a/components/datadog/fakeintake/ecsFargate.go
+++ b/components/datadog/fakeintake/ecsFargate.go
@@ -35,7 +35,7 @@ func NewECSFargateInstance(e aws.Environment) (*Instance, error) {
 
 	alb, err := lb.NewApplicationLoadBalancer(e.Ctx, namer.ResourceName("lb"), &lb.ApplicationLoadBalancerArgs{
 		Name:           e.CommonNamer.DisplayName(pulumi.String("fakeintake")),
-		SubnetIds:      pulumi.ToStringArray(e.DefaultSubnets()),
+		SubnetIds:      e.RandomSubnets(),
 		Internal:       pulumi.BoolPtr(!e.ECSServicePublicIP()),
 		SecurityGroups: pulumi.ToStringArray(e.DefaultSecurityGroups()),
 		DefaultTargetGroup: &lb.TargetGroupArgs{
@@ -64,7 +64,7 @@ func NewECSFargateInstance(e aws.Environment) (*Instance, error) {
 		NetworkConfiguration: &classicECS.ServiceNetworkConfigurationArgs{
 			AssignPublicIp: pulumi.BoolPtr(false),
 			SecurityGroups: pulumi.ToStringArray(e.DefaultSecurityGroups()),
-			Subnets:        pulumi.ToStringArray(e.DefaultSubnets()),
+			Subnets:        e.RandomSubnets(),
 		},
 		LoadBalancers: classicECS.ServiceLoadBalancerArray{
 			&classicECS.ServiceLoadBalancerArgs{

--- a/resources/aws/ec2/vm.go
+++ b/resources/aws/ec2/vm.go
@@ -19,7 +19,7 @@ func NewEC2Instance(e aws.Environment, name, ami, arch, instanceType, keyPair, u
 
 	instance, err := ec2.NewInstance(e.Ctx, e.Namer.ResourceName(name), &ec2.InstanceArgs{
 		Ami:                 pulumi.StringPtr(ami),
-		SubnetId:            pulumi.StringPtr(e.DefaultSubnets()[0]),
+		SubnetId:            e.RandomSubnets().Index(pulumi.Int(0)),
 		InstanceType:        pulumi.StringPtr(instanceType),
 		VpcSecurityGroupIds: pulumi.ToStringArray(e.DefaultSecurityGroups()),
 		KeyName:             pulumi.StringPtr(keyPair),

--- a/resources/aws/ec2/vmtemplate.go
+++ b/resources/aws/ec2/vmtemplate.go
@@ -18,7 +18,7 @@ func CreateLaunchTemplate(e aws.Environment, name string, ami, instanceType, iam
 		},
 		NetworkInterfaces: ec2.LaunchTemplateNetworkInterfaceArray{
 			ec2.LaunchTemplateNetworkInterfaceArgs{
-				SubnetId:                 pulumi.StringPtr(e.DefaultSubnets()[0]),
+				SubnetId:                 e.RandomSubnets().Index(pulumi.Int(0)),
 				DeleteOnTermination:      pulumi.StringPtr("true"),
 				AssociatePublicIpAddress: pulumi.StringPtr("false"),
 				SecurityGroups:           pulumi.ToStringArray(e.DefaultSecurityGroups()),

--- a/resources/aws/ecs/fargateService.go
+++ b/resources/aws/ecs/fargateService.go
@@ -28,7 +28,7 @@ func FargateService(e aws.Environment, name string, clusterArn pulumi.StringInpu
 		NetworkConfiguration: classicECS.ServiceNetworkConfigurationArgs{
 			AssignPublicIp: pulumi.BoolPtr(e.ECSServicePublicIP()),
 			SecurityGroups: pulumi.ToStringArray(e.DefaultSecurityGroups()),
-			Subnets:        pulumi.ToStringArray(e.DefaultSubnets()),
+			Subnets:        e.RandomSubnets(),
 		},
 		TaskDefinition:            taskDefArn,
 		EnableExecuteCommand:      pulumi.BoolPtr(true),

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -95,7 +95,7 @@ func Run(ctx *pulumi.Context) error {
 		Fargate:                      fargateProfile,
 		ClusterSecurityGroup:         clusterSG,
 		NodeAssociatePublicIpAddress: pulumi.BoolRef(false),
-		PrivateSubnetIds:             pulumi.ToStringArray(awsEnv.DefaultSubnets()),
+		PrivateSubnetIds:             awsEnv.RandomSubnets(),
 		VpcId:                        pulumi.StringPtr(awsEnv.DefaultVPCID()),
 		SkipDefaultNodeGroup:         pulumi.BoolRef(true),
 		// The content of the aws-auth map is the merge of `InstanceRoles` and `RoleMappings`.

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -73,7 +73,7 @@ func newEC2Instance(awsEnv aws.Environment, name, ami, arch, instanceType, keyPa
 
 	instance, err := awsEc2.NewInstance(awsEnv.Ctx, awsEnv.Namer.ResourceName(name), &awsEc2.InstanceArgs{
 		Ami:                 pulumi.StringPtr(ami),
-		SubnetId:            pulumi.StringPtr(awsEnv.DefaultSubnets()[0]),
+		SubnetId:            awsEnv.RandomSubnets().Index(pulumi.Int(0)),
 		InstanceType:        pulumi.StringPtr(instanceType),
 		VpcSecurityGroupIds: pulumi.ToStringArray(awsEnv.DefaultSecurityGroups()),
 		KeyName:             pulumi.StringPtr(keyPair),


### PR DESCRIPTION
What does this PR do?
---------------------

Make a better use of the IP available in the subnets in order to avoid premature exhaustion of IP.

| Before | After |
|--------|--------|
| All single VM use-cases were spawning the VM always on the same first subnet. This could lead to exhaustion of available IP in the first subnet whereas the other two subnets were barely used. | Single VM use-cases are now spawning the VM on a subnet randomly chosen among the 3 available ones. It spreads the usage on all 3 subnets. |
| Load balancers were consuming 3 IP, one per subnet in which they were present. | It’s not possible to have a load balancer inside a single availability zone. But, instead of putting them in all 3 zones, we now put them only in 2 zones randomly chosen among the 3 available ones. |
| ECS and EKS clusters were spread on the 3 zones. It didn’t consume more IP. | But concentrating them on 2 zones reduces the probability of cross-zone traffic from 2 chances out of 3 to 1 chance out of 2. |

Which scenarios this will impact?
-------------------

all

Motivation
----------

We already faced errors due to IP exhaustion.

Additional Notes
----------------
