### PR TITLE
Temporarly disable integration test locally to avoid overwritting local config

### DIFF
--- a/integration-tests/invoke_test.go
+++ b/integration-tests/invoke_test.go
@@ -13,6 +13,9 @@ import (
 )
 
 func TestInvokeVM(t *testing.T) {
+	if _, ok := os.LookupEnv("CI"); !ok {
+		t.Skip()
+	}
 
 	var setupStdout, setupStderr bytes.Buffer
 


### PR DESCRIPTION

What does this PR do?
---------------------

Temp fix to avoid overwriting local config when running go test locally

Which scenarios this will impact?
-------------------

Motivation
----------

Not break config while the issue is fixed with a proper fix

Additional Notes
----------------
