### PR TITLE
Ensure stacks output have the ECS or K8S cluster name

### DIFF
--- a/scenarios/aws/ecs/run.go
+++ b/scenarios/aws/ecs/run.go
@@ -28,6 +28,10 @@ func Run(ctx *pulumi.Context) error {
 		return err
 	}
 
+	// Export cluster’s properties
+	ctx.Export("ecs-cluster-name", ecsCluster.Name)
+	ctx.Export("ecs-cluster-arn", ecsCluster.Arn)
+
 	// Handle capacity providers
 	capacityProviders := pulumi.StringArray{}
 	if awsEnv.ECSFargateCapacityProvider() {
@@ -145,7 +149,5 @@ func Run(ctx *pulumi.Context) error {
 		}
 	}
 
-	ctx.Export("ecs-cluster-name", ecsCluster.Name)
-	ctx.Export("ecs-cluster-arn", ecsCluster.Arn)
 	return nil
 }

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -121,7 +121,8 @@ func Run(ctx *pulumi.Context) error {
 		return err
 	}
 
-	// Export the cluster's kubeconfig.
+	// Export cluster’s properties
+	ctx.Export("eks-cluster-name", cluster.EksCluster.Name())
 	ctx.Export("kubeconfig", cluster.Kubeconfig)
 
 	nodeGroups := make([]pulumi.Resource, 0)

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -122,7 +122,7 @@ func Run(ctx *pulumi.Context) error {
 	}
 
 	// Export cluster’s properties
-	ctx.Export("eks-cluster-name", cluster.EksCluster.Name())
+	ctx.Export("kube-cluster-name", cluster.EksCluster.Name())
 	ctx.Export("kubeconfig", cluster.Kubeconfig)
 
 	nodeGroups := make([]pulumi.Resource, 0)

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -71,7 +71,7 @@ datadog:
 			return err
 		}
 
-		ctx.Export("kind-cluster-name", pulumi.String(ctx.Stack()))
+		ctx.Export("kube-cluster-name", pulumi.String(ctx.Stack()))
 		ctx.Export("agent-linux-helm-install-name", helmComponent.LinuxHelmReleaseName)
 		ctx.Export("agent-linux-helm-install-status", helmComponent.LinuxHelmReleaseStatus)
 

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -30,7 +30,7 @@ func Run(ctx *pulumi.Context) error {
 		return err
 	}
 
-	// Export the cluster's kubeconfig.
+	// Export cluster’s properties
 	ctx.Export("kubeconfig", kubeConfig)
 
 	// Building Kubernetes provider
@@ -71,6 +71,7 @@ datadog:
 			return err
 		}
 
+		ctx.Export("kind-cluster-name", pulumi.String(ctx.Stack()))
 		ctx.Export("agent-linux-helm-install-name", helmComponent.LinuxHelmReleaseName)
 		ctx.Export("agent-linux-helm-install-status", helmComponent.LinuxHelmReleaseStatus)
 


### PR DESCRIPTION
What does this PR do?
---------------------

Ensure stacks output have the ECS or Kubernetes cluster name.

Which scenarios this will impact?
-------------------

ECS, EKS, Kind

Motivation
----------

In the `datadog-agent` CI, I’d like to be able to build URLs to the [E2e tests — containers — ECS](https://dddev.datadoghq.com/dashboard/mnw-tdr-jd8/e2e-tests-containers-ecs) and [E2e tests — containers — K8s](https://dddev.datadoghq.com/dashboard/qcp-brm-ysc/e2e-tests-containers-k8s) dashboards with the template variables  (`ecs_cluster_name` and `kube_cluster_name`) already pre-filled so that the link is “ready-to-click”.

Additional Notes
----------------
