### PR TITLE
golangci needs go version of at least 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/test-infra-definitions
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
What does this PR do?
---------------------

Bumps the go version in go.mod to 1.20 due to [failures installing golangci on ci](https://github.com/DataDog/test-infra-definitions/actions/runs/5930254863/job/16082089060)

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
