### PR TITLE
Config file path can now be configured, also fixes integration tests ran locally

### DIFF
--- a/integration-tests/invoke_test.go
+++ b/integration-tests/invoke_test.go
@@ -46,7 +46,9 @@ func TestInvokeVM(t *testing.T) {
 
 	err = setupCmd.Wait()
 	require.NoError(t, err, "Error found: %s %s", setupStdout.String(), setupStderr.String())
-	require.Contains(t, setupStdout.String(), "Configuration file saved at", "If setup succeeded, last message should contain 'Configuration file saved at'")
+	require.Contains(t, setupStdout.String(), fmt.Sprintf("Configuration file saved at %s", tmpConfigFile), fmt.Sprintf("If setup succeeded, last message should contain 'Configuration file saved at %s'", tmpConfigFile))
+
+	defer os.Remove(tmpConfigFile)
 
 	createCmd := exec.Command("invoke", "create-vm", "--stack-name", fmt.Sprintf("integration-testing-%s", os.Getenv("CI_PIPELINE_ID")), "--no-copy-to-clipboard", "--no-use-aws-vault", "--config-path", tmpConfigFile)
 	createOutput, err := createCmd.Output()

--- a/integration-tests/invoke_test.go
+++ b/integration-tests/invoke_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,13 +14,12 @@ import (
 )
 
 func TestInvokeVM(t *testing.T) {
-	if _, ok := os.LookupEnv("CI"); !ok {
-		t.Skip()
-	}
 
 	var setupStdout, setupStderr bytes.Buffer
 
-	setupCmd := exec.Command("invoke", "setup", "--no-copy-to-clipboard")
+	tmpConfigFile := filepath.Join(os.TempDir(), "test-infra-test.yaml")
+
+	setupCmd := exec.Command("invoke", "setup", "--no-copy-to-clipboard", "--config-path", tmpConfigFile)
 	setupCmd.Stdout = &setupStdout
 	setupCmd.Stderr = &setupStderr
 	stdin, _ := setupCmd.StdinPipe()
@@ -48,11 +48,11 @@ func TestInvokeVM(t *testing.T) {
 	require.NoError(t, err, "Error found: %s %s", setupStdout.String(), setupStderr.String())
 	require.Contains(t, setupStdout.String(), "Configuration file saved at", "If setup succeeded, last message should contain 'Configuration file saved at'")
 
-	createCmd := exec.Command("invoke", "create-vm", "--stack-name", fmt.Sprintf("integration-testing-%s", os.Getenv("CI_PIPELINE_ID")), "--no-copy-to-clipboard", "--no-use-aws-vault")
+	createCmd := exec.Command("invoke", "create-vm", "--stack-name", fmt.Sprintf("integration-testing-%s", os.Getenv("CI_PIPELINE_ID")), "--no-copy-to-clipboard", "--no-use-aws-vault", "--config-path", tmpConfigFile)
 	createOutput, err := createCmd.Output()
 	assert.NoError(t, err, "Error found: %s", string(createOutput))
 
-	destroyCmd := exec.Command("invoke", "destroy-vm", "--yes", "--stack-name", fmt.Sprintf("integration-testing-%s", os.Getenv("CI_PIPELINE_ID")), "--no-use-aws-vault")
+	destroyCmd := exec.Command("invoke", "destroy-vm", "--yes", "--stack-name", fmt.Sprintf("integration-testing-%s", os.Getenv("CI_PIPELINE_ID")), "--no-use-aws-vault", "--config-path", tmpConfigFile)
 	destroyOutput, err := destroyCmd.Output()
 	require.NoError(t, err, "Error found destroying stack: %s", string(destroyOutput))
 }

--- a/tasks/config.py
+++ b/tasks/config.py
@@ -11,6 +11,7 @@ profile_filename = ".test_infra_config.yaml"
 
 
 class Config(BaseModel, extra=Extra.forbid):
+    
     class Params(BaseModel, extra=Extra.forbid):
         class Aws(BaseModel, extra=Extra.forbid):
             keyPairName: Optional[str]
@@ -66,8 +67,8 @@ class Config(BaseModel, extra=Extra.forbid):
             return {}
         return self.stackParams
 
-    def save_to_local_config(self):
-        profile_path = get_full_profile_path()
+    def save_to_local_config(self, config_path: Optional[str] = None):
+        profile_path = get_full_profile_path(config_path)
         try:
             with open(profile_path, "w") as outfile:
                 yaml.dump(self.dict(), outfile)
@@ -76,8 +77,8 @@ class Config(BaseModel, extra=Extra.forbid):
         info(f"Configuration file saved at {profile_path}")
 
 
-def get_local_config() -> Config:
-    profile_path = get_full_profile_path()
+def get_local_config(profile_path: Optional[str] = None) -> Config:
+    profile_path = get_full_profile_path(profile_path)
     try:
         with open(profile_path) as f:
             content = f.read()
@@ -87,5 +88,7 @@ def get_local_config() -> Config:
         return Config.parse_obj({})
 
 
-def get_full_profile_path() -> str:
+def get_full_profile_path(profile_path: Optional[str] = None) -> str:
+    if profile_path:
+        return str(Path(profile_path).expanduser().absolute()) # Return absolute path to config file, handle "~"" with expanduser
     return str(Path.home().joinpath(profile_filename))

--- a/tasks/config.py
+++ b/tasks/config.py
@@ -11,7 +11,6 @@ profile_filename = ".test_infra_config.yaml"
 
 
 class Config(BaseModel, extra=Extra.forbid):
-    
     class Params(BaseModel, extra=Extra.forbid):
         class Aws(BaseModel, extra=Extra.forbid):
             keyPairName: Optional[str]
@@ -90,5 +89,7 @@ def get_local_config(profile_path: Optional[str] = None) -> Config:
 
 def get_full_profile_path(profile_path: Optional[str] = None) -> str:
     if profile_path:
-        return str(Path(profile_path).expanduser().absolute()) # Return absolute path to config file, handle "~"" with expanduser
+        return str(
+            Path(profile_path).expanduser().absolute()
+        )  # Return absolute path to config file, handle "~"" with expanduser
     return str(Path.home().joinpath(profile_filename))

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -15,6 +15,7 @@ default_public_path_key_name = "ddinfra:aws/defaultPublicKeyPath"
 def deploy(
     ctx: Context,
     scenario_name: str,
+    config_path: Optional[str] = None,
     key_pair_required: bool = False,
     public_key_required: bool = False,
     app_key_required: bool = False,
@@ -36,9 +37,9 @@ def deploy(
     flags["ddagent:deploy"] = install_agent
 
     try:
-        cfg = config.get_local_config()
+        cfg = config.get_local_config(config_path)
     except ValidationError as e:
-        raise Exit(f"Error in config {get_full_profile_path()}:{e}")
+        raise Exit(f"Error in config {get_full_profile_path(config_path)}:{e}")
 
     flags[default_public_path_key_name] = _get_public_path_key_name(cfg, public_key_required)
     flags["scenario"] = scenario_name

--- a/tasks/destroy.py
+++ b/tasks/destroy.py
@@ -12,6 +12,7 @@ from .tool import error, get_aws_wrapper, get_stack_name, get_stack_name_prefix,
 def destroy(
     ctx: Context,
     scenario_name: str,
+    config_path: Optional[str] = None,
     stack: Optional[str] = None,
     use_aws_vault: Optional[bool] = True,
     force_yes: Optional[bool] = False,
@@ -29,9 +30,9 @@ def destroy(
         return
 
     try:
-        cfg = config.get_local_config()
+        cfg = config.get_local_config(config_path)
     except ValidationError as e:
-        raise Exit(f"Error in config {config.get_full_profile_path()}:{e}")
+        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}:{e}")
     aws_account = cfg.get_aws().get_account()
 
     if stack is not None:

--- a/tasks/doc.py
+++ b/tasks/doc.py
@@ -25,3 +25,4 @@ architecture: str = f"The architecture to use. Possible values are {tool.get_arc
 yes: str = "Automatically approve and perform the destroy without previewing it"
 use_aws_vault: str = "Wrap aws command with aws-vault, default to True"
 copy_to_clipboard: str = "Enable copy to clipboard, default to True"
+config_path: str = "Specify a custom config path to use"

--- a/tasks/docker.py
+++ b/tasks/docker.py
@@ -14,6 +14,7 @@ scenario_name = "aws/dockervm"
 
 @task(
     help={
+        "config_path": doc.config_path,
         "install_agent": doc.install_agent,
         "agent_version": doc.container_agent_version,
         "stack_name": doc.stack_name,
@@ -22,6 +23,7 @@ scenario_name = "aws/dockervm"
 )
 def create_docker(
     ctx: Context,
+    config_path: Optional[str] = None,
     stack_name: Optional[str] = None,
     install_agent: Optional[bool] = True,
     agent_version: Optional[str] = None,
@@ -37,6 +39,7 @@ def create_docker(
     full_stack_name = deploy(
         ctx,
         scenario_name,
+        config_path,
         key_pair_required=True,
         stack_name=stack_name,
         install_agent=install_agent,

--- a/tasks/ecs.py
+++ b/tasks/ecs.py
@@ -15,6 +15,7 @@ scenario_name = "aws/ecs"
 
 @task(
     help={
+        "config_path": doc.config_path,
         "install_agent": doc.install_agent,
         "agent_version": doc.container_agent_version,
         "stack_name": doc.stack_name,
@@ -27,6 +28,7 @@ scenario_name = "aws/ecs"
 )
 def create_ecs(
     ctx: Context,
+    config_path: Optional[str]= None,
     stack_name: Optional[str] = None,
     install_agent: Optional[bool] = True,
     agent_version: Optional[str] = None,
@@ -49,22 +51,23 @@ def create_ecs(
     full_stack_name = deploy(
         ctx,
         scenario_name,
+        config_path,
         stack_name=stack_name,
         install_agent=install_agent,
         agent_version=agent_version,
         extra_flags=extra_flags,
     )
-    _show_connection_message(ctx, full_stack_name)
+    _show_connection_message(ctx, config_path, full_stack_name)
 
 
-def _show_connection_message(ctx: Context, full_stack_name: str):
+def _show_connection_message(ctx: Context, config_path: Optional[str], full_stack_name: str):
     outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
     cluster_name = outputs["ecs-cluster-name"]
 
     try:
-        local_config = config.get_local_config()
+        local_config = config.get_local_config(config_path)
     except ValidationError as e:
-        raise Exit(f"Error in config {config.get_full_profile_path()}:{e}")
+        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}:{e}")
 
     command = (
         f"{tool.get_aws_wrapper(local_config.get_aws().get_account())} aws ecs list-tasks --cluster {cluster_name}"

--- a/tasks/ecs.py
+++ b/tasks/ecs.py
@@ -28,7 +28,7 @@ scenario_name = "aws/ecs"
 )
 def create_ecs(
     ctx: Context,
-    config_path: Optional[str]= None,
+    config_path: Optional[str] = None,
     stack_name: Optional[str] = None,
     install_agent: Optional[bool] = True,
     agent_version: Optional[str] = None,

--- a/tasks/eks.py
+++ b/tasks/eks.py
@@ -17,6 +17,7 @@ scenario_name = "aws/eks"
 
 @task(
     help={
+        "config_path": doc.config_path,
         "install_agent": doc.install_agent,
         "agent_version": doc.container_agent_version,
         "stack_name": doc.stack_name,
@@ -28,6 +29,7 @@ scenario_name = "aws/eks"
 )
 def create_eks(
     ctx: Context,
+    config_path: Optional[str] = None,
     debug: Optional[bool] = False,
     stack_name: Optional[str] = None,
     install_agent: Optional[bool] = True,
@@ -57,10 +59,10 @@ def create_eks(
         agent_version=agent_version,
         extra_flags=extra_flags,
     )
-    _show_connection_message(ctx, full_stack_name)
+    _show_connection_message(ctx, full_stack_name, config_path)
 
 
-def _show_connection_message(ctx: Context, full_stack_name: str):
+def _show_connection_message(ctx: Context, full_stack_name: str, config_path: Optional[str]):
     outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
     kubeconfig_output = outputs["kubeconfig"]
     kubeconfig_content = yaml.dump(kubeconfig_output)
@@ -70,9 +72,9 @@ def _show_connection_message(ctx: Context, full_stack_name: str):
         f.write(kubeconfig_content)
 
     try:
-        local_config = config.get_local_config()
+        local_config = config.get_local_config(config_path)
     except ValidationError as e:
-        raise Exit(f"Error in config {config.get_full_profile_path()}:{e}")
+        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}:{e}")
 
     command = f"KUBECONFIG={kubeconfig} {tool.get_aws_wrapper(local_config.get_aws().get_account())} kubectl get nodes"
 

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -29,7 +29,6 @@ def setup(_: Context, config_path: Optional[str] = None, copy_to_clipboard: Opti
     os.system("pulumi login --local")
 
     info("🤖 Let's configure your environment for e2e tests! Press ctrl+c to stop me")
-    print(config_path)
     try:
         config = get_local_config(config_path)
     except Exception:

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -8,14 +8,17 @@ import pyperclip
 from invoke.context import Context
 from invoke.tasks import task
 
+from . import doc
 from .config import Config, get_full_profile_path, get_local_config
 from .tool import ask, info, is_windows, warn
 
 available_aws_accounts = ["agent-sandbox", "sandbox", "agent-qa"]
 
 
-@task
-def setup(_: Context, copy_to_clipboard: Optional[bool] = True) -> None:
+@task(
+        help={"config_path": doc.config_path, "copy_to_clipboard": doc.copy_to_clipboard}
+)
+def setup(_: Context, config_path: Optional[str] = None, copy_to_clipboard: Optional[bool] = True) -> None:
     """
     Setup a local environment interactively
     """
@@ -28,8 +31,9 @@ def setup(_: Context, copy_to_clipboard: Optional[bool] = True) -> None:
     os.system("pulumi login --local")
 
     info("🤖 Let's configure your environment for e2e tests! Press ctrl+c to stop me")
+    print(config_path)
     try:
-        config = get_local_config()
+        config = get_local_config(config_path)
     except Exception:
         config = Config.parse_obj({})
 
@@ -38,8 +42,8 @@ def setup(_: Context, copy_to_clipboard: Optional[bool] = True) -> None:
     # Agent config
     setupAgentConfig(config)
 
-    config.save_to_local_config()
-    cat_profile_command = f"cat {get_full_profile_path()}"
+    config.save_to_local_config(config_path)
+    cat_profile_command = f"cat {get_full_profile_path(config_path)}"
     if copy_to_clipboard:
         pyperclip.copy(cat_profile_command)
     print(

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -15,9 +15,7 @@ from .tool import ask, info, is_windows, warn
 available_aws_accounts = ["agent-sandbox", "sandbox", "agent-qa"]
 
 
-@task(
-        help={"config_path": doc.config_path, "copy_to_clipboard": doc.copy_to_clipboard}
-)
+@task(help={"config_path": doc.config_path, "copy_to_clipboard": doc.copy_to_clipboard})
 def setup(_: Context, config_path: Optional[str] = None, copy_to_clipboard: Optional[bool] = True) -> None:
     """
     Setup a local environment interactively

--- a/tasks/vm.py
+++ b/tasks/vm.py
@@ -14,6 +14,7 @@ scenario_name = "aws/vm"
 
 @task(
     help={
+        "config_path": doc.config_path,
         "install_agent": doc.install_agent,
         "pipeline_id": doc.pipeline_id,
         "agent_version": doc.agent_version,
@@ -29,6 +30,7 @@ scenario_name = "aws/vm"
 )
 def create_vm(
     ctx: Context,
+    config_path: Optional[str] = None,
     stack_name: Optional[str] = None,
     pipeline_id: Optional[str] = None,
     install_agent: Optional[bool] = True,
@@ -58,6 +60,7 @@ def create_vm(
     full_stack_name = deploy(
         ctx,
         scenario_name,
+        config_path,
         key_pair_required=True,
         public_key_required=(os_family.lower() == "windows"),
         stack_name=stack_name,
@@ -86,14 +89,14 @@ def _show_connection_message(ctx: Context, full_stack_name: str, copy_to_clipboa
     )
 
 
-@task(help={"stack_name": doc.stack_name, "yes": doc.yes})
+@task(help={"config_path": doc.config_path, "stack_name": doc.stack_name, "yes": doc.yes, "use_aws_vault":doc.use_aws_vault})
 def destroy_vm(
-    ctx: Context, stack_name: Optional[str] = None, yes: Optional[bool] = False, use_aws_vault: Optional[bool] = True
+    ctx: Context, config_path: Optional[str] = None, stack_name: Optional[str] = None, yes: Optional[bool] = False, use_aws_vault: Optional[bool] = True
 ):
     """
     Destroy a new virtual machine on the cloud.
     """
-    destroy(ctx, scenario_name, stack_name, use_aws_vault, force_yes=yes)
+    destroy(ctx, scenario_name, config_path, stack_name, use_aws_vault, force_yes=yes)
 
 
 def _get_os_family(os_family: Optional[str]) -> str:

--- a/tasks/vm.py
+++ b/tasks/vm.py
@@ -89,9 +89,20 @@ def _show_connection_message(ctx: Context, full_stack_name: str, copy_to_clipboa
     )
 
 
-@task(help={"config_path": doc.config_path, "stack_name": doc.stack_name, "yes": doc.yes, "use_aws_vault":doc.use_aws_vault})
+@task(
+    help={
+        "config_path": doc.config_path,
+        "stack_name": doc.stack_name,
+        "yes": doc.yes,
+        "use_aws_vault": doc.use_aws_vault,
+    }
+)
 def destroy_vm(
-    ctx: Context, config_path: Optional[str] = None, stack_name: Optional[str] = None, yes: Optional[bool] = False, use_aws_vault: Optional[bool] = True
+    ctx: Context,
+    config_path: Optional[str] = None,
+    stack_name: Optional[str] = None,
+    yes: Optional[bool] = False,
+    use_aws_vault: Optional[bool] = True,
 ):
     """
     Destroy a new virtual machine on the cloud.


### PR DESCRIPTION
What does this PR do?
---------------------

Add --config-path option to all invoke task, to specify a custom location for the config file

Which scenarios this will impact?
-------------------

All

Motivation
----------

It can be useful if user wants to manage several config file. It is also useful to fix integration tests, to be able to use a temporary configuration file, to not break local config file of user running go test

Additional Notes
----------------

Another solution could be to use an env variable `TEST-INFRA-CONFIG_FILE` and to check for this variable in the `get_full_profile_path` function
