### PR TITLE
[CONTINT-3310] Increase the memory for the fake intake to avoid OOM kill

### DIFF
--- a/components/datadog/apps/fakeintake/fargateFakeintakeService.go
+++ b/components/datadog/apps/fakeintake/fargateFakeintakeService.go
@@ -2,6 +2,7 @@ package fakeintake
 
 import (
 	"fmt"
+
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 	ecsClient "github.com/DataDog/test-infra-definitions/resources/aws/ecs"
@@ -109,7 +110,7 @@ func NewECSFargateInstance(e aws.Environment) (*Instance, error) {
 				},
 			},
 			Cpu:    pulumi.StringPtr("256"),
-			Memory: pulumi.StringPtr("512"),
+			Memory: pulumi.StringPtr("1024"),
 			ExecutionRole: &awsx.DefaultRoleWithPolicyArgs{
 				RoleArn: pulumi.StringPtr(e.ECSTaskExecutionRole()),
 			},


### PR DESCRIPTION
What does this PR do?
---------------------

Increase the amount of memory granted to the fake intake.

Which scenarios this will impact?
-------------------

Motivation
----------

On the EKS scenario, the fake intake is almost always close to 100% of memory usage and is OOM killed every 10 or 15 minutes.
![image](https://github.com/DataDog/test-infra-definitions/assets/1437785/e544a5cd-7f89-4e7a-bb0a-85420f08124d)
![image](https://github.com/DataDog/test-infra-definitions/assets/1437785/d3acc7d5-d046-4d64-af24-dac0fbd5b39f)

Additional Notes
----------------
