### PR TITLE
[runner] pin cython < 3.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ RUN cd /tmp/test-infra && \
 # https://github.com/yaml/pyyaml/issues/724#issuecomment-1638636728
 RUN curl -fsSL https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/requirements.txt | \
   grep -ivE "boto3|botocore|awscli|urllib3|PyYAML" > requirements-agent.txt && \
-  pithon3  install "cython<3.0.0" && \
+  pip3 install "cython<3.0.0" && \
   pip3 install --no-build-isolation PyYAML==5.4.1 && \
   pip3 install -r requirements-agent.txt && \
   go install gotest.tools/gotestsum@latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,12 +91,19 @@ RUN cd /tmp/test-infra && \
   cd / && \
   rm -rf /tmp/test-infra
 
-# Install Agent / test requirements
+# Install Agent requirements, required to run invoke tests task
 # Remove AWS-related deps as we already install AWS CLI v2
+# Remove PyYAML to workaround issues with cpython 3.0.0
+# https://github.com/yaml/pyyaml/issues/724#issuecomment-1638636728
 RUN curl -fsSL https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/requirements.txt | \
-  grep -ivE "boto3|botocore|awscli|urllib3" > requirements-agent.txt && \
+  grep -ivE "boto3|botocore|awscli|urllib3|PyYAML" > requirements-agent.txt && \
+  pithon3  install "cython<3.0.0" && \
+  pip3 install --no-build-isolation PyYAML==5.4.1 && \
   pip3 install -r requirements-agent.txt && \
   go install gotest.tools/gotestsum@latest
+
+# Install go test requirements
+RUN go install gotest.tools/gotestsum@latest
 
 # I think it's safe to say if we're using this mega image, we want pulumi
 ENTRYPOINT ["pulumi"]


### PR DESCRIPTION
What does this PR do?
---------------------

Pin cython under 3.0.0 to fix PyYAML wheel build error.

Which scenarios this will impact?
-------------------

None

Motivation
----------

Since `cython==3.0.0` release `PyYAML==5.4.1` installation fails

https://github.com/yaml/pyyaml/issues/724#issuecomment-1638636728

`PyYAML==6.0.1` was released with a fix pinning `cython<3.0.0`, there is no backporting yet on `PyYAML=5.4`, so we are fixing this with a workaround. 

`PyYAML` wheel is built because there is no pre-build package for python 3.10. 

We need to explicit install `PyYAML` as it will be removed from `datadog-agent-build-image` requirements in https://github.com/DataDog/datadog-agent-buildimages/pull/419

Additional Notes
----------------

We could also downgrade the base image to [3.9.5-slim-buster](https://hub.docker.com/layers/library/python/3.9.5-slim-buster/images/sha256-892a914025a5fe75cdc228c597c069e1ff028b08eb05fd03403d2c844f860f11?context=explore), which would downgrade debian from 11 to 10 too. This would let us use the same python version used in agent images.

We could also bump PyYAML dependency to 6.0.1 that has the cython fix pinned.

One further note, we install agent python requirements because we use this image in the agent repository. For this reason, we could have a pulumi capable image defined here, and an invoke capable image depending on this one defined in https://github.com/DataDog/datadog-agent-buildimages 