### PR TITLE
Use timeout options added to Command plugin

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,11 +58,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install lint python requirements
-        run: pip3 install -r https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/circleci/requirements.txt
+        run: pip3 install -r https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/requirements/circleci.txt
       - name: Run linters
         run: |
           flake8 tasks
           black --check --diff tasks
           isort --check-only --diff tasks
           vulture --ignore-decorators @task --ignore-names 'test_*,Test*' tasks
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,15 +101,13 @@ RUN cd /tmp/test-infra && \
 # Remove AWS-related deps as we already install AWS CLI v2
 # Remove PyYAML to workaround issues with cpython 3.0.0
 # https://github.com/yaml/pyyaml/issues/724#issuecomment-1638636728
-RUN curl --retry 10 -fsSL https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/requirements.txt | \
+# WORKAROUND: Pining to b468e3cdcbe66e8b8852a29be6c66b03bc08e03d as later changes break the filtering
+RUN curl --retry 10 -fsSL https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/b468e3cdcbe66e8b8852a29be6c66b03bc08e03d/requirements.txt | \
   grep -ivE "boto3|botocore|awscli|urllib3|PyYAML" > requirements-agent.txt && \
   pip3 install "cython<3.0.0" && \
   pip3 install --no-build-isolation PyYAML==5.4.1 && \
   pip3 install -r requirements-agent.txt && \
   go install gotest.tools/gotestsum@latest
-
-# Install go test requirements
-RUN go install gotest.tools/gotestsum@latest
 
 # I think it's safe to say if we're using this mega image, we want pulumi
 ENTRYPOINT ["pulumi"]

--- a/common/utils/remote.go
+++ b/common/utils/remote.go
@@ -5,7 +5,16 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
+const (
+	// We retry every 5s maximum 5 minutes
+	dialTimeoutSeconds int = 5
+	dialErrorLimit     int = 60
+)
+
 func ConfigureRemoteSSH(user, sshKeyPath, sshKeyPassword, sshAgentPath string, conn *remote.ConnectionArgs) error {
+	conn.PerDialTimeout = pulumi.IntPtr(dialTimeoutSeconds)
+	conn.DialErrorLimit = pulumi.IntPtr(dialErrorLimit)
+
 	conn.User = pulumi.StringPtr(user)
 
 	if sshKeyPath != "" {


### PR DESCRIPTION
What does this PR do?
---------------------

With `Command` plugin bumped to `0.9` we can finally control the `Dial` timeout, meaning that we won't get stuck for 2-3 minutes (OS timeout) before retrying SSH connection if the first attempt is made while SSH server is not yet ready.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
