### PR TITLE
[task] use account wrapper in output commands in ecs and eks

### DIFF
--- a/tasks/eks.py
+++ b/tasks/eks.py
@@ -1,11 +1,13 @@
 import os
 from invoke.tasks import task
+from pydantic import ValidationError
 import yaml
 from .destroy import destroy
 from .deploy import deploy
-from . import doc
+from . import config, doc
 from typing import Optional
 from invoke.context import Context
+from invoke.exceptions import Exit
 from . import tool
 import pyperclip
 
@@ -59,14 +61,19 @@ def create_eks(
 
 def _show_connection_message(ctx: Context, full_stack_name: str):
     outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
-    kubeconfig = outputs["kubeconfig"]
-    kubeconfig_content = yaml.dump(kubeconfig)
-    config = f"{full_stack_name}-config.yaml"
-    f = os.open(path=config, flags=(os.O_WRONLY | os.O_CREAT | os.O_TRUNC), mode=0o600)
+    kubeconfig_output = outputs["kubeconfig"]
+    kubeconfig_content = yaml.dump(kubeconfig_output)
+    kubeconfig = f"{full_stack_name}-config.yaml"
+    f = os.open(path=kubeconfig, flags=(os.O_WRONLY | os.O_CREAT | os.O_TRUNC), mode=0o600)
     with open(f, "w") as f:
         f.write(kubeconfig_content)
+    
+    try:
+        local_config = config.get_local_config()
+    except ValidationError as e:
+        raise Exit(f"Error in config {config.get_full_profile_path()}:{e}")
 
-    command = f"KUBECONFIG={config} aws-vault exec sandbox-account-admin -- kubectl get nodes"
+    command = f"KUBECONFIG={config} {tool.get_aws_wrapper(local_config.get_aws().get_account())} -- kubectl get nodes"
     pyperclip.copy(command)
     print(
         f"\nYou can run the following command to connect to the EKS cluster\n\n{command}\n\nThis command was copied to the clipboard\n"


### PR DESCRIPTION
What does this PR do?
---------------------

Use account from local profile to build the helper command to reach eks and ecs infrastructures after an environment is created on an account. 

Which scenarios this will impact?
-------------------

eks, ecs

Motivation
----------

The current command copied to the clipboard is using `sandbox` hardcoded account

Additional Notes
----------------
