### PR TITLE
[dockerfile] install helm from binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,9 +57,8 @@ RUN apt-get update -y && \
 # Install Go
 RUN curl -fsSLo --retry=10 /tmp/go.tgz https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
   echo "${GO_SHA} /tmp/go.tgz" | sha256sum -c - && \
-  tar -C /usr/local -xzf /tmp/go.tgz && \
+  tar -C /usr/local/bin -xzf /tmp/go.tgz --strip-components=2 go/bin && \
   rm /tmp/go.tgz && \
-  export PATH="/usr/local/go/bin:$PATH" && \
   go version
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
@@ -72,10 +71,8 @@ ENV XDG_CONFIG_HOME=/root/.config
 ENV XDG_CACHE_HOME=/root/.cache
 RUN curl -fsSLo --retry=10 /tmp/helm.tgz https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
   echo "${HELM_SHA} /tmp/helm.tgz" | sha256sum -c - && \
-  mkdir /usr/local/helm && \
-  tar -C /usr/local/helm -xzf /tmp/helm.tgz --strip-components=1 linux-amd64/helm && \
+  tar -C /usr/local/bin -xzf /tmp/helm.tgz --strip-components=1 linux-amd64/helm && \
   rm /tmp/helm.tgz && \
-  export PATH="/usr/local/helm:$PATH" && \
   helm version && \
   helm repo add stable https://charts.helm.sh/stable && \
   helm repo update

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,10 +72,10 @@ ENV XDG_CONFIG_HOME=/root/.config
 ENV XDG_CACHE_HOME=/root/.cache
 RUN curl -fsSLo --retry=10 /tmp/helm.tgz https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
   echo "${HELM_SHA} /tmp/helm.tgz" | sha256sum -c - && \
-  mkdir -p /usr/local/helm && \
-  tar -C /usr/local/helm -xzf /tmp/helm.tgz && \
+  mkdir /usr/local/helm && \
+  tar -C /usr/local/helm -xzf /tmp/helm.tgz --strip-components=1 linux-amd64/helm && \
   rm /tmp/helm.tgz && \
-  export PATH="/usr/local/helm/linux-amd64:$PATH" && \
+  export PATH="/usr/local/helm:$PATH" && \
   helm version && \
   helm repo add stable https://charts.helm.sh/stable && \
   helm repo update

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 # (e.g. in GitHub actions where $HOME points to /github/home).
 ENV XDG_CONFIG_HOME=/root/.config
 ENV XDG_CACHE_HOME=/root/.cache
-RUN curl -fsSLo /tmp/helm.tgz https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
+RUN curl -fsSLo --retry=10 /tmp/helm.tgz https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
   echo "${HELM_SHA} /tmp/helm.tgz" | sha256sum -c - && \
   mkdir -p /usr/local/helm && \
   tar -C /usr/local/helm -xzf /tmp/helm.tgz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ FROM python:3.10-slim-bullseye AS base
 
 ENV GO_VERSION=1.20.3
 ENV GO_SHA=979694c2c25c735755bf26f4f45e19e64e4811d661dd07b8c010f7a8e18adfca
+ENV HELM_VERSION=3.12.3
+ENV HELM_SHA=1b2313cd198d45eab00cc37c38f6b1ca0a948ba279c29e322bdf426d406129b5
 
 # Install deps all in one step
 RUN apt-get update -y && \
@@ -68,7 +70,13 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 # (e.g. in GitHub actions where $HOME points to /github/home).
 ENV XDG_CONFIG_HOME=/root/.config
 ENV XDG_CACHE_HOME=/root/.cache
-RUN curl -L https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash && \
+RUN curl -fsSLo /tmp/helm.tgz https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz && \
+  echo "${HELM_SHA} /tmp/helm.tgz" | sha256sum -c - && \
+  mkdir -p /usr/local/helm && \
+  tar -C /usr/local/helm -xzf /tmp/helm.tgz && \
+  rm /tmp/helm.tgz && \
+  export PATH="/usr/local/helm/linux-amd64:$PATH" && \
+  helm version && \
   helm repo add stable https://charts.helm.sh/stable && \
   helm repo update
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,10 @@ RUN apt-get update -y && \
   curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
   curl -fsSL https://packages.microsoft.com/keys/microsoft.asc     | apt-key add - && \
   # IAM Authenticator for EKS
-  curl -fsSLo /usr/bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.9/aws-iam-authenticator_0.5.9_linux_amd64 && \
+  curl -fsSLo --retry=10 /usr/bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.9/aws-iam-authenticator_0.5.9_linux_amd64 && \
   chmod +x /usr/bin/aws-iam-authenticator && \
   # AWS v2 cli
-  curl -fsSLo awscliv2.zip https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip && \
+  curl -fsSLo --retry=10 awscliv2.zip https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip && \
   unzip -q awscliv2.zip && \
   ./aws/install && \
   rm -rf aws && \
@@ -55,7 +55,7 @@ RUN apt-get update -y && \
   rm -rf /var/lib/apt/lists/*
 
 # Install Go
-RUN curl -fsSLo /tmp/go.tgz https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
+RUN curl -fsSLo --retry=10 /tmp/go.tgz https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
   echo "${GO_SHA} /tmp/go.tgz" | sha256sum -c - && \
   tar -C /usr/local -xzf /tmp/go.tgz && \
   rm /tmp/go.tgz && \


### PR DESCRIPTION
What does this PR do?
---------------------

Install helm in pulumi-runner image using binaries instead of the script fetched from github

Which scenarios this will impact?
-------------------

None 

Motivation
----------

This will prevent the github error rate we get when installing using the install script. It also prevents flakiness pinning helm version

Additional Notes
----------------
