### PR TITLE
Perform full check on cpu specs

### DIFF
--- a/scenarios/aws/microVMs/microvms/resources/amd64/domain.xls
+++ b/scenarios/aws/microVMs/microvms/resources/amd64/domain.xls
@@ -8,9 +8,7 @@
       </xsl:copy>
    </xsl:template>
   <xsl:template match="/domain/features">
-       <cpu mode='host-passthrough' check='none'>
-           <model fallback='forbid'>qemu64</model>
-       </cpu>
+      <cpu mode='host-passthrough' check='full'/>
   </xsl:template>
 
   <xsl:template match="/domain/devices/disk">

--- a/scenarios/aws/microVMs/microvms/resources/distro/domain-amd64.xls
+++ b/scenarios/aws/microVMs/microvms/resources/distro/domain-amd64.xls
@@ -8,9 +8,7 @@
       </xsl:copy>
    </xsl:template>
   <xsl:template match="/domain/features">
-       <cpu mode='host-passthrough' check='none'>
-           <model fallback='forbid'>qemu64</model>
-       </cpu>
+      <cpu mode='host-passthrough' check='full'/>
   </xsl:template>
 
   <xsl:template match="/domain/devices/disk">


### PR DESCRIPTION
What does this PR do?
---------------------

Which scenarios this will impact?
-------------------

Motivation
----------
Qemu failed to setup CPUs with the fallback option originally specified on `ThinkPad P15v`.
The fixes instructs libvirt to perform a full check to ensure that the host specs match the CPU which qemu can emulate before trying to launch the VM. 

This fixes the problem for reason without needing to fallback to a different machine type. According to the documentation this should only do an early fail if the virtual CPU specs do not match the host CPU specs. Not sure why its fixes the underlying problem.

#### full

> The virtual CPU created by the hypervisor will be checked against the CPU specification and the domain will not be started unless the two CPUs match.

https://libvirt.org/formatdomain.html#cpu-model-and-topology


Additional Notes
----------------
