### PR TITLE
Mark custom filesystem as `Local` if required

### DIFF
--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -108,17 +108,12 @@ func NewLibvirtFSDistroRecipe(ctx *pulumi.Context, vmset *vmconfig.VMSet, pool *
 		baseVolumeMap[k.Tag] = img
 	}
 
-	local := false
-	if vmset.Arch == LocalVMSet {
-		local = true
-	}
-
 	return &LibvirtFilesystem{
 		ctx:           ctx,
 		pool:          pool,
 		images:        images,
 		baseVolumeMap: baseVolumeMap,
-		isLocal:       local,
+		isLocal:       vmset.Arch == LocalVMSet,
 	}
 }
 
@@ -149,17 +144,12 @@ func NewLibvirtFSCustomRecipe(ctx *pulumi.Context, vmset *vmconfig.VMSet, pool *
 		baseVolumeMap[k.Tag] = img
 	}
 
-	local := false
-	if vmset.Arch == LocalVMSet {
-		local = true
-	}
-
 	return &LibvirtFilesystem{
 		ctx:           ctx,
 		images:        []*filesystemImage{img},
 		baseVolumeMap: baseVolumeMap,
 		pool:          pool,
-		isLocal:       local,
+		isLocal:       vmset.Arch == LocalVMSet,
 	}
 }
 

--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -149,11 +149,17 @@ func NewLibvirtFSCustomRecipe(ctx *pulumi.Context, vmset *vmconfig.VMSet, pool *
 		baseVolumeMap[k.Tag] = img
 	}
 
+	local := false
+	if vmset.Arch == LocalVMSet {
+		local = true
+	}
+
 	return &LibvirtFilesystem{
 		ctx:           ctx,
 		images:        []*filesystemImage{img},
 		baseVolumeMap: baseVolumeMap,
 		pool:          pool,
+		isLocal:       local,
 	}
 }
 


### PR DESCRIPTION
What does this PR do?
---------------------

Which scenarios this will impact?
-------------------

Motivation
----------
The custom filesystem was not being marked as local, which was causing it to traverse the remote deployment path when the stack was launch locally.

Additional Notes
----------------
