### PR TITLE
Add parameters to set docker registry credentials

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -36,6 +36,9 @@ const (
 	DDAgentFullImagePathParamName        = "fullImagePath"
 	DDClusterAgentVersionParamName       = "clusterAgentVersion"
 	DDClusterAgentFullImagePathParamName = "clusterAgentFullImagePath"
+	DDImagePullRegistryParamName         = "imagePullRegistry"
+	DDImagePullUsernameParamName         = "imagePullUsername"
+	DDImagePullPasswordParamName         = "imagePullPassword"
 	DDAgentAPIKeyParamName               = "apiKey"
 	DDAgentAPPKeyParamName               = "appKey"
 	DDAgentFakeintake                    = "fakeintake"
@@ -166,6 +169,18 @@ func (e *CommonEnvironment) AgentFullImagePath() string {
 
 func (e *CommonEnvironment) ClusterAgentFullImagePath() string {
 	return e.AgentConfig.Get(DDClusterAgentFullImagePathParamName)
+}
+
+func (e *CommonEnvironment) ImagePullRegistry() string {
+	return e.AgentConfig.Get(DDImagePullRegistryParamName)
+}
+
+func (e *CommonEnvironment) ImagePullUsername() string {
+	return e.AgentConfig.Require(DDImagePullUsernameParamName)
+}
+
+func (e *CommonEnvironment) ImagePullPassword() pulumi.StringOutput {
+	return e.AgentConfig.RequireSecret(DDImagePullPasswordParamName)
 }
 
 func (e *CommonEnvironment) AgentAPIKey() pulumi.StringOutput {


### PR DESCRIPTION
What does this PR do?
---------------------

Add new parameters
* `ddagent:imagePullRegistry`
* `ddagent:imagePullUsername`
* `ddagent:imagePullPassword`

to set docker registry credentials.

Which scenarios this will impact?
-------------------

Those based on Helm deployment.

Motivation
----------

Whereas EKS nodes have, by default and out of the box, the credentials to fetch the docker images from the private ECR of the same AWS project, it’s not the case for the kind setup.
The kind testcase is currently failing because all the pods remain in `ImagePullBackoff` because they miss the credentials to fetch the agent docker images from the private ECR registry.

Additional Notes
----------------

https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/