### PR TITLE
use GITHUB_TOKEN to avoid github quota limit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,6 +37,7 @@ build-runner-image:
   tags: ["arch:amd64"]
   variables:
     PUSH_IMAGE: "false"
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   rules:
     - if: $CI_COMMIT_BRANCH == "main"
       variables:


### PR DESCRIPTION

What does this PR do?
---------------------

use GITHUB_TOKEN to avoid github quota limit
This PR depend on https://github.com/helm/helm/pull/12358 

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
