### PR TITLE
When creating a VM disable the fake intake by default

### DIFF
--- a/tasks/vm.py
+++ b/tasks/vm.py
@@ -33,7 +33,7 @@ def create_vm(
     agent_version: Optional[str] = None,
     debug: Optional[bool] = False,
     os_family: Optional[str] = None,
-    use_fakeintake: Optional[bool] = True,
+    use_fakeintake: Optional[bool] = False,
     ami_id: Optional[str] = None,
     architecture: Optional[str] = None,
 ) -> None:


### PR DESCRIPTION
What does this PR do?
---------------------
This PR disables by default the creation of the fake intake when creating a vm.

Which scenarios this will impact?
-------------------

Motivation
----------
Most of the time the user doesn't need the fake intake when creating a VM.

Additional Notes
----------------
