### PR TITLE
[task] Improve team tag instructions

### DIFF
--- a/.test_infra_config.yaml.example
+++ b/.test_infra_config.yaml.example
@@ -4,6 +4,10 @@ configParams:
   # aws configuration
 
   aws:
+    # aws account where resources will be created on
+    # example "agent-sandbox"
+    account: ""
+
     # aws key pair name
     # must be available in aws sandbox account
     # required to configure EC2 instances
@@ -14,6 +18,11 @@ configParams:
     # required to configure Windows EC2 instances
 
     publicKeyPath: ""
+
+    # team tag labeling all resources. In real config this
+    # would be the github team name
+
+    teamTag: ""
   # agent related config
   agent:
     # Datadog API key

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -105,7 +105,7 @@ def setupAWSConfig(config: Config):
     if config.configParams.aws.teamTag is None:
         config.configParams.aws.teamTag = ""
     while True:
-        msg = "🔖 What is your team? This will tag all your resources by `team:<team>`"
+        msg = "🔖 What is your github team? This will tag all your resources by `team:<team>`. Use kebab-case format (example: agent-platform)"
         if len(config.configParams.aws.teamTag) > 0:
             msg += f". Default [{config.configParams.aws.teamTag}]"
         msg += ": "


### PR DESCRIPTION
What does this PR do?
---------------------

Improve team tag instructions in setup team, suggesting using github team name

Which scenarios this will impact?
-------------------

All

Motivation
----------

Feedback to have more guidelines on which name we should use. At DD we have different team name sources:

* workday
* github
* slack channel

Using agent guidelines and keep using github team name. Some devs might have more than one team (ex squad plus team), they can select their main team name

Additional Notes
----------------
