### PR TITLE
Restart the agent when having a empty config

### DIFF
--- a/components/datadog/agent/install.go
+++ b/components/datadog/agent/install.go
@@ -87,10 +87,6 @@ func updateAgentConfig(
 	extraAgentConfig []pulumi.StringInput,
 	os os.OS,
 	lastCommand *remote.Command) (*remote.Command, pulumi.StringInput, error) {
-	if agentConfig == "" && len(extraAgentConfig) == 0 {
-		// no update in agent config, safely early return
-		return lastCommand, nil, nil
-	}
 
 	agentConfigFullPath := path.Join(os.GetAgentConfigFolder(), "datadog.yaml")
 	var err error


### PR DESCRIPTION
What does this PR do?
---------------------

Restart the agent when having an empty config. This fixes the following code where using `""` as config doesn't restart the agent.
```go
v.UpdateEnv(e2e.AgentStackDef(nil, agentparams.WithAgentConfig("log_level: debug")))
v.UpdateEnv(e2e.AgentStackDef(nil, agentparams.WithAgentConfig(""))) // Agent not restart
```

