### PR TITLE
Add system-probe and security-agent config

### DIFF
--- a/components/datadog/agent/install.go
+++ b/components/datadog/agent/install.go
@@ -50,7 +50,7 @@ func NewInstaller(vm vm.VM, options ...agentparams.Option) (*Installer, error) {
 	}
 
 	var updateConfigTrigger pulumi.StringInput
-	lastCommand, updateConfigTrigger, err = updateAgentConfig(
+	lastCommand, _, err = updateAgentConfig(
 		vm.GetFileManager(),
 		env,
 		params.AgentConfig,

--- a/components/datadog/agent/install.go
+++ b/components/datadog/agent/install.go
@@ -49,8 +49,8 @@ func NewInstaller(vm vm.VM, options ...agentparams.Option) (*Installer, error) {
 		return nil, err
 	}
 
-	var updateConfigTrigger pulumi.StringInput
-	lastCommand, _, err = updateAgentConfig(
+	var updateAgentConfigTrigger, updateSystemConfigTrigger, updateSecurityAgentConfigTrigger pulumi.StringInput
+	lastCommand, updateAgentConfigTrigger, err = updateAgentConfig(
 		vm.GetFileManager(),
 		env,
 		params.AgentConfig,

--- a/components/datadog/agent/install.go
+++ b/components/datadog/agent/install.go
@@ -49,16 +49,17 @@ func NewInstaller(vm vm.VM, options ...agentparams.Option) (*Installer, error) {
 		return nil, err
 	}
 
-	var updateAgentConfigTrigger, updateSystemConfigTrigger, updateSecurityAgentConfigTrigger pulumi.StringInput
-	lastCommand, updateAgentConfigTrigger, err = updateAgentConfig(
-		vm.GetFileManager(),
-		env,
-		params.AgentConfig,
-		params.ExtraAgentConfig,
-		os,
-		lastCommand)
-	if err != nil {
-		return nil, err
+	fileChangeTriggers := make(map[string]pulumi.StringInput)
+	var trigger pulumi.StringInput
+	for _, input := range []struct{ path, content string }{
+		{"datadog.yaml", params.AgentConfig},
+		{"system-probe.yaml", params.SystemProbeConfig},
+		{"security-agent.yaml", params.SecurityAgentConfig}} {
+		lastCommand, trigger, err = updateConfig(vm.GetFileManager(), input.path, input.content, params.ExtraAgentConfig, env, os, lastCommand)
+		fileChangeTriggers[input.path] = trigger
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var filesHash string
@@ -73,7 +74,7 @@ func NewInstaller(vm vm.VM, options ...agentparams.Option) (*Installer, error) {
 		func(cmd pulumi.String) *command.Args {
 			return &command.Args{
 				Create:   cmd,
-				Triggers: pulumi.Array{updateConfigTrigger, pulumi.String(filesHash)},
+				Triggers: pulumi.Array{fileChangeTriggers["datadog.yaml"], fileChangeTriggers["system-probe.yaml"], fileChangeTriggers["security-agent.yaml"], pulumi.String(filesHash)},
 			}
 		},
 		os, runner, commonNamer.ResourceName("restart-agent"), lastCommand)
@@ -103,26 +104,32 @@ func restartAgent(
 	return lastCommand, nil
 }
 
-func updateAgentConfig(
+func updateConfig(
 	fileManager *command.FileManager,
-	env *config.CommonEnvironment,
-	agentConfig string,
+	configPath string,
+	configContent string,
 	extraAgentConfig []pulumi.StringInput,
+	env *config.CommonEnvironment,
 	os os.OS,
 	lastCommand *remote.Command) (*remote.Command, pulumi.StringInput, error) {
 
-	agentConfigFullPath := path.Join(os.GetAgentConfigFolder(), "datadog.yaml")
+	configFullPath := path.Join(os.GetAgentConfigFolder(), configPath)
 	var err error
 
-	pulumiAgentString := pulumi.String(agentConfig).ToStringOutput()
-	for _, extraConfig := range extraAgentConfig {
-		pulumiAgentString = pulumi.Sprintf("%v\n%v", pulumiAgentString, extraConfig)
-	}
+	fmt.Println("path = ", configPath)
+	fmt.Println("content = ", configContent)
 
-	agentConfigWithAPIKEY := pulumi.Sprintf("api_key: %v\n%v", env.AgentAPIKey(), pulumiAgentString)
+	pulumiAgentString := pulumi.String(configContent).ToStringOutput()
+	// If core agent, set api key and extra configs
+	if configPath == "datadog.yaml" {
+		for _, extraConfig := range extraAgentConfig {
+			pulumiAgentString = pulumi.Sprintf("%v\n%v", pulumiAgentString, extraConfig)
+		}
+		pulumiAgentString = pulumi.Sprintf("api_key: %v\n%v", env.AgentAPIKey(), pulumiAgentString)
+	}
 	lastCommand, err = fileManager.CopyInlineFile(
-		agentConfigWithAPIKEY,
-		agentConfigFullPath,
+		pulumiAgentString,
+		configFullPath,
 		true,
 		utils.PulumiDependsOn(lastCommand))
 	if err != nil {

--- a/components/datadog/agent/install.go
+++ b/components/datadog/agent/install.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"fmt"
 	"path"
 
 	"github.com/DataDog/test-infra-definitions/common/config"
@@ -115,9 +114,6 @@ func updateConfig(
 
 	configFullPath := path.Join(os.GetAgentConfigFolder(), configPath)
 	var err error
-
-	fmt.Println("path = ", configPath)
-	fmt.Println("content = ", configContent)
 
 	pulumiAgentString := pulumi.String(configContent).ToStringOutput()
 	// If core agent, set api key and extra configs

--- a/components/datadog/agent/install.go
+++ b/components/datadog/agent/install.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"fmt"
 	"path"
 
 	"github.com/DataDog/test-infra-definitions/common/config"

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -20,6 +20,8 @@ import (
 //   - [WithVersion]
 //   - [WithPipelineID]
 //   - [WithAgentConfig]
+//   - [WithSystemProbeConfig]
+//   - [WithSecurityAgentConfig]
 //   - [WithFile]
 //   - [WithIntegration]
 //   - [WithTelemetry]
@@ -34,11 +36,13 @@ type FileDefinition struct {
 }
 
 type Params struct {
-	Version          os.AgentVersion
-	AgentConfig      string
-	Integrations     map[string]*FileDefinition
-	Files            map[string]*FileDefinition
-	ExtraAgentConfig []pulumi.StringInput
+	Version             os.AgentVersion
+	AgentConfig         string
+	SystemProbeConfig   string
+	SecurityAgentConfig string
+	Integrations        map[string]*FileDefinition
+	Files               map[string]*FileDefinition
+	ExtraAgentConfig    []pulumi.StringInput
 }
 
 type Option = func(*Params) error
@@ -120,6 +124,22 @@ func parsePipelineVersion(s string) os.AgentVersion {
 func WithAgentConfig(config string) func(*Params) error {
 	return func(p *Params) error {
 		p.AgentConfig = config
+		return nil
+	}
+}
+
+// WithSystemProbeConfig sets the configuration of system-probe.
+func WithSystemProbeConfig(config string) func(*Params) error {
+	return func(p *Params) error {
+		p.SystemProbeConfig = config
+		return nil
+	}
+}
+
+// WithSecurityAgentConfig sets the configuration of the security-agent.
+func WithSecurityAgentConfig(config string) func(*Params) error {
+	return func(p *Params) error {
+		p.SystemProbeConfig = config
 		return nil
 	}
 }

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -139,7 +139,7 @@ func WithSystemProbeConfig(config string) func(*Params) error {
 // WithSecurityAgentConfig sets the configuration of the security-agent.
 func WithSecurityAgentConfig(config string) func(*Params) error {
 	return func(p *Params) error {
-		p.SystemProbeConfig = config
+		p.SecurityAgentConfig = config
 		return nil
 	}
 }


### PR DESCRIPTION
What does this PR do?
---------------------
This PR adds the ability to set configurations for system-probe and the security-agent using `WithSystemProbeConfig` and `WithSecurityAgentConfig`

