### PR TITLE
Fix CPU configuration and downloading with multiple VMSets

### DIFF
--- a/scenarios/aws/microVMs/microvms/libvirt.go
+++ b/scenarios/aws/microVMs/microvms/libvirt.go
@@ -82,14 +82,19 @@ type VMCollection struct {
 
 func (vm *VMCollection) SetupCollectionFilesystems(depends []pulumi.Resource) ([]pulumi.Resource, error) {
 	var waitFor []pulumi.Resource
+	var err error
 
+	var libvirtPoolReady []pulumi.Resource
 	if vm.instance.Arch != LocalVMSet {
-		libvirtPoolReady, err := setupRemoteLibvirtPool(vm.pool, vm.instance.runner, depends)
-		if err != nil {
-			return []pulumi.Resource{}, err
-		}
-		depends = append(depends, libvirtPoolReady...)
+		libvirtPoolReady, err = setupRemoteLibvirtPool(vm.pool, vm.instance.runner, depends)
+	} else {
+		libvirtPoolReady, err = setupLocalLibvirtPool(vm.instance.e.Ctx, vm.libvirtProvider, vm.pool, depends)
+
 	}
+	if err != nil {
+		return []pulumi.Resource{}, err
+	}
+	depends = append(depends, libvirtPoolReady...)
 
 	for _, set := range vm.vmsets {
 		fs, err := newLibvirtFS(vm.instance.e.Ctx, &set, vm.pool)

--- a/scenarios/aws/microVMs/microvms/resources/amd64/domain.xls
+++ b/scenarios/aws/microVMs/microvms/resources/amd64/domain.xls
@@ -8,7 +8,6 @@
       </xsl:copy>
    </xsl:template>
   <xsl:template match="/domain/features">
-      <cpu mode='host-passthrough' check='full'/>
   </xsl:template>
 
   <xsl:template match="/domain/devices/disk">

--- a/scenarios/aws/microVMs/microvms/resources/amd64/domain.xls
+++ b/scenarios/aws/microVMs/microvms/resources/amd64/domain.xls
@@ -8,9 +8,7 @@
       </xsl:copy>
    </xsl:template>
   <xsl:template match="/domain/features">
-       <cpu mode='host-passthrough' check='none'>
-           <model fallback='forbid'>qemu64</model>
-       </cpu>
+      <cpu mode='host-passthrough' check='full'/>
   </xsl:template>
 
   <xsl:template match="/domain/devices/disk">

--- a/scenarios/aws/microVMs/microvms/resources/distro/domain-amd64.xls
+++ b/scenarios/aws/microVMs/microvms/resources/distro/domain-amd64.xls
@@ -8,7 +8,6 @@
       </xsl:copy>
    </xsl:template>
   <xsl:template match="/domain/features">
-      <cpu mode='host-passthrough' check='full'/>
   </xsl:template>
 
   <xsl:template match="/domain/devices/disk">

--- a/scenarios/aws/microVMs/microvms/resources/distro/domain-amd64.xls
+++ b/scenarios/aws/microVMs/microvms/resources/distro/domain-amd64.xls
@@ -8,9 +8,7 @@
       </xsl:copy>
    </xsl:template>
   <xsl:template match="/domain/features">
-       <cpu mode='host-passthrough' check='none'>
-           <model fallback='forbid'>qemu64</model>
-       </cpu>
+      <cpu mode='host-passthrough' check='full'/>
   </xsl:template>
 
   <xsl:template match="/domain/devices/disk">


### PR DESCRIPTION
What does this PR do?
---------------------
This PR performs two fixes.

1. Fix downloading of qcow2 images from S3 with multiple VMSets.
2. Remove hardcoded configuration of CPUs, so that libvirt can detect the configuration best suited.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
