### PR TITLE
Show the correct path for KUBECONFIG when creating a EKS cluster

### DIFF
--- a/tasks/eks.py
+++ b/tasks/eks.py
@@ -74,7 +74,7 @@ def _show_connection_message(ctx: Context, full_stack_name: str):
     except ValidationError as e:
         raise Exit(f"Error in config {config.get_full_profile_path()}:{e}")
 
-    command = f"KUBECONFIG={config} {tool.get_aws_wrapper(local_config.get_aws().get_account())} -- kubectl get nodes"
+    command = f"KUBECONFIG={kubeconfig} {tool.get_aws_wrapper(local_config.get_aws().get_account())} -- kubectl get nodes"
     pyperclip.copy(command)
     print(
         f"\nYou can run the following command to connect to the EKS cluster\n\n{command}\n\nThis command was copied to the clipboard\n"

--- a/tasks/eks.py
+++ b/tasks/eks.py
@@ -74,7 +74,9 @@ def _show_connection_message(ctx: Context, full_stack_name: str):
     except ValidationError as e:
         raise Exit(f"Error in config {config.get_full_profile_path()}:{e}")
 
-    command = f"KUBECONFIG={kubeconfig} {tool.get_aws_wrapper(local_config.get_aws().get_account())} -- kubectl get nodes"
+    command = (
+        f"KUBECONFIG={kubeconfig} {tool.get_aws_wrapper(local_config.get_aws().get_account())} -- kubectl get nodes"
+    )
     pyperclip.copy(command)
     print(
         f"\nYou can run the following command to connect to the EKS cluster\n\n{command}\n\nThis command was copied to the clipboard\n"


### PR DESCRIPTION
What does this PR do?
---------------------
Show the correct path for KUBECONFIG when creating a EKS cluster introduced by https://github.com/DataDog/test-infra-definitions/pull/245/files.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
