### PR TITLE
Fix a panic in `resources/aws/ecs.FargateTaskDefinitionWithAgent`

### DIFF
--- a/resources/aws/ecs/fargateService.go
+++ b/resources/aws/ecs/fargateService.go
@@ -33,8 +33,8 @@ func FargateService(e aws.Environment, name string, clusterArn pulumi.StringInpu
 func FargateTaskDefinitionWithAgent(e aws.Environment, name string, family pulumi.StringInput, containers []*ecs.TaskDefinitionContainerDefinitionArgs, apiKeySSMParamName pulumi.StringInput, fakeintake *ddfakeintake.ConnectionExporter) (*ecs.FargateTaskDefinition, error) {
 	containersMap := make(map[string]ecs.TaskDefinitionContainerDefinitionArgs)
 	for _, c := range containers {
-		// Ugly hack as the implementation of pulumi.StringPtrInput is just `type stringPtr string`
-		containersMap[reflect.ValueOf(c.Name).Elem().String()] = *c
+		// Ugly hack as the implementation of pulumi.StringInput is just `type String string`
+		containersMap[reflect.ValueOf(c.Name).String()] = *c
 	}
 	containersMap["datadog-agent"] = *agent.ECSFargateLinuxContainerDefinition(*e.CommonEnvironment, apiKeySSMParamName, fakeintake, getFirelensLogConfiguration(pulumi.String("datadog-agent"), pulumi.String("datadog-agent"), apiKeySSMParamName))
 	containersMap["log_router"] = *FargateFirelensContainerDefinition()


### PR DESCRIPTION
What does this PR do?
---------------------

Fix a panic 💣 in `resources/aws/ecs.FargateTaskDefinitionWithAgent`:

```
Diagnostics:
  pulumi:pulumi:Stack (dd-lenaic-ecs):
    panic: reflect: call of reflect.Value.Elem on string Value
    goroutine 1 [running]:
    reflect.Value.Elem({0x380b7c0?, 0x46def50?, 0x40fa07?})
        /home/lenaic/.local/go/src/reflect/value.go:1261 +0x1a5
    github.com/DataDog/test-infra-definitions/resources/aws/ecs.FargateTaskDefinitionWithAgent({0xc0004901c0, {0xc000171760, {0xc0006147c0, 0x1, 0x1}}, 0xc000318600, {{{0x433d3f6, 0x9}}, {{0x434a34e, 0x15}, ...}}, ...}, ...)
        /home/lenaic/doc/devel/DataDog/test-infra-definitions/resources/aws/ecs/fargateService.go:37 +0x16e
    github.com/DataDog/test-infra-definitions/scenarios/aws/ecs.Run(0xc000171760)
        /home/lenaic/doc/devel/DataDog/test-infra-definitions/scenarios/aws/ecs/run.go:103 +0xb9a
    main.main.func1(0xc000171760)
        /home/lenaic/doc/devel/DataDog/test-infra-definitions/main.go:39 +0x6cf
    github.com/pulumi/pulumi/sdk/v3/go/pulumi.RunWithContext(0xc000171760, 0x4406b28)
        /home/lenaic/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.83.0/go/pulumi/run.go:121 +0x1aa
    github.com/pulumi/pulumi/sdk/v3/go/pulumi.runErrInner(0xc0000061a0?, 0x4405308, {0x0, 0x0, 0x4086f9?})
        /home/lenaic/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.83.0/go/pulumi/run.go:97 +0x317
    github.com/pulumi/pulumi/sdk/v3/go/pulumi.Run(0x0?, {0x0?, 0x2f7e560?, 0xc0000061a0?})
        /home/lenaic/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.83.0/go/pulumi/run.go:49 +0x2e
    main.main()
        /home/lenaic/doc/devel/DataDog/test-infra-definitions/main.go:22 +0x27

    error: an unhandled error occurred: program exited with non-zero exit code: 2
```

Which scenarios this will impact?
-------------------

* ecs

Motivation
----------

Panicking isn’t great.

Additional Notes
----------------

This panic has been triggered by the change of the `Name` field of the `ecs.TaskDefinitionContainerDefinitionArgs` struct from `StringPtr` to `String` here: https://github.com/pulumi/pulumi-awsx/commit/2a8dbea3188a7419c5ac122d151435ca4387926c#diff-984b248c69cc97c3a12edb4459419dda69b73f5cb543a6e467228fd9ac53c39fR1146