### PR TITLE
[dockerfile] update requirements and jobs order

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,7 +55,7 @@ release-runner-image:
   tags: ["arch:amd64"]
   script:
     - docker pull ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA}
-    - ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA:0:12}
+    - docker tag ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA} ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA:0:12}
     - docker push ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA:0:12}
   rules:
     - if: $CI_COMMIT_BRANCH == "main"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,6 @@ build-runner-image:
   rules:
     - when: on_success
   script:
-    # Tag with 8 and 12 SHA to match go.mod
     - docker buildx build --no-cache --pull --push --label target=build --tag ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA} .
   retry: 2
 
@@ -56,9 +55,8 @@ release-runner-image:
   tags: ["arch:amd64"]
   script:
     - docker pull ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA}
-    - docker tag  ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA} ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA} 
-    - docker tag  ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA} ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA:0:12}
-    - docker push --label target=build ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA:0:12} --tag ${IMAGE_REPOSITORY}:${CI_COMMIT_SHA:0:12}  .
-  only:
-    - main
-  when: on_success
+    - ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA:0:12}
+    - docker push ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA:0:12}
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+      when: on_success

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,14 +1,33 @@
 variables:
-  IMAGE_REPOSITORY: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/test-infra-definitions
+  BUILD_STABLE_REGISTRY: 486234852809.dkr.ecr.us-east-1.amazonaws.com
+  CI_IMAGE_REPO: "ci/${CI_PROJECT_NAME}"
+  CI_REGISTRY_IMAGE: "$BUILD_STABLE_REGISTRY/$CI_IMAGE_REPO/runner"
+  CI_REGISTRY_IMAGE_TEST: "$BUILD_STABLE_REGISTRY/$CI_IMAGE_REPO/runner-dev"
   KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: "test-infra-definitions"
 
 stages:
-  - test
   - build
+  - test
+  - release
+
+
+build-runner-image:
+  stage: build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10.13
+  tags: ["arch:amd64"]
+  variables:
+    RELEASE_IMAGE: "false"
+  rules:
+    - when: on_success
+  script:
+    # Tag with 8 and 12 SHA to match go.mod
+    - docker buildx build --no-cache --pull --push --label target=build --tag ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA} .
+  retry: 2
+
 
 integration-testing:
   stage: test
-  image: $IMAGE_REPOSITORY/runner:8388801b
+  image: ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA}
   tags: ["arch:amd64"]
   before_script:
     # Setup AWS Credentials
@@ -31,21 +50,15 @@ integration-testing:
     KUBERNETES_MEMORY_REQUEST: "6Gi"
     KUBERNETES_MEMORY_LIMIT: "12Gi"
 
-build-runner-image:
-  stage: build
+release-runner-image:
+  stage: release
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10.13
   tags: ["arch:amd64"]
-  variables:
-    PUSH_IMAGE: "false"
-  rules:
-    - if: $CI_COMMIT_BRANCH == "main"
-      variables:
-        PUSH_IMAGE: "true"
-    - when: on_success
   script:
-    - TARGET_REPO="${IMAGE_REPOSITORY}/runner"
-    - if [ "$PUSH_IMAGE" = "true" ]; then PUSH_ARG="--push"; fi
-    # Tag with 8 and 12 SHA to match go.mod
-    - docker buildx build --no-cache --pull $PUSH_ARG --tag ${TARGET_REPO}:${CI_COMMIT_SHORT_SHA} --tag ${TARGET_REPO}:${CI_COMMIT_SHA:0:12}  .
-  retry: 2
-
+    - docker pull ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA}
+    - docker tag  ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA} ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHORT_SHA} 
+    - docker tag  ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA} ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA:0:12}
+    - docker push --label target=build ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA:0:12} --tag ${IMAGE_REPOSITORY}:${CI_COMMIT_SHA:0:12}  .
+  only:
+    - main
+  when: on_success

--- a/Dockerfile
+++ b/Dockerfile
@@ -101,12 +101,9 @@ RUN cd /tmp/test-infra && \
 # Remove AWS-related deps as we already install AWS CLI v2
 # Remove PyYAML to workaround issues with cpython 3.0.0
 # https://github.com/yaml/pyyaml/issues/724#issuecomment-1638636728
-# WORKAROUND: Pining to b468e3cdcbe66e8b8852a29be6c66b03bc08e03d as later changes break the filtering
-RUN curl --retry 10 -fsSL https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/b468e3cdcbe66e8b8852a29be6c66b03bc08e03d/requirements.txt | \
-  grep -ivE "boto3|botocore|awscli|urllib3|PyYAML" > requirements-agent.txt && \
-  pip3 install "cython<3.0.0" && \
+RUN pip3 install "cython<3.0.0" && \
   pip3 install --no-build-isolation PyYAML==5.4.1 && \
-  pip3 install -r requirements-agent.txt && \
+  pip3 install -r https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/requirements/e2e.txt & \
   go install gotest.tools/gotestsum@latest
 
 # I think it's safe to say if we're using this mega image, we want pulumi


### PR DESCRIPTION
What does this PR do?
---------------------

* Use e2e requirements from [buildimages](https://github.com/DataDog/datadog-agent-buildimages/blob/main/requirements/e2e.txt)
* Build the image and publish to a test repo, run integration tests on the test version, push to stable runner on main after tests success

Which scenarios this will impact?
-------------------

None

Motivation
----------

Use e2e python requirements to keep in sync with other agent python requirements, since the image is used by `datadog-agent` pipeline

Run tests on the pipeline image to ensure the image runs fine

Additional Notes
----------------
