### PR TITLE
Fallback random version, add install workload parameter for EKS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/pulumi/pulumi-eks/sdk v1.0.1
 	github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.30.2
 	github.com/pulumi/pulumi-libvirt/sdk v0.4.0
-	github.com/pulumi/pulumi-random/sdk/v4 v4.14.0
+	github.com/pulumi/pulumi-random/sdk/v4 v4.13.4
 	github.com/pulumi/pulumi/sdk/v3 v3.83.0
 	github.com/samber/lo v1.38.1
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,8 @@ github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.30.2 h1:xJu48+RW+BHHnKtBni6Vj5vKqO
 github.com/pulumi/pulumi-kubernetes/sdk/v3 v3.30.2/go.mod h1:7yCJFC/jnUwFs566f0FAY2iAzc4G1mQP8H6K+40FK4Y=
 github.com/pulumi/pulumi-libvirt/sdk v0.4.0 h1:wq1Ox8FRKQ1kc2DPq3m5DGQgZEhE7kp4mtG556HxJLs=
 github.com/pulumi/pulumi-libvirt/sdk v0.4.0/go.mod h1:tjjyDajp6Pb1pRCdaIugknIfzxw3Prev3o/k2nade+I=
-github.com/pulumi/pulumi-random/sdk/v4 v4.14.0 h1:ljy/gUeur2kZZWL3JPy0J9zLDYKKA0zMd1mT7xrpI7s=
-github.com/pulumi/pulumi-random/sdk/v4 v4.14.0/go.mod h1:XqGATLB6KKuWRDhWvHO6YVwv0DRW/cK/pWzNkuhMB24=
+github.com/pulumi/pulumi-random/sdk/v4 v4.13.4 h1:g3jdktE5L5IDrOw4OiB+yhgxSw0okRPJnyV6PlIzTEQ=
+github.com/pulumi/pulumi-random/sdk/v4 v4.13.4/go.mod h1:cFlJw0eQnqN+62QpITEF9M08gVyzNCeXrKRsuJptFak=
 github.com/pulumi/pulumi/sdk/v3 v3.16.0/go.mod h1:252ou/zAU1g6E8iTwe2Y9ht7pb5BDl2fJlOuAgZCHiA=
 github.com/pulumi/pulumi/sdk/v3 v3.25.0/go.mod h1:VsxW+TGv2VBLe/MeqsAr9r0zKzK/gbAhFT9QxYr24cY=
 github.com/pulumi/pulumi/sdk/v3 v3.36.0/go.mod h1:e1xuPnh9aKzCesrFf96DEzcybLdRWRMhKeKVBmb2lm0=

--- a/tasks/doc.py
+++ b/tasks/doc.py
@@ -1,6 +1,7 @@
 from . import tool
 
 install_agent: str = f"Install the Agent (default {tool.get_default_agent_install()})."
+install_workload: str = f"Install test workload (default {tool.get_default_workload_install()})."
 pipeline_id: str = (
     "The pipeline id of the custom Agent build for example '16497585' (may be taken form the gitlab url)'"
 )

--- a/tasks/eks.py
+++ b/tasks/eks.py
@@ -19,6 +19,7 @@ scenario_name = "aws/eks"
     help={
         "config_path": doc.config_path,
         "install_agent": doc.install_agent,
+        "install_workload": doc.install_workload,
         "agent_version": doc.container_agent_version,
         "stack_name": doc.stack_name,
         "linux_node_group": doc.linux_node_group,
@@ -33,6 +34,7 @@ def create_eks(
     debug: Optional[bool] = False,
     stack_name: Optional[str] = None,
     install_agent: Optional[bool] = True,
+    install_workload: Optional[bool] = True,
     agent_version: Optional[str] = None,
     linux_node_group: bool = True,
     linux_arm_node_group: bool = False,
@@ -48,6 +50,7 @@ def create_eks(
     extra_flags["ddinfra:aws/eks/linuxARMNodeGroup"] = linux_arm_node_group
     extra_flags["ddinfra:aws/eks/linuxBottlerocketNodeGroup"] = bottlerocket_node_group
     extra_flags["ddinfra:aws/eks/windowsNodeGroup"] = windows_node_group
+    extra_flags["ddtestworkload:deploy"] = install_workload
 
     full_stack_name = deploy(
         ctx,

--- a/tasks/tool.py
+++ b/tasks/tool.py
@@ -61,6 +61,10 @@ def get_default_agent_install() -> bool:
     return True
 
 
+def get_default_workload_install() -> bool:
+    return True
+
+
 def get_stack_name(stack_name: Optional[str], scenario_name: str) -> str:
     if stack_name is None:
         stack_name = scenario_name.replace("/", "-")


### PR DESCRIPTION
What does this PR do?
---------------------

`random 4.14` requires `Go 1.21`, which we are not using yet, making `go mod tidy` unhappy.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
