### PR TITLE
Add CI_PIPELINE_ID in env var tags, to automatically tags re sources with pipeline id

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -115,7 +115,7 @@ func (e *CommonEnvironment) ExtraResourcesTags() map[string]string {
 
 func EnvVariableResourceTags() map[string]string {
 	tags := map[string]string{}
-	lookupVars := []string{"TEAM", "PIPELINE_ID"}
+	lookupVars := []string{"TEAM", "CI_PIPELINE_ID"}
 	for _, varName := range lookupVars {
 		if val := os.Getenv(varName); val != "" {
 			tags[varName] = val

--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -115,7 +115,7 @@ func (e *CommonEnvironment) ExtraResourcesTags() map[string]string {
 
 func EnvVariableResourceTags() map[string]string {
 	tags := map[string]string{}
-	lookupVars := []string{"TEAM", "CI_PIPELINE_ID"}
+	lookupVars := []string{"TEAM", "PIPELINE_ID", "CI_PIPELINE_ID"}
 	for _, varName := range lookupVars {
 		if val := os.Getenv(varName); val != "" {
 			tags[varName] = val


### PR DESCRIPTION
What does this PR do?
---------------------

It includes `CI_PIPELINE_ID` in the list of env var that will be used as tags for resources. So resources are automatically tagged when running in CI.

Which scenarios this will impact?
-------------------

Motivation
----------

To be able to link resources with CI pipelines. Which is convenient to create a clean up job for example

Additional Notes
----------------
