### PR TITLE
Wait for agent ready in pulumi with opt-out

### DIFF
--- a/components/datadog/agent/install.go
+++ b/components/datadog/agent/install.go
@@ -78,6 +78,19 @@ func NewInstaller(vm vm.VM, options ...agentparams.Option) (*Installer, error) {
 		},
 		os, runner, commonNamer.ResourceName("restart-agent"), lastCommand)
 
+	if err != nil {
+		return nil, err
+	}
+
+	if params.WaitReady {
+		waitReadyCommand := os.GetWaitAgentReadyCmd()
+		lastCommand, err = runner.Command(
+			commonNamer.ResourceName("wait-ready-agent"),
+			&command.Args{
+				Create: pulumi.String(waitReadyCommand),
+			}, utils.PulumiDependsOn(lastCommand))
+	}
+
 	return &Installer{dependsOn: lastCommand, vm: vm}, err
 }
 

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -39,6 +39,7 @@ type Params struct {
 	Integrations     map[string]*FileDefinition
 	Files            map[string]*FileDefinition
 	ExtraAgentConfig []pulumi.StringInput
+	WaitReady        bool
 }
 
 type Option = func(*Params) error
@@ -47,6 +48,7 @@ func NewParams(env *config.CommonEnvironment, options ...Option) (*Params, error
 	p := &Params{
 		Integrations: make(map[string]*FileDefinition),
 		Files:        make(map[string]*FileDefinition),
+		WaitReady:    true,
 	}
 	defaultVersion := WithLatest()
 	if env.AgentVersion() != "" {
@@ -86,6 +88,14 @@ func WithVersion(version string) func(*Params) error {
 func WithPipelineID(version string) func(*Params) error {
 	return func(p *Params) error {
 		p.Version = parsePipelineVersion(version)
+
+		return nil
+	}
+}
+
+func WithoutWaitReady() func(*Params) error {
+	return func(p *Params) error {
+		p.WaitReady = false
 
 		return nil
 	}

--- a/components/os/os.go
+++ b/components/os/os.go
@@ -31,8 +31,10 @@ type OS interface {
 	GetServiceManager() *ServiceManager
 	GetAgentConfigFolder() string
 	GetSSHUser() string
+
 	GetAgentInstallCmd(AgentVersion) (string, error)
 	GetRunAgentCmd(parameters string) string
+	GetWaitAgentReadyCmd() string
 	GetType() Type
 	CreatePackageManager(runner *command.Runner) (command.PackageManager, error)
 	CheckIsAbsPath(string) bool

--- a/components/os/os.go
+++ b/components/os/os.go
@@ -31,7 +31,6 @@ type OS interface {
 	GetServiceManager() *ServiceManager
 	GetAgentConfigFolder() string
 	GetSSHUser() string
-
 	GetAgentInstallCmd(AgentVersion) (string, error)
 	GetRunAgentCmd(parameters string) string
 	GetWaitAgentReadyCmd() string

--- a/components/os/unix.go
+++ b/components/os/unix.go
@@ -41,6 +41,11 @@ func (*Unix) GetRunAgentCmd(parameters string) string {
 	return "sudo datadog-agent " + parameters
 }
 
+func (u *Unix) GetWaitAgentReadyCmd() string {
+	statudCmd := u.GetRunAgentCmd("status")
+	return fmt.Sprintf("until %s; do sleep 1; done", statudCmd)
+}
+
 func getDefaultInstanceType(env config.Environment, arch Architecture) string {
 	switch arch {
 	case AMD64Arch:

--- a/components/os/windows.go
+++ b/components/os/windows.go
@@ -78,6 +78,11 @@ func (*Windows) GetRunAgentCmd(parameters string) string {
 	return `& "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" ` + parameters
 }
 
+func (w *Windows) GetWaitAgentReadyCmd() string {
+	statusCmd := w.GetRunAgentCmd("status")
+	return fmt.Sprintf("while(-not $statusExitCode) { %s; $statusExitCode = $?; sleep 1 }", statusCmd)
+}
+
 func getAgentURL(version AgentVersion) (string, error) {
 	minor := strings.ReplaceAll(version.Minor, "~", "-")
 	fullVersion := fmt.Sprintf("%v.%v", version.Major, minor)


### PR DESCRIPTION
What does this PR do?
---------------------

By default Pulumi will wait for the agent to be ready. Can be opt-out with `WithoutWaitReady` params

Which scenarios this will impact?
-------------------

VM scenario

Motivation
----------

Additional Notes
----------------
