### PR TITLE
Use newer Fedora AMI that works

### DIFF
--- a/scenarios/aws/vm/ec2os/fedora.go
+++ b/scenarios/aws/vm/ec2os/fedora.go
@@ -28,7 +28,7 @@ func (*fedora) GetSSHUser() string { return "fedora" }
 func (u *fedora) GetImage(arch os.Architecture) (string, error) {
 	switch arch {
 	case os.AMD64Arch:
-		return ec2.SearchAMI(u.env, "679593333241", "Fedora-Cloud-Base-34-1.2*-standard-*", string(arch))
+		return ec2.SearchAMI(u.env, "125523088429", "Fedora-Cloud-Base-37-*", string(arch))
 	case os.ARM64Arch:
 		// OptInRequired: In order to use this AWS Marketplace product you need to accept terms and subscribe
 		return "", errors.New("ARM64 is not supported for Fedora")


### PR DESCRIPTION
What does this PR do?
---------------------

Change the AMI used for creating a Fedora VM

Which scenarios this will impact?
-------------------

VM scenario
Motivation
----------

Be able to create Fedora VM

Additional Notes
----------------
