### PR TITLE
Fix the `release-runner-image` CI job and use `crane` instead `docker pull/push`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,9 +54,7 @@ release-runner-image:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10.13
   tags: ["arch:amd64"]
   script:
-    - docker pull ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA}
-    - docker tag ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA} ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA:0:12}
-    - docker push ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA:0:12}
+    - crane copy ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA} ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA:0:12}
   rules:
     - if: $CI_COMMIT_BRANCH == "main"
       when: on_success


### PR DESCRIPTION
What does this PR do?
---------------------

Fix the `release-runner-image` CI job which is currently failing with this error:
```
$ docker pull ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA}
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
```

Which scenarios this will impact?
-------------------

Motivation
----------

The job is currently broken because the docker socket isn’t accessible from a Kubernetes runner.
Using `crane` is also more efficient as we don’t need to complete the download of the full image locally before starting to upload it to its new name.

Additional Notes
----------------

This PR depends on a new image that needs to be mirrored thanks to ~~DataDog/images#4565~~ ~~DataDog/images#4568~~.