### PR TITLE
Migrate to Kubernetes GitLab runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,7 @@ integration-testing:
 build-runner-image:
   stage: build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10.13
-  tags: ["runner:docker"]
+  tags: ["arch:amd64"]
   variables:
     PUSH_IMAGE: "false"
   rules:


### PR DESCRIPTION
What does this PR do?
---------------------

Migrate the `build-runner-image` GitLab job to Kubernetes runners.

Which scenarios this will impact?
-------------------

Only the build of the test image.

Motivation
----------

CI/CD evolution
`runner:docker` is deprecated.

Additional Notes
----------------

https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/2411528655/Onboarding+To+Gitlab+CI#Gitlab-runner-tags