### PR TITLE
Allow VM to boot with multiple disks

### DIFF
--- a/scenarios/aws/microVMs/microvms/domain.go
+++ b/scenarios/aws/microVMs/microvms/domain.go
@@ -17,7 +17,6 @@ import (
 
 const (
 	dhcpEntriesTemplate = "<host mac='%s' name='%s' ip='%s'/>"
-	sharedFSMountPoint  = "/opt/kernel-version-testing"
 )
 
 func getNextVMIP(ip *net.IP) net.IP {
@@ -108,7 +107,7 @@ func newDomainConfiguration(e *config.CommonEnvironment, cfg domainConfiguration
 	efi := filepath.Join(GetWorkingDirectory(), "efi.fd")
 	domain.RecipeLibvirtDomainArgs.Xls = rc.GetDomainXLS(
 		map[string]pulumi.StringInput{
-			resources.SharedFSMount: pulumi.String(sharedFSMountPoint),
+			resources.SharedFSMount: pulumi.String(sharedFSMountpoint()),
 			resources.DomainID:      pulumi.String(domain.domainID),
 			resources.MACAddress:    domain.mac,
 			resources.Nvram:         pulumi.String(varstore),

--- a/scenarios/aws/microVMs/microvms/domain.go
+++ b/scenarios/aws/microVMs/microvms/domain.go
@@ -147,16 +147,12 @@ func setupDomainVolume(ctx *pulumi.Context, providerFn LibvirtProviderFn, depend
 	return volume, nil
 }
 
-func nextDisk(disk string) string {
-	return fmt.Sprintf("vd%c", rune(int(disk[len(disk)-1])+1))
-}
-
 func getVolumeDiskTarget(isRootVolume bool, lastDisk string) string {
 	if isRootVolume {
-		return resources.VDADisk
+		return "/dev/vda"
 	}
 
-	return nextDisk(lastDisk)
+	return fmt.Sprintf("/dev/vd%c", rune(int(lastDisk[len(lastDisk)-1])+1))
 }
 
 func GenerateDomainConfigurationsForVMSet(e *config.CommonEnvironment, providerFn LibvirtProviderFn, depends []pulumi.Resource, set *vmconfig.VMSet, fs *LibvirtFilesystem) ([]*Domain, error) {
@@ -183,7 +179,7 @@ func GenerateDomainConfigurationsForVMSet(e *config.CommonEnvironment, providerF
 
 				// setup volume to be used by this domain
 				libvirtVolumes := fs.baseVolumeMap[kernel.Tag]
-				lastDisk := resources.VDADisk
+				lastDisk := getVolumeDiskTarget(true, "")
 				for _, vol := range libvirtVolumes {
 					lastDisk = getVolumeDiskTarget(vol.Mountpoint() == RootMountpoint, lastDisk)
 					if vol.Pool().Type() != resources.DefaultPool {

--- a/scenarios/aws/microVMs/microvms/domain.go
+++ b/scenarios/aws/microVMs/microvms/domain.go
@@ -199,7 +199,7 @@ func GenerateDomainConfigurationsForVMSet(e *config.CommonEnvironment, providerF
 						depends,
 						vol.Key(),
 						vol.Pool().Name(),
-						vol.FullResourceName("final-overlay", domain.domainID),
+						vol.FullResourceName("final-overlay", kernel.Tag),
 					)
 					if err != nil {
 						return []*Domain{}, err

--- a/scenarios/aws/microVMs/microvms/domain.go
+++ b/scenarios/aws/microVMs/microvms/domain.go
@@ -167,6 +167,7 @@ func GenerateDomainConfigurationsForVMSet(e *config.CommonEnvironment, provider 
 				if err != nil {
 					return []*Domain{}, err
 				}
+				domain.RecipeLibvirtDomainArgs.Volumes = append(domain.RecipeLibvirtDomainArgs.Volumes, rootVolume)
 
 				domain.domainArgs = domain.RecipeLibvirtDomainArgs.Resources.GetLibvirtDomainArgs(
 					&domain.RecipeLibvirtDomainArgs,

--- a/scenarios/aws/microVMs/microvms/domain.go
+++ b/scenarios/aws/microVMs/microvms/domain.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	dhcpEntriesTemplate = "<host mac='%s' name='%s' ip='%s'/>"
+	sharedFSMountPoint  = "/opt/kernel-version-testing"
 )
 
 func getNextVMIP(ip *net.IP) net.IP {
@@ -107,7 +108,7 @@ func newDomainConfiguration(e *config.CommonEnvironment, cfg domainConfiguration
 	efi := filepath.Join(GetWorkingDirectory(), "efi.fd")
 	domain.RecipeLibvirtDomainArgs.Xls = rc.GetDomainXLS(
 		map[string]pulumi.StringInput{
-			resources.SharedFSMount: pulumi.String(sharedFSMountpoint()),
+			resources.SharedFSMount: pulumi.String(sharedFSMountPoint),
 			resources.DomainID:      pulumi.String(domain.domainID),
 			resources.MACAddress:    domain.mac,
 			resources.Nvram:         pulumi.String(varstore),
@@ -185,7 +186,7 @@ func GenerateDomainConfigurationsForVMSet(e *config.CommonEnvironment, providerF
 						depends,
 						vol.Key(),
 						vol.Pool().Name(),
-						vol.FullResourceName("final-overlay"),
+						vol.FullResourceName("final-overlay", domain.domainID),
 					)
 					if err != nil {
 						return []*Domain{}, err

--- a/scenarios/aws/microVMs/microvms/domain.go
+++ b/scenarios/aws/microVMs/microvms/domain.go
@@ -172,7 +172,7 @@ func GenerateDomainConfigurationsForVMSet(e *config.CommonEnvironment, providerF
 				// setup volume to be used by this domain
 				libvirtVolumes := fs.baseVolumeMap[kernel.Tag]
 				for _, vol := range libvirtVolumes {
-					if vol.Pool().Type() != DefaultPool {
+					if vol.Pool().Type() != resources.DefaultPool {
 						domain.Disks = append(domain.Disks, resources.DomainDisk{
 							VolumeID: pulumi.String(vol.Key()),
 							Attach:   resources.AttachAsFile,

--- a/scenarios/aws/microVMs/microvms/err.go
+++ b/scenarios/aws/microVMs/microvms/err.go
@@ -3,7 +3,7 @@ package microvms
 import "errors"
 
 var (
-	ErrVMSetsNotMapped = errors.New("vmsets must be mapped to collection before building pools.")
+	ErrVMSetsNotMapped = errors.New("vmsets must be mapped to collection before building pools")
 	ErrInvalidPoolSize = errors.New("ram backed pool must have size specified in megabytes or gigabytes with the appropriate suffix 'M' or 'G'")
-	ErrZeroRamDiskSize = errors.New("ram disk size not provided")
+	ErrZeroRAMDiskSize = errors.New("ram disk size not provided")
 )

--- a/scenarios/aws/microVMs/microvms/err.go
+++ b/scenarios/aws/microVMs/microvms/err.go
@@ -1,0 +1,8 @@
+package microvms
+
+import "errors"
+
+var (
+	ErrVMSetsNotMapped = errors.New("vmsets must be mapped to collection before building pools.")
+	ErrInvalidPoolSize = errors.New("ram backed pool must have size specified in megabytes or gigabytes with the appropriate suffix 'M' or 'G'")
+)

--- a/scenarios/aws/microVMs/microvms/err.go
+++ b/scenarios/aws/microVMs/microvms/err.go
@@ -5,4 +5,5 @@ import "errors"
 var (
 	ErrVMSetsNotMapped = errors.New("vmsets must be mapped to collection before building pools.")
 	ErrInvalidPoolSize = errors.New("ram backed pool must have size specified in megabytes or gigabytes with the appropriate suffix 'M' or 'G'")
+	ErrZeroRamDiskSize = errors.New("ram disk size not provided")
 )

--- a/scenarios/aws/microVMs/microvms/libvirt.go
+++ b/scenarios/aws/microVMs/microvms/libvirt.go
@@ -248,20 +248,6 @@ func BuildVMCollections(instances map[string]*Instance, vmsets []vmconfig.VMSet,
 			return vmCollections, waitFor, err
 		}
 		waitFor = append(waitFor, wait...)
-
-		// setup domain sockets for communicating with the domains
-		for _, domain := range collection.domains {
-			createDomainSocketDone, err := buildDomainSocket(collection.instance.runner,
-				domain.domainID,
-				domain.domainNamer.ResourceName("create-domain-socket", domain.domainID),
-				depends,
-			)
-			if err != nil {
-				return vmCollections, waitFor, err
-			}
-			waitFor = append(waitFor, createDomainSocketDone)
-		}
-
 	}
 
 	// map domains to ips

--- a/scenarios/aws/microVMs/microvms/libvirt.go
+++ b/scenarios/aws/microVMs/microvms/libvirt.go
@@ -24,7 +24,6 @@ func libvirtResourceName(identifiers ...string) string {
 }
 
 func libvirtResourceNamer(ctx *pulumi.Context, identifiers ...string) namer.Namer {
-	fmt.Println(identifiers)
 	return namer.NewNamer(ctx, libvirtResourceName(identifiers...))
 }
 

--- a/scenarios/aws/microVMs/microvms/libvirt.go
+++ b/scenarios/aws/microVMs/microvms/libvirt.go
@@ -101,7 +101,6 @@ func (vm *VMCollection) SetupCollectionFilesystems(depends []pulumi.Resource) ([
 			vm.instance.runner,
 			vm.libvirtProviderFn,
 			vm.instance.Arch == LocalVMSet,
-			vm.instance.instanceNamer,
 			depends,
 		)
 		if err != nil {
@@ -250,9 +249,9 @@ func buildCollectionPools(ctx *pulumi.Context, collection *VMCollection) error {
 	for _, v := range collection.vmsets {
 		for _, d := range v.Disks {
 			switch d.Type {
-			case resources.RamPool:
-				if _, ok := collection.pools[resources.RamPool]; !ok {
-					collection.pools[resources.RamPool], err = NewRAMBackedLibvirtPool(ctx, &d)
+			case resources.RAMPool:
+				if _, ok := collection.pools[resources.RAMPool]; !ok {
+					collection.pools[resources.RAMPool], err = NewRAMBackedLibvirtPool(ctx, &d)
 				}
 			default:
 			}

--- a/scenarios/aws/microVMs/microvms/libvirt.go
+++ b/scenarios/aws/microVMs/microvms/libvirt.go
@@ -19,12 +19,13 @@ import (
 
 const domainSocketCreateCmd = `rm -f /tmp/%s.sock && python3 -c "import socket as s; sock = s.socket(s.AF_UNIX); sock.bind('/tmp/%s.sock')"`
 
-func libvirtResourceName(stack, identifier string) string {
-	return fmt.Sprintf("ddvm-%s", identifier)
+func libvirtResourceName(identifiers ...string) string {
+	return strings.Join(identifiers, "-")
 }
 
 func libvirtResourceNamer(ctx *pulumi.Context, identifiers ...string) namer.Namer {
-	return namer.NewNamer(ctx, libvirtResourceName(ctx.Stack(), strings.Join(identifiers, "-")))
+	fmt.Println(identifiers)
+	return namer.NewNamer(ctx, libvirtResourceName(identifiers...))
 }
 
 type LibvirtProviderFn func() (*libvirt.Provider, error)

--- a/scenarios/aws/microVMs/microvms/libvirt.go
+++ b/scenarios/aws/microVMs/microvms/libvirt.go
@@ -252,7 +252,7 @@ func buildCollectionPools(ctx *pulumi.Context, collection *VMCollection) error {
 			switch d.Type {
 			case resources.RamPool:
 				if _, ok := collection.pools[resources.RamPool]; !ok {
-					collection.pools[resources.RamPool], err = NewRamBackedLibvirtPool(ctx, &d)
+					collection.pools[resources.RamPool], err = NewRAMBackedLibvirtPool(ctx, &d)
 				}
 			default:
 			}

--- a/scenarios/aws/microVMs/microvms/libvirt.go
+++ b/scenarios/aws/microVMs/microvms/libvirt.go
@@ -20,7 +20,7 @@ import (
 const domainSocketCreateCmd = `rm -f /tmp/%s.sock && python3 -c "import socket as s; sock = s.socket(s.AF_UNIX); sock.bind('/tmp/%s.sock')"`
 
 func libvirtResourceName(stack, identifier string) string {
-	return fmt.Sprintf("%s-ddvm-%s", stack, identifier)
+	return fmt.Sprintf("ddvm-%s", identifier)
 }
 
 func libvirtResourceNamer(ctx *pulumi.Context, identifiers ...string) namer.Namer {

--- a/scenarios/aws/microVMs/microvms/libvirt.go
+++ b/scenarios/aws/microVMs/microvms/libvirt.go
@@ -104,7 +104,7 @@ func (vm *VMCollection) SetupCollectionFilesystems(depends []pulumi.Resource) ([
 			depends,
 		)
 		if err != nil {
-			return []pulumi.Resource{}, err
+			return nil, err
 		}
 		depends = append(depends, libvirtPoolReady...)
 	}
@@ -112,7 +112,7 @@ func (vm *VMCollection) SetupCollectionFilesystems(depends []pulumi.Resource) ([
 	for _, set := range vm.vmsets {
 		fs, err := newLibvirtFS(vm.instance.e.Ctx, &set, vm.pools)
 		if err != nil {
-			return []pulumi.Resource{}, err
+			return nil, err
 		}
 		vm.fs[set.ID] = fs
 	}
@@ -138,7 +138,7 @@ func (vm *VMCollection) SetupCollectionFilesystems(depends []pulumi.Resource) ([
 	for _, fs := range vm.fs {
 		fsDone, err := fs.SetupLibvirtFilesystem(vm.libvirtProviderFn, vm.instance.runner, depends)
 		if err != nil {
-			return []pulumi.Resource{}, err
+			return nil, err
 		}
 		waitFor = append(waitFor, fsDone...)
 	}
@@ -152,11 +152,11 @@ func (vm *VMCollection) SetupCollectionDomainConfigurations(depends []pulumi.Res
 	for _, set := range vm.vmsets {
 		fs, ok := vm.fs[set.ID]
 		if !ok {
-			return []pulumi.Resource{}, fmt.Errorf("failed to find filesystem for vmset %s", set.ID)
+			return nil, fmt.Errorf("failed to find filesystem for vmset %s", set.ID)
 		}
 		domains, err := GenerateDomainConfigurationsForVMSet(vm.instance.e.CommonEnvironment, vm.libvirtProviderFn, depends, &set, fs)
 		if err != nil {
-			return []pulumi.Resource{}, err
+			return nil, err
 		}
 
 		// Setup individual Nvram disk for arm64 distro images
@@ -173,7 +173,7 @@ func (vm *VMCollection) SetupCollectionDomainConfigurations(depends []pulumi.Res
 					pulumi.DependsOn(depends),
 				)
 				if err != nil {
-					return []pulumi.Resource{}, err
+					return nil, err
 				}
 
 				waitFor = append(waitFor, varstoreDone)

--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -24,10 +24,6 @@ type LibvirtFilesystem struct {
 	isLocal       bool
 }
 
-func rootFSDir() string {
-	return filepath.Join(GetWorkingDirectory(), "rootfs")
-}
-
 // libvirt complains when volume name contains '/'. We replace with '-'
 func fsPathToLibvirtResource(path string) string {
 	return strings.TrimPrefix(strings.ReplaceAll(path, "/", "-"), "-")

--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -51,10 +51,6 @@ func buildVolumeResourceXMLFn(base map[string]pulumi.StringInput, recipe string)
 	}
 }
 
-func getImagePath(base, name string) string {
-	return filepath.Join(base, name)
-}
-
 func isQCOW2(name string) bool {
 	return strings.HasSuffix(name, "qcow2")
 }
@@ -76,7 +72,7 @@ func NewLibvirtFSDistroRecipe(ctx *pulumi.Context, vmset *vmconfig.VMSet, pools 
 	defaultPool := pools[resources.DefaultPool]
 	for _, k := range vmset.Kernels {
 		imageName := defaultPool.Name() + "-" + k.Tag
-		imagePath := getImagePath(filepath.Join(GetWorkingDirectory(), "rootfs"), k.Dir)
+		imagePath := filepath.Join(filepath.Join(GetWorkingDirectory(), "rootfs"), k.Dir)
 		vol := NewLibvirtVolume(
 			defaultPool,
 			filesystemImage{
@@ -145,7 +141,7 @@ func NewLibvirtFSCustomRecipe(ctx *pulumi.Context, vmset *vmconfig.VMSet, pools 
 
 	baseVolumeMap := make(map[string][]LibvirtVolume)
 	imageName := vmset.Img.ImageName
-	path := getImagePath(filepath.Join(GetWorkingDirectory(), "rootfs"), imageName)
+	path := filepath.Join(filepath.Join(GetWorkingDirectory(), "rootfs"), imageName)
 	vol := NewLibvirtVolume(
 		pools[resources.DefaultPool],
 		filesystemImage{

--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -31,9 +31,9 @@ func fsPathToLibvirtResource(path string) string {
 
 // the vmset name deduplicates volume resource name for the same VMs launched in different vmsets
 // the architecture deduplicates volume resource name for the same VMs launched with different archs.
-func getNamer(ctx *pulumi.Context, vmsetNamer, arch string) func(string) namer.Namer {
+func getNamer(ctx *pulumi.Context, vmsetName, arch string) func(string) namer.Namer {
 	return func(volKey string) namer.Namer {
-		return libvirtResourceNamer(ctx, fsPathToLibvirtResource(volKey), vmsetNamer, arch)
+		return libvirtResourceNamer(ctx, fsPathToLibvirtResource(volKey), vmsetName, arch)
 	}
 }
 
@@ -99,7 +99,6 @@ func NewLibvirtFSDistroRecipe(ctx *pulumi.Context, vmset *vmconfig.VMSet, pools 
 		imgName := filepath.Base(strings.TrimPrefix(d.BackingStore, "file://"))
 		imageName := pools[d.Type].Name() + "-" + imgName
 		storePath := strings.TrimPrefix(d.BackingStore, "file://")
-		fmt.Printf("store path: %s\n", storePath)
 		vol := NewLibvirtVolume(
 			pools[d.Type],
 			filesystemImage{
@@ -226,6 +225,7 @@ func refreshFromBackingStore(volume LibvirtVolume, runner *Runner, urlPath strin
 	} else {
 		refreshCmd = fmt.Sprintf(refreshFromEBS, urlPath)
 	}
+	refreshCmd = "true"
 	// We do this because reading the EBS blocks is the only way to download the files
 	// from the backing storage. Not doing this means, that the file is downloaded when
 	// it is first accessed in other commands. This can cause other problems, on top of

--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -13,7 +13,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-const refreshFromEBS = "fio --filename=%s --rw=read --bs=64m --iodepth=32 --ioengine=libaio --direct=1 --name=volume-initialize"
+const (
+	refreshFromEBS = "fio --filename=%s --rw=read --bs=64m --iodepth=32 --ioengine=libaio --direct=1 --name=volume-initialize"
+	RootMountpoint = "/"
+)
 
 type LibvirtFilesystem struct {
 	ctx           *pulumi.Context
@@ -90,6 +93,7 @@ func NewLibvirtFSDistroRecipe(ctx *pulumi.Context, vmset *vmconfig.VMSet, pools 
 				vmset.Recipe,
 			),
 			getNamer(ctx, vmset.Name, vmset.Arch),
+			RootMountpoint,
 		)
 		volumes = append(volumes, vol)
 		baseVolumeMap[k.Tag] = append(baseVolumeMap[k.Tag], vol)
@@ -114,6 +118,7 @@ func NewLibvirtFSDistroRecipe(ctx *pulumi.Context, vmset *vmconfig.VMSet, pools 
 				vmset.Recipe,
 			),
 			getNamer(ctx, vmset.Name, vmset.Arch),
+			d.Mountpoint,
 		)
 
 		// associate extra disks with all vms
@@ -157,6 +162,7 @@ func NewLibvirtFSCustomRecipe(ctx *pulumi.Context, vmset *vmconfig.VMSet, pools 
 			vmset.Recipe,
 		),
 		getNamer(ctx, vmset.Name, vmset.Arch),
+		RootMountpoint,
 	)
 	volumes = append(volumes, vol)
 
@@ -183,6 +189,7 @@ func NewLibvirtFSCustomRecipe(ctx *pulumi.Context, vmset *vmconfig.VMSet, pools 
 				vmset.Recipe,
 			),
 			getNamer(ctx, vmset.Name, vmset.Arch),
+			d.Mountpoint,
 		)
 
 		// associate extra disks with all vms

--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -87,13 +87,13 @@ func NewLibvirtFSDistroRecipe(ctx *pulumi.Context, vmset *vmconfig.VMSet, pools 
 			pools[d.Type],
 			filesystemImage{
 				imageName:   imageName,
-				imagePath:   getImagePath(storePath, imageName),
+				imagePath:   storePath,
 				imageSource: d.BackingStore,
 			},
 			buildVolumeResourceXMLFn(
 				map[string]pulumi.StringInput{
 					resources.ImageName: pulumi.String(imageName),
-					resources.ImagePath: pulumi.String(getImagePath(storePath, imageName)),
+					resources.ImagePath: pulumi.String(storePath),
 				},
 				vmset.Recipe,
 			),
@@ -153,13 +153,13 @@ func NewLibvirtFSCustomRecipe(ctx *pulumi.Context, vmset *vmconfig.VMSet, pools 
 			pools[d.Type],
 			filesystemImage{
 				imageName:   imageName,
-				imagePath:   getImagePath(storePath, imageName),
+				imagePath:   storePath,
 				imageSource: d.BackingStore,
 			},
 			buildVolumeResourceXMLFn(
 				map[string]pulumi.StringInput{
 					resources.ImageName: pulumi.String(imageName),
-					resources.ImagePath: pulumi.String(getImagePath(storePath, imageName)),
+					resources.ImagePath: pulumi.String(storePath),
 				},
 				vmset.Recipe,
 			),

--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -96,21 +96,20 @@ func NewLibvirtFSDistroRecipe(ctx *pulumi.Context, vmset *vmconfig.VMSet, pools 
 	}
 
 	for _, d := range vmset.Disks {
-		imgName := filepath.Base(strings.TrimPrefix(d.BackingStore, "file://"))
+		imgName := filepath.Base(d.Target)
 		imageName := pools[d.Type].Name() + "-" + imgName
-		storePath := strings.TrimPrefix(d.BackingStore, "file://")
 		vol := NewLibvirtVolume(
 			pools[d.Type],
 			filesystemImage{
 				imageName:   imageName,
-				imagePath:   storePath,
+				imagePath:   d.Target,
 				imageSource: d.BackingStore,
 			},
 			buildVolumeResourceXMLFn(
 				map[string]pulumi.StringInput{
 					resources.ImageName: pulumi.String(imageName),
-					resources.ImagePath: pulumi.String(storePath),
-					resources.Format:    pulumi.String(format(storePath)),
+					resources.ImagePath: pulumi.String(d.Target),
+					resources.Format:    pulumi.String(format(imageName)),
 				},
 				vmset.Recipe,
 			),
@@ -166,20 +165,19 @@ func NewLibvirtFSCustomRecipe(ctx *pulumi.Context, vmset *vmconfig.VMSet, pools 
 	}
 
 	for _, d := range vmset.Disks {
-		imgName := filepath.Base(strings.TrimPrefix(d.BackingStore, "file://"))
+		imgName := filepath.Base(d.Target)
 		imageName := pools[d.Type].Name() + "-" + imgName
-		storePath := strings.TrimPrefix(d.BackingStore, "file://")
 		vol := NewLibvirtVolume(
 			pools[d.Type],
 			filesystemImage{
 				imageName:   imageName,
-				imagePath:   storePath,
+				imagePath:   d.Target,
 				imageSource: d.BackingStore,
 			},
 			buildVolumeResourceXMLFn(
 				map[string]pulumi.StringInput{
 					resources.ImageName: pulumi.String(imageName),
-					resources.ImagePath: pulumi.String(storePath),
+					resources.ImagePath: pulumi.String(d.Target),
 					resources.Format:    pulumi.String(format(imageName)),
 				},
 				vmset.Recipe,

--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -81,7 +81,8 @@ func NewLibvirtFSDistroRecipe(ctx *pulumi.Context, vmset *vmconfig.VMSet, pools 
 	}
 
 	for _, d := range vmset.Disks {
-		imageName := d.ImageName
+		imgName := filepath.Base(strings.TrimPrefix(d.BackingStore, "file://"))
+		imageName := pools[d.Type].Name() + "-" + imgName
 		storePath := strings.TrimPrefix(d.BackingStore, "file://")
 		vol := NewLibvirtVolume(
 			pools[d.Type],
@@ -147,7 +148,8 @@ func NewLibvirtFSCustomRecipe(ctx *pulumi.Context, vmset *vmconfig.VMSet, pools 
 	}
 
 	for _, d := range vmset.Disks {
-		imageName := pools[d.Type].Name() + "-" + d.ImageName
+		imgName := filepath.Base(strings.TrimPrefix(d.BackingStore, "file://"))
+		imageName := pools[d.Type].Name() + "-" + imgName
 		storePath := strings.TrimPrefix(d.BackingStore, "file://")
 		vol := NewLibvirtVolume(
 			pools[d.Type],

--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	refreshFromEBS = "fio --filename=%s --rw=read --bs=64m --iodepth=32 --ioengine=libaio --direct=1 --name=volume-initialize"
-	RootMountpoint = "/"
+	refreshFromEBS   = "fio --filename=%s --rw=read --bs=64m --iodepth=32 --ioengine=libaio --direct=1 --name=volume-initialize"
+	RootMountpoint   = "/"
+	DockerMountpoint = "/mnt/docker"
 )
 
 type LibvirtFilesystem struct {

--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -248,7 +248,7 @@ func refreshFromBackingStore(volume LibvirtVolume, runner *Runner, urlPath strin
 
 	res, err := runner.Command(volume.FullResourceName("download-rootfs"), &downloadRootfsArgs, pulumi.DependsOn(depends))
 	if err != nil {
-		return []pulumi.Resource{}, err
+		return nil, err
 	}
 
 	return []pulumi.Resource{res}, err
@@ -271,7 +271,7 @@ func downloadRootfs(fs *LibvirtFilesystem, runner *Runner, depends []pulumi.Reso
 		fsImage := volume.UnderlyingImage()
 		url, err := url.Parse(fsImage.imageSource)
 		if err != nil {
-			return []pulumi.Resource{}, fmt.Errorf("error parsing url %s: %w", fsImage.imageSource, err)
+			return nil, fmt.Errorf("error parsing url %s: %w", fsImage.imageSource, err)
 		}
 
 		if url.Scheme == "file" {
@@ -325,9 +325,9 @@ func (fs *LibvirtFilesystem) SetupLibvirtFilesystem(providerFn LibvirtProviderFn
 	//
 	// [IMPORTANT] The download may start as the first step. So if the setup changes such that the download
 	// becomes dependent on some prior step, this call should change !!
-	downloadRootfsDone, err := downloadRootfs(fs, runner, []pulumi.Resource{})
+	downloadRootfsDone, err := downloadRootfs(fs, runner, nil)
 	if err != nil {
-		return []pulumi.Resource{}, err
+		return nil, err
 	}
 
 	depends = append(depends, downloadRootfsDone...)
@@ -339,7 +339,7 @@ func setupLibvirtFilesystem(fs *LibvirtFilesystem, runner *Runner, providerFn Li
 	for _, vol := range fs.volumes {
 		setupLibvirtVMVolumeDone, err := vol.SetupLibvirtVMVolume(fs.ctx, runner, providerFn, fs.isLocal, depends)
 		if err != nil {
-			return []pulumi.Resource{}, err
+			return nil, err
 		}
 
 		waitFor = append(waitFor, setupLibvirtVMVolumeDone)

--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -14,9 +14,8 @@ import (
 )
 
 const (
-	refreshFromEBS   = "fio --filename=%s --rw=read --bs=64m --iodepth=32 --ioengine=libaio --direct=1 --name=volume-initialize"
-	RootMountpoint   = "/"
-	DockerMountpoint = "/mnt/docker"
+	refreshFromEBS = "fio --filename=%s --rw=read --bs=64m --iodepth=32 --ioengine=libaio --direct=1 --name=volume-initialize"
+	RootMountpoint = "/"
 )
 
 type LibvirtFilesystem struct {

--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -55,8 +55,6 @@ func NewLibvirtFSDistroRecipe(ctx *pulumi.Context, vmset *vmconfig.VMSet, pool L
 	baseVolumeMap := make(map[string]LibvirtVolume)
 	for _, k := range vmset.Kernels {
 		imageName := pool.Name() + "-" + k.Tag
-		fmt.Println(k.Tag)
-		fmt.Println(imageName)
 		vol := NewLibvirtVolume(
 			pool,
 			filesystemImage{

--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -225,7 +225,7 @@ func refreshFromBackingStore(volume LibvirtVolume, runner *Runner, urlPath strin
 	} else {
 		refreshCmd = fmt.Sprintf(refreshFromEBS, urlPath)
 	}
-	refreshCmd = "true"
+
 	// We do this because reading the EBS blocks is the only way to download the files
 	// from the backing storage. Not doing this means, that the file is downloaded when
 	// it is first accessed in other commands. This can cause other problems, on top of

--- a/scenarios/aws/microVMs/microvms/network.go
+++ b/scenarios/aws/microVMs/microvms/network.go
@@ -137,6 +137,8 @@ func generateNetworkResource(ctx *pulumi.Context, providerFn LibvirtProviderFn, 
 	network, err := libvirt.NewNetwork(ctx, resourceNamer.ResourceName("network"), &libvirt.NetworkArgs{
 		Addresses: pulumi.StringArray{pulumi.String(microVMGroupSubnet)},
 		Mode:      pulumi.String("nat"),
+		// enable jumbo frames for the underlying interface. This is an optimization for NFS.
+		Mtu: pulumi.Int(9000),
 		Xml: libvirt.NetworkXmlArgs{
 			Xslt: netXML,
 		},

--- a/scenarios/aws/microVMs/microvms/network.go
+++ b/scenarios/aws/microVMs/microvms/network.go
@@ -91,7 +91,7 @@ func allowNFSPortsForBridge(ctx *pulumi.Context, isLocal bool, bridge pulumi.Str
 	}
 	iptablesAllowTCPDone, err := runner.Command(resourceNamer.ResourceName("allow-nfs-ports-tcp"), &iptablesAllowTCPArgs)
 	if err != nil {
-		return []pulumi.Resource{}, err
+		return nil, err
 	}
 
 	iptablesAllowUDPArgs := command.Args{
@@ -103,7 +103,7 @@ func allowNFSPortsForBridge(ctx *pulumi.Context, isLocal bool, bridge pulumi.Str
 	}
 	iptablesAllowUDPDone, err := runner.Command(resourceNamer.ResourceName("allow-nfs-ports-udp"), &iptablesAllowUDPArgs)
 	if err != nil {
-		return []pulumi.Resource{}, err
+		return nil, err
 	}
 
 	return []pulumi.Resource{iptablesAllowTCPDone, iptablesAllowUDPDone}, nil

--- a/scenarios/aws/microVMs/microvms/network.go
+++ b/scenarios/aws/microVMs/microvms/network.go
@@ -137,8 +137,6 @@ func generateNetworkResource(ctx *pulumi.Context, providerFn LibvirtProviderFn, 
 	network, err := libvirt.NewNetwork(ctx, resourceNamer.ResourceName("network"), &libvirt.NetworkArgs{
 		Addresses: pulumi.StringArray{pulumi.String(microVMGroupSubnet)},
 		Mode:      pulumi.String("nat"),
-		// enable jumbo frames for the underlying interface. This is an optimization for NFS.
-		Mtu: pulumi.Int(9000),
 		Xml: libvirt.NetworkXmlArgs{
 			Xslt: netXML,
 		},

--- a/scenarios/aws/microVMs/microvms/pool.go
+++ b/scenarios/aws/microVMs/microvms/pool.go
@@ -201,7 +201,6 @@ func NewRAMBackedLibvirtPool(ctx *pulumi.Context, disk *vmconfig.Disk) (LibvirtP
 }
 
 func (p *rambackedLibvirtPool) SetupLibvirtPool(ctx *pulumi.Context, runner *Runner, providerFn LibvirtProviderFn, isLocal bool, namer namer.Namer, depends []pulumi.Resource) ([]pulumi.Resource, error) {
-	fmt.Printf("p.baseImagePath: %s\n", p.baseImagePath)
 	buildSharedDiskInRamfsArgs := command.Args{
 		Create: pulumi.Sprintf(sharedDiskCmd, p.poolPath, p.poolSize, p.baseImagePath),
 		Delete: pulumi.Sprintf("umount %[1]s && rm -r %[1]s", p.poolPath),

--- a/scenarios/aws/microVMs/microvms/pool.go
+++ b/scenarios/aws/microVMs/microvms/pool.go
@@ -14,7 +14,7 @@ import (
 )
 
 type LibvirtPool interface {
-	SetupLibvirtPool(ctx *pulumi.Context, runner *Runner, providerFn LibvirtProviderFn, isLocal bool, namer namer.Namer, depends []pulumi.Resource) ([]pulumi.Resource, error)
+	SetupLibvirtPool(ctx *pulumi.Context, runner *Runner, providerFn LibvirtProviderFn, isLocal bool, depends []pulumi.Resource) ([]pulumi.Resource, error)
 	Name() string
 	Type() vmconfig.PoolType
 	Path() string
@@ -139,7 +139,7 @@ func localGlobalPool(ctx *pulumi.Context, p *globalLibvirtPool, providerFn Libvi
 	return []pulumi.Resource{poolReady}, nil
 }
 
-func (p *globalLibvirtPool) SetupLibvirtPool(ctx *pulumi.Context, runner *Runner, providerFn LibvirtProviderFn, isLocal bool, namer namer.Namer, depends []pulumi.Resource) ([]pulumi.Resource, error) {
+func (p *globalLibvirtPool) SetupLibvirtPool(ctx *pulumi.Context, runner *Runner, providerFn LibvirtProviderFn, isLocal bool, depends []pulumi.Resource) ([]pulumi.Resource, error) {
 	if isLocal {
 		return localGlobalPool(ctx, p, providerFn, depends)
 	}
@@ -193,14 +193,14 @@ func NewRAMBackedLibvirtPool(ctx *pulumi.Context, disk *vmconfig.Disk) (LibvirtP
 	return &rambackedLibvirtPool{
 		poolName:      poolName,
 		poolNamer:     libvirtResourceNamer(ctx, poolName),
-		poolType:      resources.RamPool,
+		poolType:      resources.RAMPool,
 		poolPath:      poolPath,
 		poolSize:      disk.Size,
 		baseImagePath: baseImagePath,
 	}, nil
 }
 
-func (p *rambackedLibvirtPool) SetupLibvirtPool(ctx *pulumi.Context, runner *Runner, providerFn LibvirtProviderFn, isLocal bool, namer namer.Namer, depends []pulumi.Resource) ([]pulumi.Resource, error) {
+func (p *rambackedLibvirtPool) SetupLibvirtPool(ctx *pulumi.Context, runner *Runner, providerFn LibvirtProviderFn, isLocal bool, depends []pulumi.Resource) ([]pulumi.Resource, error) {
 	buildSharedDiskInRamfsArgs := command.Args{
 		Create: pulumi.Sprintf(sharedDiskCmd, p.poolPath, p.poolSize, p.baseImagePath),
 		Delete: pulumi.Sprintf("umount %[1]s && rm -r %[1]s", p.poolPath),
@@ -217,7 +217,7 @@ func (p *rambackedLibvirtPool) SetupLibvirtPool(ctx *pulumi.Context, runner *Run
 		return []pulumi.Resource{}, err
 	}
 
-	poolReady, err := libvirt.NewPool(ctx, namer.ResourceName("create-libvirt-ram-pool"), &libvirt.PoolArgs{
+	poolReady, err := libvirt.NewPool(ctx, p.poolNamer.ResourceName("create-libvirt-ram-pool"), &libvirt.PoolArgs{
 		Type: pulumi.String("dir"),
 		Name: pulumi.String(p.poolName),
 		Path: pulumi.String(p.poolPath),

--- a/scenarios/aws/microVMs/microvms/pool.go
+++ b/scenarios/aws/microVMs/microvms/pool.go
@@ -74,7 +74,7 @@ func remoteGlobalPool(p *globalLibvirtPool, runner *Runner, depends []pulumi.Res
 	}
 	poolXMLWritten, err := runner.Command(p.poolNamer.ResourceName("write-pool-xml"), &poolXMLWrittenArgs, pulumi.DependsOn(depends))
 	if err != nil {
-		return []pulumi.Resource{}, err
+		return nil, err
 	}
 	depends = append(depends, poolXMLWritten)
 
@@ -100,22 +100,22 @@ func remoteGlobalPool(p *globalLibvirtPool, runner *Runner, depends []pulumi.Res
 
 	poolDefineReady, err := runner.Command(p.poolNamer.ResourceName("define-libvirt-pool"), &poolDefineReadyArgs, pulumi.DependsOn(depends))
 	if err != nil {
-		return []pulumi.Resource{}, err
+		return nil, err
 	}
 
 	poolBuildReady, err := runner.Command(p.poolNamer.ResourceName("build-libvirt-pool"), &poolBuildReadyArgs, pulumi.DependsOn([]pulumi.Resource{poolDefineReady}))
 	if err != nil {
-		return []pulumi.Resource{}, err
+		return nil, err
 	}
 
 	poolStartReady, err := runner.Command(p.poolNamer.ResourceName("start-libvirt-pool"), &poolStartReadyArgs, pulumi.DependsOn([]pulumi.Resource{poolBuildReady}))
 	if err != nil {
-		return []pulumi.Resource{}, err
+		return nil, err
 	}
 
 	poolRefreshDone, err := runner.Command(p.poolNamer.ResourceName("refresh-libvirt-pool"), &poolRefreshDoneArgs, pulumi.DependsOn([]pulumi.Resource{poolStartReady}))
 	if err != nil {
-		return []pulumi.Resource{}, err
+		return nil, err
 	}
 
 	return []pulumi.Resource{poolRefreshDone}, nil
@@ -124,7 +124,7 @@ func remoteGlobalPool(p *globalLibvirtPool, runner *Runner, depends []pulumi.Res
 func localGlobalPool(ctx *pulumi.Context, p *globalLibvirtPool, providerFn LibvirtProviderFn, depends []pulumi.Resource) ([]pulumi.Resource, error) {
 	provider, err := providerFn()
 	if err != nil {
-		return []pulumi.Resource{}, err
+		return nil, err
 	}
 
 	poolReady, err := libvirt.NewPool(ctx, "create-libvirt-pool", &libvirt.PoolArgs{
@@ -133,7 +133,7 @@ func localGlobalPool(ctx *pulumi.Context, p *globalLibvirtPool, providerFn Libvi
 		Path: pulumi.String(p.poolPath),
 	}, pulumi.Provider(provider), pulumi.DependsOn(depends))
 	if err != nil {
-		return []pulumi.Resource{}, err
+		return nil, err
 	}
 
 	return []pulumi.Resource{poolReady}, nil
@@ -209,12 +209,12 @@ func (p *rambackedLibvirtPool) SetupLibvirtPool(ctx *pulumi.Context, runner *Run
 
 	buildSharedDiskInRamfsDone, err := runner.Command("build-shared-disk", &buildSharedDiskInRamfsArgs, pulumi.DependsOn(depends))
 	if err != nil {
-		return []pulumi.Resource{}, err
+		return nil, err
 	}
 
 	provider, err := providerFn()
 	if err != nil {
-		return []pulumi.Resource{}, err
+		return nil, err
 	}
 
 	poolReady, err := libvirt.NewPool(ctx, p.poolNamer.ResourceName("create-libvirt-ram-pool"), &libvirt.PoolArgs{
@@ -223,7 +223,7 @@ func (p *rambackedLibvirtPool) SetupLibvirtPool(ctx *pulumi.Context, runner *Run
 		Path: pulumi.String(p.poolPath),
 	}, pulumi.Provider(provider), pulumi.DependsOn([]pulumi.Resource{buildSharedDiskInRamfsDone}))
 	if err != nil {
-		return []pulumi.Resource{}, err
+		return nil, err
 	}
 	return []pulumi.Resource{poolReady}, nil
 }

--- a/scenarios/aws/microVMs/microvms/pool.go
+++ b/scenarios/aws/microVMs/microvms/pool.go
@@ -161,8 +161,6 @@ func (p *globalLibvirtPool) Path() string {
 
 type rambackedLibvirtPool struct {
 	poolName      string
-	poolXML       pulumi.StringOutput
-	poolXMLPath   string
 	poolNamer     namer.Namer
 	poolType      vmconfig.PoolType
 	poolPath      string
@@ -179,13 +177,13 @@ mkfs.ext4 -F %[3]s' && \
 sudo mount -o exec,loop %[3]s %[1]s/deps && cd %[1]s/deps && sudo touch win.123 && cd %[1]s && sudo umount %[1]s/deps \
 `
 
-func NewRamBackedLibvirtPool(ctx *pulumi.Context, disk *vmconfig.Disk) (LibvirtPool, error) {
+func NewRAMBackedLibvirtPool(ctx *pulumi.Context, disk *vmconfig.Disk) (LibvirtPool, error) {
 	poolName := libvirtResourceName(ctx.Stack(), "ram-pool")
 	baseImagePath := strings.TrimPrefix(disk.BackingStore, "file://")
 	poolPath := filepath.Dir(baseImagePath)
 
 	if disk.Size == "" {
-		return nil, ErrZeroRamDiskSize
+		return nil, ErrZeroRAMDiskSize
 	}
 
 	if !(strings.HasSuffix(disk.Size, "G") || strings.HasSuffix(disk.Size, "M")) {

--- a/scenarios/aws/microVMs/microvms/pool.go
+++ b/scenarios/aws/microVMs/microvms/pool.go
@@ -1,0 +1,142 @@
+package microvms
+
+import (
+	"fmt"
+
+	"github.com/DataDog/test-infra-definitions/common/namer"
+	"github.com/DataDog/test-infra-definitions/components/command"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/microVMs/microvms/resources"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/microVMs/vmconfig"
+	"github.com/pulumi/pulumi-libvirt/sdk/go/libvirt"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+type LibvirtPool interface {
+	SetupLibvirtPool(ctx *pulumi.Context, runner *Runner, providerFn LibvirtProviderFn, isLocal bool, depends []pulumi.Resource) ([]pulumi.Resource, error)
+	Name() string
+}
+
+type globalLibvirtPool struct {
+	poolName    string
+	poolXML     pulumi.StringOutput
+	poolXMLPath string
+	poolNamer   namer.Namer
+}
+
+//func generateRamBackedPool() (map[string]pulumi.StringInput, string) {
+//	poolName := libvirtResourceName(ctx.Stack(), "ram-pool")
+//	return generatePool(poolName, generateRamPoolPath()), poolName
+//}
+
+func generateGlobalPoolPath(name string) string {
+	return fmt.Sprintf("%s/libvirt/pools/%s", GetWorkingDirectory(), name)
+}
+
+func generateRamPoolPath() string {
+	return fmt.Sprintf("%s/kmt-ramfs/", GetWorkingDirectory())
+}
+
+func NewGlobalLibvirtPool(ctx *pulumi.Context) LibvirtPool {
+	poolName := libvirtResourceName(ctx.Stack(), "global-pool")
+	rc := resources.NewResourceCollection(vmconfig.RecipeDefault)
+	poolXML := rc.GetPoolXML(
+		map[string]pulumi.StringInput{
+			resources.PoolName: pulumi.String(poolName),
+			resources.PoolPath: pulumi.String(generateGlobalPoolPath(poolName)),
+		},
+	)
+
+	return &globalLibvirtPool{
+		poolName:    poolName,
+		poolXML:     poolXML,
+		poolXMLPath: fmt.Sprintf("/tmp/pool-%s.tmp", poolName),
+		poolNamer:   libvirtResourceNamer(ctx, poolName),
+	}
+}
+
+/*
+Setup for remote pool and local pool is different for a number of reasons:
+  - Libvirt pools and volumes on remote machines are setup using the virsh cli tool. This is because
+    the pulumi-libvirt sdk always uploads the base volume image from the host (where pulumi runs) to the
+    remote machine (where the micro-vms are setup).
+    This is too inefficient for us. We would like for it to assume the images are already present on the remote
+    machine. Therefore we create volumes using the virsh cli and we have to create the pools in the same way
+    since we cannot pass the `pool` object, returned by the pulumi-libvirt api,  around in remote commands.
+  - On the remote machine all commands are run with 'sudo' to simplify permission issues;
+    we do not want to do this on the local machine. For local machines the pulumi-libvirt API works fine, since
+    the target environment and the pulumi host are the same machine. It is simpler to use this API locally than
+    have a complicated permissions setup.
+*/
+func remoteGlobalPool(p *globalLibvirtPool, runner *Runner, depends []pulumi.Resource) ([]pulumi.Resource, error) {
+	poolBuildReadyArgs := command.Args{
+		Create: pulumi.Sprintf("virsh pool-build %s", p.poolName),
+		Delete: pulumi.Sprintf("virsh pool-delete %s", p.poolName),
+		Sudo:   true,
+	}
+	poolStartReadyArgs := command.Args{
+		Create: pulumi.Sprintf("virsh pool-start %s", p.poolName),
+		Delete: pulumi.Sprintf("virsh pool-destroy %s", p.poolName),
+		Sudo:   true,
+	}
+	poolRefreshDoneArgs := command.Args{
+		Create: pulumi.Sprintf("virsh pool-refresh %s", p.poolName),
+		Sudo:   true,
+	}
+
+	poolDefineReadyArgs := command.Args{
+		Create: pulumi.Sprintf("virsh pool-define %s", p.poolXMLPath),
+		Sudo:   true,
+	}
+
+	poolDefineReady, err := runner.Command(p.poolNamer.ResourceName("define-libvirt-pool"), &poolDefineReadyArgs, pulumi.DependsOn(depends))
+	if err != nil {
+		return []pulumi.Resource{}, err
+	}
+
+	poolBuildReady, err := runner.Command(p.poolNamer.ResourceName("build-libvirt-pool"), &poolBuildReadyArgs, pulumi.DependsOn([]pulumi.Resource{poolDefineReady}))
+	if err != nil {
+		return []pulumi.Resource{}, err
+	}
+
+	poolStartReady, err := runner.Command(p.poolNamer.ResourceName("start-libvirt-pool"), &poolStartReadyArgs, pulumi.DependsOn([]pulumi.Resource{poolBuildReady}))
+	if err != nil {
+		return []pulumi.Resource{}, err
+	}
+
+	poolRefreshDone, err := runner.Command(p.poolNamer.ResourceName("refresh-libvirt-pool"), &poolRefreshDoneArgs, pulumi.DependsOn([]pulumi.Resource{poolStartReady}))
+	if err != nil {
+		return []pulumi.Resource{}, err
+	}
+
+	return []pulumi.Resource{poolRefreshDone}, nil
+}
+
+func localGlobalPool(ctx *pulumi.Context, p *globalLibvirtPool, providerFn LibvirtProviderFn, depends []pulumi.Resource) ([]pulumi.Resource, error) {
+	provider, err := providerFn()
+	if err != nil {
+		return []pulumi.Resource{}, err
+	}
+
+	poolReady, err := libvirt.NewPool(ctx, "create-libvirt-pool", &libvirt.PoolArgs{
+		Type: pulumi.String("dir"),
+		Name: pulumi.String(p.poolName),
+		Path: pulumi.String(generateGlobalPoolPath(p.poolName)),
+	}, pulumi.Provider(provider), pulumi.DependsOn(depends))
+	if err != nil {
+		return []pulumi.Resource{}, err
+	}
+
+	return []pulumi.Resource{poolReady}, nil
+}
+
+func (p *globalLibvirtPool) SetupLibvirtPool(ctx *pulumi.Context, runner *Runner, providerFn LibvirtProviderFn, isLocal bool, depends []pulumi.Resource) ([]pulumi.Resource, error) {
+	if isLocal {
+		return localGlobalPool(ctx, p, providerFn, depends)
+	}
+
+	return remoteGlobalPool(p, runner, depends)
+}
+
+func (p *globalLibvirtPool) Name() string {
+	return p.poolName
+}

--- a/scenarios/aws/microVMs/microvms/pool.go
+++ b/scenarios/aws/microVMs/microvms/pool.go
@@ -68,6 +68,16 @@ Setup for remote pool and local pool is different for a number of reasons:
     have a complicated permissions setup.
 */
 func remoteGlobalPool(p *globalLibvirtPool, runner *Runner, depends []pulumi.Resource) ([]pulumi.Resource, error) {
+	poolXMLWrittenArgs := command.Args{
+		Create: pulumi.Sprintf("echo \"%s\" > %s", p.poolXML, p.poolXMLPath),
+		Delete: pulumi.Sprintf("rm -f %s", p.poolXMLPath),
+	}
+	poolXMLWritten, err := runner.Command(p.poolNamer.ResourceName("write-pool-xml"), &poolXMLWrittenArgs, pulumi.DependsOn(depends))
+	if err != nil {
+		return []pulumi.Resource{}, err
+	}
+	depends = append(depends, poolXMLWritten)
+
 	poolBuildReadyArgs := command.Args{
 		Create: pulumi.Sprintf("virsh pool-build %s", p.poolName),
 		Delete: pulumi.Sprintf("virsh pool-delete %s", p.poolName),

--- a/scenarios/aws/microVMs/microvms/provision.go
+++ b/scenarios/aws/microVMs/microvms/provision.go
@@ -83,7 +83,7 @@ func reloadSSHD(runner *Runner, depends []pulumi.Resource) ([]pulumi.Resource, e
 }
 
 // This function provisions the metal instance for setting up libvirt based micro-vms.
-func provisionInstance(instance *Instance) ([]pulumi.Resource, error) {
+func provisionMetalInstance(instance *Instance) ([]pulumi.Resource, error) {
 	if instance.Arch == LocalVMSet {
 		return nil, nil
 	}

--- a/scenarios/aws/microVMs/microvms/provision.go
+++ b/scenarios/aws/microVMs/microvms/provision.go
@@ -11,6 +11,8 @@ import (
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/microVMs/microvms/resources"
 )
 
+const DockerMountpoint = "/mnt/docker"
+
 var initSudoPassword sync.Once
 var SudoPasswordLocal pulumi.StringOutput
 var SudoPasswordRemote pulumi.StringOutput

--- a/scenarios/aws/microVMs/microvms/provision.go
+++ b/scenarios/aws/microVMs/microvms/provision.go
@@ -84,13 +84,11 @@ func reloadSSHD(runner *Runner, depends []pulumi.Resource) ([]pulumi.Resource, e
 
 // This function provisions the metal instance for setting up libvirt based micro-vms.
 func provisionInstance(instance *Instance) ([]pulumi.Resource, error) {
-	runner := instance.runner
-
 	if instance.Arch == LocalVMSet {
 		return nil, nil
 	}
 
-	allowEnvDone, err := setupSSHAllowEnv(instance.runner, sharedDiskDone)
+	allowEnvDone, err := setupSSHAllowEnv(instance.runner, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/scenarios/aws/microVMs/microvms/provision.go
+++ b/scenarios/aws/microVMs/microvms/provision.go
@@ -117,7 +117,7 @@ func setDockerDataRoot(runner *Runner, disks []resources.DomainDisk, namer namer
 		}
 
 		args := command.Args{
-			Create: pulumi.Sprintf("sh -c 'systemctl stop docker && echo '{}' | jq -n '. += {\"data-root\":\"/mnt/docker\"}' > /etc/docker/daemon.json && systemctl start docker'", d.Mountpoint),
+			Create: pulumi.Sprintf("sh -c 'systemctl stop docker && echo '{}' | jq -n '. += {\"data-root\":\"%s\"}' > /etc/docker/daemon.json && systemctl start docker'", d.Mountpoint),
 			Sudo:   true,
 		}
 		done, err := runner.Command(namer.ResourceName("set-docker-data-root"), &args, pulumi.DependsOn(depends))

--- a/scenarios/aws/microVMs/microvms/provision.go
+++ b/scenarios/aws/microVMs/microvms/provision.go
@@ -117,7 +117,7 @@ func setDockerDataRoot(runner *Runner, disks []resources.DomainDisk, namer namer
 		}
 
 		args := command.Args{
-			Create: pulumi.Sprintf("sh -c 'systemctl stop docker && echo '{}' | jq -n '. += {\"data-root\":\"%s\"}' > /etc/docker/daemon.json && systemctl start docker'", d.Mountpoint),
+			Create: pulumi.Sprintf("echo -e '{\n\t\"data-root\":\"%s\"\n}' > /etc/docker/daemon.json && sudo systemctl restart docker", d.Mountpoint),
 			Sudo:   true,
 		}
 		done, err := runner.Command(namer.ResourceName("set-docker-data-root"), &args, pulumi.DependsOn(depends))

--- a/scenarios/aws/microVMs/microvms/resources/amd64.go
+++ b/scenarios/aws/microVMs/microvms/resources/amd64.go
@@ -43,7 +43,7 @@ func (a *AMD64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomain
 
 	var disks libvirt.DomainDiskArray
 	sort.Slice(args.Disks, func(i, j int) bool {
-		return args.Disks[i].Target < args.Disks[i].Target
+		return args.Disks[i].Target < args.Disks[j].Target
 	})
 	for _, disk := range args.Disks {
 		switch disk.Attach {

--- a/scenarios/aws/microVMs/microvms/resources/amd64.go
+++ b/scenarios/aws/microVMs/microvms/resources/amd64.go
@@ -26,7 +26,7 @@ func (a *AMD64ResourceCollection) GetDomainXLS(args map[string]pulumi.StringInpu
 	return formatResourceXML(amd64DomainXLS, args)
 }
 
-func (a *AMD64ResourceCollection) GetVolumeXML(args map[string]pulumi.StringInput) pulumi.StringOutput {
+func (a *AMD64ResourceCollection) GetVolumeXML(args *RecipeLibvirtVolumeArgs) pulumi.StringOutput {
 	return GetDefaultVolumeXML(args, a.recipe)
 }
 

--- a/scenarios/aws/microVMs/microvms/resources/amd64.go
+++ b/scenarios/aws/microVMs/microvms/resources/amd64.go
@@ -35,12 +35,17 @@ func (a *AMD64ResourceCollection) GetPoolXML(args map[string]pulumi.StringInput)
 
 func (a *AMD64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomainArgs) *libvirt.DomainArgs {
 	var cmdlines []map[string]interface{}
-
 	for cmd, val := range args.ExtraKernelParams {
 		cmdlines = append(cmdlines, map[string]interface{}{cmd: pulumi.String(val)})
 	}
-
 	cmdlines = append(cmdlines, kernelCmdlines...)
+
+	var disks libvirt.DomainDiskArray
+	for _, vol := range args.Volumes {
+		disks = append(disks, libvirt.DomainDiskArgs{
+			VolumeId: vol.ID(),
+		})
+	}
 
 	domainArgs := libvirt.DomainArgs{
 		Name: pulumi.String(args.DomainName),
@@ -51,11 +56,7 @@ func (a *AMD64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomain
 				TargetType: pulumi.String("serial"),
 			},
 		},
-		Disks: libvirt.DomainDiskArray{
-			libvirt.DomainDiskArgs{
-				VolumeId: args.Volume.ID(),
-			},
-		},
+		Disks:    disks,
 		Kernel:   pulumi.String(args.KernelPath),
 		Cmdlines: pulumi.ToMapArray(cmdlines),
 		Memory:   pulumi.Int(args.Memory),

--- a/scenarios/aws/microVMs/microvms/resources/amd64/domain.xls
+++ b/scenarios/aws/microVMs/microvms/resources/amd64/domain.xls
@@ -19,10 +19,6 @@
           <target dir='kernel-version-testing'/>
       </filesystem>
       <readonly/>
-      <channel type='unix'>
-          <source mode='bind' path='/tmp/{domainID}.sock'/>
-          <target type='virtio' name='logs-output-socket' state='disconnected'/>
-      </channel>
       <xsl:copy>
           <xsl:apply-templates select="@*|node()"/>
       </xsl:copy>

--- a/scenarios/aws/microVMs/microvms/resources/arm64.go
+++ b/scenarios/aws/microVMs/microvms/resources/arm64.go
@@ -44,7 +44,7 @@ func (a *ARM64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomain
 
 	var disks libvirt.DomainDiskArray
 	sort.Slice(args.Disks, func(i, j int) bool {
-		return args.Disks[i].Target < args.Disks[i].Target
+		return args.Disks[i].Target < args.Disks[j].Target
 	})
 	for _, disk := range args.Disks {
 		switch disk.Attach {

--- a/scenarios/aws/microVMs/microvms/resources/arm64.go
+++ b/scenarios/aws/microVMs/microvms/resources/arm64.go
@@ -39,8 +39,14 @@ func (a *ARM64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomain
 	for cmd, val := range args.ExtraKernelParams {
 		cmdlines = append(cmdlines, map[string]interface{}{cmd: pulumi.String(val)})
 	}
-
 	cmdlines = append(cmdlines, kernelCmdlines...)
+
+	var disks libvirt.DomainDiskArray
+	for _, vol := range args.Volumes {
+		disks = append(disks, libvirt.DomainDiskArgs{
+			VolumeId: vol.ID(),
+		})
+	}
 
 	domainArgs := libvirt.DomainArgs{
 		Name: pulumi.String(args.DomainName),
@@ -51,11 +57,7 @@ func (a *ARM64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomain
 				TargetType: pulumi.String("serial"),
 			},
 		},
-		Disks: libvirt.DomainDiskArray{
-			libvirt.DomainDiskArgs{
-				VolumeId: args.Volume.ID(),
-			},
-		},
+		Disks:    disks,
 		Machine:  pulumi.String("virt"),
 		Kernel:   pulumi.String(args.KernelPath),
 		Cmdlines: pulumi.ToMapArray(cmdlines),

--- a/scenarios/aws/microVMs/microvms/resources/arm64.go
+++ b/scenarios/aws/microVMs/microvms/resources/arm64.go
@@ -3,6 +3,7 @@ package resources
 import (
 	// import embed
 	_ "embed"
+	"sort"
 
 	"github.com/pulumi/pulumi-libvirt/sdk/go/libvirt"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -42,10 +43,21 @@ func (a *ARM64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomain
 	cmdlines = append(cmdlines, kernelCmdlines...)
 
 	var disks libvirt.DomainDiskArray
-	for _, vol := range args.Volumes {
-		disks = append(disks, libvirt.DomainDiskArgs{
-			VolumeId: vol.ID(),
-		})
+	sort.Slice(args.Disks, func(i, j int) bool {
+		return args.Disks[i].Target < args.Disks[i].Target
+	})
+	for _, disk := range args.Disks {
+		switch disk.Attach {
+		case AttachAsFile:
+			disks = append(disks, libvirt.DomainDiskArgs{
+				File: disk.VolumeID,
+			})
+		case AttachAsVolume:
+			disks = append(disks, libvirt.DomainDiskArgs{
+				VolumeId: disk.VolumeID,
+			})
+		default:
+		}
 	}
 
 	domainArgs := libvirt.DomainArgs{

--- a/scenarios/aws/microVMs/microvms/resources/arm64.go
+++ b/scenarios/aws/microVMs/microvms/resources/arm64.go
@@ -27,7 +27,7 @@ func (a *ARM64ResourceCollection) GetDomainXLS(args map[string]pulumi.StringInpu
 	return formatResourceXML(arm64DomainXLS, args)
 }
 
-func (a *ARM64ResourceCollection) GetVolumeXML(args map[string]pulumi.StringInput) pulumi.StringOutput {
+func (a *ARM64ResourceCollection) GetVolumeXML(args *RecipeLibvirtVolumeArgs) pulumi.StringOutput {
 	return GetDefaultVolumeXML(args, a.recipe)
 }
 

--- a/scenarios/aws/microVMs/microvms/resources/arm64/domain.xls
+++ b/scenarios/aws/microVMs/microvms/resources/arm64/domain.xls
@@ -36,7 +36,7 @@
       </xsl:copy>
   </xsl:template>
 
-   <xsl:template match="/domain/devices/disk[@type='file']/driver">
+  <xsl:template match="/domain/devices/disk[@type='file']/driver">
      <readonly/>
       <xsl:copy>
           <xsl:apply-templates select="@*|node()"/>

--- a/scenarios/aws/microVMs/microvms/resources/arm64/domain.xls
+++ b/scenarios/aws/microVMs/microvms/resources/arm64/domain.xls
@@ -31,10 +31,6 @@
           <target dir='kernel-version-testing'/>
       </filesystem>
       <readonly/>
-      <channel type='unix'>
-          <source mode='bind' path='/tmp/{domainID}.sock'/>
-          <target type='virtio' name='logs-output-socket' state='disconnected'/>
-      </channel>
       <xsl:copy>
           <xsl:apply-templates select="@*|node()"/>
       </xsl:copy>

--- a/scenarios/aws/microVMs/microvms/resources/arm64/domain.xls
+++ b/scenarios/aws/microVMs/microvms/resources/arm64/domain.xls
@@ -35,7 +35,15 @@
           <xsl:apply-templates select="@*|node()"/>
       </xsl:copy>
   </xsl:template>
-  
+
+   <xsl:template match="/domain/devices/disk[@type='file']/driver">
+     <readonly/>
+      <xsl:copy>
+          <xsl:apply-templates select="@*|node()"/>
+      </xsl:copy>
+  </xsl:template>
+
+ 
   <xsl:template match="/domain/devices/interface[@type='network']/mac/@address">
       <xsl:attribute name="address">
           <xsl:value-of select="'{mac}'"/>

--- a/scenarios/aws/microVMs/microvms/resources/default.go
+++ b/scenarios/aws/microVMs/microvms/resources/default.go
@@ -29,7 +29,7 @@ var defaultLocalVolumeXLS string
 
 var remoteVolumeXMLs = map[vmconfig.PoolType]string{
 	DefaultPool: defaultVolumeXML,
-	RamPool:     defaultRawVolumeXML,
+	RAMPool:     defaultRawVolumeXML,
 }
 
 func GetDefaultDomainXLS(...interface{}) string {

--- a/scenarios/aws/microVMs/microvms/resources/default.go
+++ b/scenarios/aws/microVMs/microvms/resources/default.go
@@ -4,6 +4,7 @@ import (
 	// import embed
 	_ "embed"
 
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/microVMs/vmconfig"
 	"github.com/pulumi/pulumi-libvirt/sdk/go/libvirt"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -20,8 +21,16 @@ var defaultPoolXML string
 //go:embed default/volume.xml
 var defaultVolumeXML string
 
+//go:embed default/raw_volume.xml
+var defaultRawVolumeXML string
+
 //go:embed default/volume_local.xls
 var defaultLocalVolumeXLS string
+
+var remoteVolumeXMLs = map[vmconfig.PoolType]string{
+	DefaultPool: defaultVolumeXML,
+	RamPool:     defaultRawVolumeXML,
+}
 
 func GetDefaultDomainXLS(...interface{}) string {
 	return defaultDomainXLS
@@ -31,12 +40,12 @@ func GetDefaultNetworkXLS(args map[string]pulumi.StringInput) pulumi.StringOutpu
 	return formatResourceXML(defaultNetworkXLS, args)
 }
 
-func GetDefaultVolumeXML(args map[string]pulumi.StringInput, recipe string) pulumi.StringOutput {
+func GetDefaultVolumeXML(args *RecipeLibvirtVolumeArgs, recipe string) pulumi.StringOutput {
 	if isLocalRecipe(recipe) {
-		return formatResourceXML(defaultLocalVolumeXLS, args)
+		return formatResourceXML(defaultLocalVolumeXLS, args.XMLArgs)
 	}
 
-	return formatResourceXML(defaultVolumeXML, args)
+	return formatResourceXML(remoteVolumeXMLs[args.PoolType], args.XMLArgs)
 }
 
 func GetDefaultPoolXML(args map[string]pulumi.StringInput, _ string) pulumi.StringOutput {
@@ -57,7 +66,7 @@ func (a *DefaultResourceCollection) GetDomainXLS(_ map[string]pulumi.StringInput
 	return pulumi.Sprintf("%s", GetDefaultDomainXLS())
 }
 
-func (a *DefaultResourceCollection) GetVolumeXML(args map[string]pulumi.StringInput) pulumi.StringOutput {
+func (a *DefaultResourceCollection) GetVolumeXML(args *RecipeLibvirtVolumeArgs) pulumi.StringOutput {
 	return GetDefaultVolumeXML(args, a.recipe)
 }
 

--- a/scenarios/aws/microVMs/microvms/resources/default/raw_volume.xml
+++ b/scenarios/aws/microVMs/microvms/resources/default/raw_volume.xml
@@ -9,8 +9,8 @@
       <format type='{format}'/>
     <permissions>
       <mode>0660</mode>
-      <owner>$(cat /etc/passwd | grep $USER | cut -d ':' -f 3)</owner>
-      <group>$(cat /etc/group | grep 'libvirt:' | cut -d ':' -f 3)</group>
+      <owner>$(grep $USER /etc/passwd | cut -d ':' -f 3)</owner>
+      <group>$(grep 'libvirt:' /etc/group | cut -d ':' -f 3)</group>
     </permissions>
   </target>
 </volume>

--- a/scenarios/aws/microVMs/microvms/resources/default/raw_volume.xml
+++ b/scenarios/aws/microVMs/microvms/resources/default/raw_volume.xml
@@ -1,0 +1,17 @@
+<volume type='file'>
+    <name>{imageName}</name>
+    <key>{volumeKey}</key>
+  <capacity unit='bytes'>104857600</capacity>
+  <allocation unit='bytes'>104857600</allocation>
+  <physical unit='bytes'>104857600</physical>
+  <target>
+      <path>{imagePath}</path>
+      <format type='{format}'/>
+    <permissions>
+      <mode>0660</mode>
+      <owner>$(cat /etc/passwd | grep $USER | cut -d ':' -f 3)</owner>
+      <group>$(cat /etc/group | grep 'libvirt:' | cut -d ':' -f 3)</group>
+    </permissions>
+  </target>
+</volume>
+

--- a/scenarios/aws/microVMs/microvms/resources/default/volume.xml
+++ b/scenarios/aws/microVMs/microvms/resources/default/volume.xml
@@ -5,8 +5,8 @@
     <format type='qcow2'/>
     <permissions>
       <mode>0660</mode>
-      <owner>$(cat /etc/passwd | grep $USER | cut -d ':' -f 3)</owner>
-      <group>$(cat /etc/group | grep 'libvirt:' | cut -d ':' -f 3)</group>
+      <owner>$(grep $USER /etc/passwd | cut -d ':' -f 3)</owner>
+      <group>$(grep 'libvirt:' /etc/group | cut -d ':' -f 3)</group>
     </permissions>
     <compat>1.1</compat>
     <clusterSize unit='B'>65536</clusterSize>

--- a/scenarios/aws/microVMs/microvms/resources/distro.go
+++ b/scenarios/aws/microVMs/microvms/resources/distro.go
@@ -29,7 +29,7 @@ func (a *DistroAMD64ResourceCollection) GetDomainXLS(args map[string]pulumi.Stri
 	return formatResourceXML(distroDomainXLS, args)
 }
 
-func (a *DistroAMD64ResourceCollection) GetVolumeXML(args map[string]pulumi.StringInput) pulumi.StringOutput {
+func (a *DistroAMD64ResourceCollection) GetVolumeXML(args *RecipeLibvirtVolumeArgs) pulumi.StringOutput {
 	return GetDefaultVolumeXML(args, a.recipe)
 }
 
@@ -94,7 +94,7 @@ func (a *DistroARM64ResourceCollection) GetDomainXLS(args map[string]pulumi.Stri
 	return formatResourceXML(distroARM64DomainXLS, args)
 }
 
-func (a *DistroARM64ResourceCollection) GetVolumeXML(args map[string]pulumi.StringInput) pulumi.StringOutput {
+func (a *DistroARM64ResourceCollection) GetVolumeXML(args *RecipeLibvirtVolumeArgs) pulumi.StringOutput {
 	return GetDefaultVolumeXML(args, a.recipe)
 }
 

--- a/scenarios/aws/microVMs/microvms/resources/distro.go
+++ b/scenarios/aws/microVMs/microvms/resources/distro.go
@@ -40,7 +40,7 @@ func (a *DistroAMD64ResourceCollection) GetPoolXML(args map[string]pulumi.String
 func (a *DistroAMD64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomainArgs) *libvirt.DomainArgs {
 	var disks libvirt.DomainDiskArray
 	sort.Slice(args.Disks, func(i, j int) bool {
-		return args.Disks[i].Target < args.Disks[i].Target
+		return args.Disks[i].Target < args.Disks[j].Target
 	})
 	for _, disk := range args.Disks {
 		switch disk.Attach {
@@ -106,7 +106,7 @@ func (a *DistroARM64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirt
 	var disks libvirt.DomainDiskArray
 
 	sort.Slice(args.Disks, func(i, j int) bool {
-		return args.Disks[i].Target < args.Disks[i].Target
+		return args.Disks[i].Target < args.Disks[j].Target
 	})
 	for _, disk := range args.Disks {
 		switch disk.Attach {

--- a/scenarios/aws/microVMs/microvms/resources/distro.go
+++ b/scenarios/aws/microVMs/microvms/resources/distro.go
@@ -3,6 +3,7 @@ package resources
 import (
 	// import embed
 	_ "embed"
+	"sort"
 
 	"github.com/pulumi/pulumi-libvirt/sdk/go/libvirt"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -38,10 +39,21 @@ func (a *DistroAMD64ResourceCollection) GetPoolXML(args map[string]pulumi.String
 
 func (a *DistroAMD64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomainArgs) *libvirt.DomainArgs {
 	var disks libvirt.DomainDiskArray
-	for _, vol := range args.Volumes {
-		disks = append(disks, libvirt.DomainDiskArgs{
-			VolumeId: vol.ID(),
-		})
+	sort.Slice(args.Disks, func(i, j int) bool {
+		return args.Disks[i].Target < args.Disks[i].Target
+	})
+	for _, disk := range args.Disks {
+		switch disk.Attach {
+		case AttachAsFile:
+			disks = append(disks, libvirt.DomainDiskArgs{
+				File: disk.VolumeID,
+			})
+		case AttachAsVolume:
+			disks = append(disks, libvirt.DomainDiskArgs{
+				VolumeId: disk.VolumeID,
+			})
+		default:
+		}
 	}
 
 	domainArgs := libvirt.DomainArgs{
@@ -92,10 +104,22 @@ func (a *DistroARM64ResourceCollection) GetPoolXML(args map[string]pulumi.String
 
 func (a *DistroARM64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomainArgs) *libvirt.DomainArgs {
 	var disks libvirt.DomainDiskArray
-	for _, vol := range args.Volumes {
-		disks = append(disks, libvirt.DomainDiskArgs{
-			VolumeId: vol.ID(),
-		})
+
+	sort.Slice(args.Disks, func(i, j int) bool {
+		return args.Disks[i].Target < args.Disks[i].Target
+	})
+	for _, disk := range args.Disks {
+		switch disk.Attach {
+		case AttachAsFile:
+			disks = append(disks, libvirt.DomainDiskArgs{
+				File: disk.VolumeID,
+			})
+		case AttachAsVolume:
+			disks = append(disks, libvirt.DomainDiskArgs{
+				VolumeId: disk.VolumeID,
+			})
+		default:
+		}
 	}
 
 	domainArgs := libvirt.DomainArgs{

--- a/scenarios/aws/microVMs/microvms/resources/distro.go
+++ b/scenarios/aws/microVMs/microvms/resources/distro.go
@@ -37,6 +37,13 @@ func (a *DistroAMD64ResourceCollection) GetPoolXML(args map[string]pulumi.String
 }
 
 func (a *DistroAMD64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomainArgs) *libvirt.DomainArgs {
+	var disks libvirt.DomainDiskArray
+	for _, vol := range args.Volumes {
+		disks = append(disks, libvirt.DomainDiskArgs{
+			VolumeId: vol.ID(),
+		})
+	}
+
 	domainArgs := libvirt.DomainArgs{
 		Name: pulumi.String(args.DomainName),
 		Consoles: libvirt.DomainConsoleArray{
@@ -46,11 +53,7 @@ func (a *DistroAMD64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirt
 				TargetType: pulumi.String("serial"),
 			},
 		},
-		Disks: libvirt.DomainDiskArray{
-			libvirt.DomainDiskArgs{
-				VolumeId: args.Volume.ID(),
-			},
-		},
+		Disks:  disks,
 		Memory: pulumi.Int(args.Memory),
 		Vcpu:   pulumi.Int(args.Vcpu),
 		Xml: libvirt.DomainXmlArgs{
@@ -88,6 +91,13 @@ func (a *DistroARM64ResourceCollection) GetPoolXML(args map[string]pulumi.String
 }
 
 func (a *DistroARM64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomainArgs) *libvirt.DomainArgs {
+	var disks libvirt.DomainDiskArray
+	for _, vol := range args.Volumes {
+		disks = append(disks, libvirt.DomainDiskArgs{
+			VolumeId: vol.ID(),
+		})
+	}
+
 	domainArgs := libvirt.DomainArgs{
 		Name: pulumi.String(args.DomainName),
 		Consoles: libvirt.DomainConsoleArray{
@@ -97,11 +107,7 @@ func (a *DistroARM64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirt
 				TargetType: pulumi.String("serial"),
 			},
 		},
-		Disks: libvirt.DomainDiskArray{
-			libvirt.DomainDiskArgs{
-				VolumeId: args.Volume.ID(),
-			},
-		},
+		Disks:   disks,
 		Memory:  pulumi.Int(args.Memory),
 		Vcpu:    pulumi.Int(args.Vcpu),
 		Machine: pulumi.String("virt"),

--- a/scenarios/aws/microVMs/microvms/resources/distro/domain-amd64.xls
+++ b/scenarios/aws/microVMs/microvms/resources/distro/domain-amd64.xls
@@ -17,10 +17,6 @@
           <target dir='kernel-version-testing'/>
       </filesystem>
       <readonly/>
-      <channel type='unix'>
-          <source mode='bind' path='/tmp/{domainID}.sock'/>
-          <target type='virtio' name='logs-output-socket' state='disconnected'/>
-      </channel>
       <xsl:copy>
           <xsl:apply-templates select="@*|node()"/>
       </xsl:copy>

--- a/scenarios/aws/microVMs/microvms/resources/distro/domain-amd64.xls
+++ b/scenarios/aws/microVMs/microvms/resources/distro/domain-amd64.xls
@@ -22,12 +22,11 @@
   </xsl:template>
 
   <xsl:template match="/domain/devices/disk[@type='file']/driver">
-     <readonly/>
+      <readonly/>
       <xsl:copy>
           <xsl:apply-templates select="@*|node()"/>
       </xsl:copy>
   </xsl:template>
-
 
   <xsl:template match="/domain/devices/interface[@type='network']/mac/@address">
       <xsl:attribute name="address">

--- a/scenarios/aws/microVMs/microvms/resources/distro/domain-amd64.xls
+++ b/scenarios/aws/microVMs/microvms/resources/distro/domain-amd64.xls
@@ -16,11 +16,18 @@
           <source dir='{sharedFSMount}'/>
           <target dir='kernel-version-testing'/>
       </filesystem>
-      <readonly/>
       <xsl:copy>
           <xsl:apply-templates select="@*|node()"/>
       </xsl:copy>
   </xsl:template>
+
+  <xsl:template match="/domain/devices/disk[@type='file']/driver">
+     <readonly/>
+      <xsl:copy>
+          <xsl:apply-templates select="@*|node()"/>
+      </xsl:copy>
+  </xsl:template>
+
 
   <xsl:template match="/domain/devices/interface[@type='network']/mac/@address">
       <xsl:attribute name="address">

--- a/scenarios/aws/microVMs/microvms/resources/distro/domain-arm64.xls
+++ b/scenarios/aws/microVMs/microvms/resources/distro/domain-arm64.xls
@@ -37,6 +37,13 @@
       </xsl:copy>
   </xsl:template>
 
+  <xsl:template match="/domain/devices/disk[@type='file']/driver">
+     <readonly/>
+      <xsl:copy>
+          <xsl:apply-templates select="@*|node()"/>
+      </xsl:copy>
+  </xsl:template>
+
   <xsl:template match="/domain/devices/interface[@type='network']/mac/@address">
       <xsl:attribute name="address">
           <xsl:value-of select="'{mac}'"/>

--- a/scenarios/aws/microVMs/microvms/resources/distro/domain-arm64.xls
+++ b/scenarios/aws/microVMs/microvms/resources/distro/domain-arm64.xls
@@ -38,7 +38,7 @@
   </xsl:template>
 
   <xsl:template match="/domain/devices/disk[@type='file']/driver">
-     <readonly/>
+      <readonly/>
       <xsl:copy>
           <xsl:apply-templates select="@*|node()"/>
       </xsl:copy>

--- a/scenarios/aws/microVMs/microvms/resources/distro/domain-arm64.xls
+++ b/scenarios/aws/microVMs/microvms/resources/distro/domain-arm64.xls
@@ -32,10 +32,6 @@
           <target dir='kernel-version-testing'/>
       </filesystem>
       <readonly/>
-      <channel type='unix'>
-          <source mode='bind' path='/tmp/{domainID}.sock'/>
-          <target type='virtio' name='logs-output-socket' state='disconnected'/>
-      </channel>
       <xsl:copy>
           <xsl:apply-templates select="@*|node()"/>
       </xsl:copy>

--- a/scenarios/aws/microVMs/microvms/resources/resources.go
+++ b/scenarios/aws/microVMs/microvms/resources/resources.go
@@ -55,8 +55,6 @@ const (
 
 type DiskTarget string
 
-const VDADisk = "vda"
-
 type DomainDisk struct {
 	VolumeID   pulumi.StringPtrInput
 	Attach     AttachMethod

--- a/scenarios/aws/microVMs/microvms/resources/resources.go
+++ b/scenarios/aws/microVMs/microvms/resources/resources.go
@@ -41,13 +41,33 @@ type ResourceCollection interface {
 	GetLibvirtDomainArgs(*RecipeLibvirtDomainArgs) *libvirt.DomainArgs
 }
 
+type AttachMethod int
+
+const (
+	AttachAsFile AttachMethod = iota
+	AttachAsVolume
+)
+
+type DiskTarget string
+
+const (
+	VDADisk = "vda"
+	VDBDisk = "vdb"
+)
+
+type DomainDisk struct {
+	VolumeID pulumi.StringPtrInput
+	Attach   AttachMethod
+	Target   DiskTarget
+}
+
 type RecipeLibvirtDomainArgs struct {
 	DomainName        string
 	Vcpu              int
 	Memory            int
 	Xls               pulumi.StringOutput
 	KernelPath        string
-	Volumes           []*libvirt.Volume
+	Disks             []DomainDisk
 	Resources         ResourceCollection
 	ExtraKernelParams map[string]string
 	Machine           string

--- a/scenarios/aws/microVMs/microvms/resources/resources.go
+++ b/scenarios/aws/microVMs/microvms/resources/resources.go
@@ -27,7 +27,7 @@ const (
 )
 
 const (
-	RamPool     vmconfig.PoolType = "ram"
+	RAMPool     vmconfig.PoolType = "ram"
 	DefaultPool vmconfig.PoolType = "default"
 )
 

--- a/scenarios/aws/microVMs/microvms/resources/resources.go
+++ b/scenarios/aws/microVMs/microvms/resources/resources.go
@@ -26,6 +26,11 @@ const (
 	VCPU          = "vcpu"
 )
 
+const (
+	RamPool     vmconfig.PoolType = "ram"
+	DefaultPool vmconfig.PoolType = "default"
+)
+
 var kernelCmdlines = []map[string]interface{}{
 	{"acpi": pulumi.String("off")},
 	{"panic": pulumi.String("-1")},
@@ -36,7 +41,7 @@ var kernelCmdlines = []map[string]interface{}{
 
 type ResourceCollection interface {
 	GetDomainXLS(args map[string]pulumi.StringInput) pulumi.StringOutput
-	GetVolumeXML(args map[string]pulumi.StringInput) pulumi.StringOutput
+	GetVolumeXML(*RecipeLibvirtVolumeArgs) pulumi.StringOutput
 	GetPoolXML(args map[string]pulumi.StringInput) pulumi.StringOutput
 	GetLibvirtDomainArgs(*RecipeLibvirtDomainArgs) *libvirt.DomainArgs
 }
@@ -71,6 +76,11 @@ type RecipeLibvirtDomainArgs struct {
 	Resources         ResourceCollection
 	ExtraKernelParams map[string]string
 	Machine           string
+}
+
+type RecipeLibvirtVolumeArgs struct {
+	PoolType vmconfig.PoolType
+	XMLArgs  map[string]pulumi.StringInput
 }
 
 func formatResourceXML(xml string, args map[string]pulumi.StringInput) pulumi.StringOutput {

--- a/scenarios/aws/microVMs/microvms/resources/resources.go
+++ b/scenarios/aws/microVMs/microvms/resources/resources.go
@@ -47,7 +47,7 @@ type RecipeLibvirtDomainArgs struct {
 	Memory            int
 	Xls               pulumi.StringOutput
 	KernelPath        string
-	Volume            *libvirt.Volume
+	Volumes           []*libvirt.Volume
 	Resources         ResourceCollection
 	ExtraKernelParams map[string]string
 	Machine           string

--- a/scenarios/aws/microVMs/microvms/resources/resources.go
+++ b/scenarios/aws/microVMs/microvms/resources/resources.go
@@ -55,15 +55,13 @@ const (
 
 type DiskTarget string
 
-const (
-	VDADisk = "vda"
-	VDBDisk = "vdb"
-)
+const VDADisk = "vda"
 
 type DomainDisk struct {
-	VolumeID pulumi.StringPtrInput
-	Attach   AttachMethod
-	Target   DiskTarget
+	VolumeID   pulumi.StringPtrInput
+	Attach     AttachMethod
+	Target     string
+	Mountpoint string
 }
 
 type RecipeLibvirtDomainArgs struct {

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -233,6 +233,7 @@ func configureInstance(instance *Instance, m *config.DDMicroVMConfig) ([]pulumi.
 			localRunner,
 			instance.instanceNamer,
 			pair,
+			nil,
 		)
 		if err != nil {
 			return nil, err
@@ -253,6 +254,7 @@ func configureInstance(instance *Instance, m *config.DDMicroVMConfig) ([]pulumi.
 		if instance.e.DefaultShutdownBehavior() == "terminate" {
 			shutdownTimerDone, err := setShutdownTimer(instance, m)
 			if err != nil {
+				return nil, err
 			}
 			waitFor = append(waitFor, shutdownTimerDone)
 		}
@@ -384,6 +386,16 @@ func run(e commonConfig.CommonEnvironment) (*ScenarioDone, error) {
 				return nil, err
 			}
 			_, err = reloadSSHD(microRunner, allowEnvDone)
+			if err != nil {
+				return nil, err
+			}
+
+			mountDisksDone, err := mountMicroVMDisks(microRunner, domain.Disks, domain.domainNamer, []pulumi.Resource{domain.lvDomain})
+			if err != nil {
+				return nil, err
+			}
+
+			_, err = setDockerDataRoot(microRunner, domain.Disks, domain.domainNamer, mountDisksDone)
 			if err != nil {
 				return nil, err
 			}

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -317,7 +317,7 @@ func run(e commonConfig.CommonEnvironment) (*ScenarioDone, error) {
 	}
 
 	for _, instance := range instances {
-		waitFor, err = configureInstance(instance, &m)
+		configureDone, err := configureInstance(instance, &m)
 		if err != nil {
 			return nil, fmt.Errorf("failed to configure instance: %w", err)
 		}
@@ -326,6 +326,8 @@ func run(e commonConfig.CommonEnvironment) (*ScenarioDone, error) {
 		if instance.Arch != LocalVMSet {
 			instanceEnv.Ctx.Export(fmt.Sprintf("%s-instance-ip", instance.Arch), instance.instance.PrivateIp)
 		}
+
+		waitFor = append(waitFor, configureDone...)
 	}
 
 	vmCollections, waitFor, err := BuildVMCollections(instances, cfg.VMSets, waitFor)

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -218,7 +218,7 @@ func configureInstance(instance *Instance, m *config.DDMicroVMConfig) ([]pulumi.
 
 	shouldProvision := m.GetBoolWithDefault(m.MicroVMConfig, config.DDMicroVMProvisionEC2Instance, true)
 	if shouldProvision && instance.Arch != LocalVMSet {
-		waitProvision, err := provisionInstance(instance)
+		waitProvision, err := provisionMetalInstance(instance)
 		if err != nil {
 			return nil, err
 		}

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -217,7 +217,7 @@ func configureInstance(instance *Instance, m *config.DDMicroVMConfig) ([]pulumi.
 	}
 
 	shouldProvision := m.GetBoolWithDefault(m.MicroVMConfig, config.DDMicroVMProvisionEC2Instance, true)
-	if shouldProvision {
+	if shouldProvision && instance.Arch != LocalVMSet {
 		waitProvision, err := provisionInstance(instance)
 		if err != nil {
 			return nil, err

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -280,6 +280,7 @@ func run(e commonConfig.CommonEnvironment) (*ScenarioDone, error) {
 	}
 
 	GetWorkingDirectory = getKernelVersionTestingWorkingDir(&m)
+	fmt.Printf("Working dir: %s\n", GetWorkingDirectory())
 
 	archs := make(map[string]bool)
 	for _, set := range cfg.VMSets {

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -280,7 +280,6 @@ func run(e commonConfig.CommonEnvironment) (*ScenarioDone, error) {
 	}
 
 	GetWorkingDirectory = getKernelVersionTestingWorkingDir(&m)
-	fmt.Printf("Working dir: %s\n", GetWorkingDirectory())
 
 	archs := make(map[string]bool)
 	for _, set := range cfg.VMSets {

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -233,7 +233,6 @@ func configureInstance(instance *Instance, m *config.DDMicroVMConfig) ([]pulumi.
 			localRunner,
 			instance.instanceNamer,
 			pair,
-			[]pulumi.Resource{},
 		)
 		if err != nil {
 			return nil, err
@@ -254,7 +253,6 @@ func configureInstance(instance *Instance, m *config.DDMicroVMConfig) ([]pulumi.
 		if instance.e.DefaultShutdownBehavior() == "terminate" {
 			shutdownTimerDone, err := setShutdownTimer(instance, m)
 			if err != nil {
-				return []pulumi.Resource{}, err
 			}
 			waitFor = append(waitFor, shutdownTimerDone)
 		}

--- a/scenarios/aws/microVMs/microvms/volume.go
+++ b/scenarios/aws/microVMs/microvms/volume.go
@@ -54,7 +54,6 @@ func remoteLibvirtVolume(v *volume, runner *Runner, depends []pulumi.Resource) (
 	var baseVolumeReady pulumi.Resource
 
 	volumeXMLPath := fmt.Sprintf("/tmp/volume-%s.xml", v.filesystemImage.imageName)
-
 	volXMLWrittenArgs := command.Args{
 		Create: pulumi.Sprintf("echo \"%s\" > %s", v.volumeXML, volumeXMLPath),
 		Delete: pulumi.Sprintf("rm -f %s", volumeXMLPath),

--- a/scenarios/aws/microVMs/microvms/volume.go
+++ b/scenarios/aws/microVMs/microvms/volume.go
@@ -38,7 +38,6 @@ func generateVolumeKey(poolPath string, volName string) string {
 
 func NewLibvirtVolume(pool LibvirtPool, fsImage filesystemImage, xmlDataFn func(string, vmconfig.PoolType) pulumi.StringOutput, volNamerFn func(string) namer.Namer) LibvirtVolume {
 	volKey := generateVolumeKey(pool.Path(), fsImage.imageName)
-	fmt.Printf("%s\n", volKey)
 	return &volume{
 		filesystemImage: fsImage,
 		volumeKey:       volKey,

--- a/scenarios/aws/microVMs/microvms/volume.go
+++ b/scenarios/aws/microVMs/microvms/volume.go
@@ -16,6 +16,7 @@ type LibvirtVolume interface {
 	FullResourceName(...string) string
 	Key() string
 	Pool() LibvirtPool
+	Mountpoint() string
 }
 
 type filesystemImage struct {
@@ -30,13 +31,20 @@ type volume struct {
 	volumeKey   string
 	volumeXML   pulumi.StringOutput
 	volumeNamer namer.Namer
+	mountpoint  string
 }
 
 func generateVolumeKey(poolPath string, volName string) string {
 	return fmt.Sprintf("%s/%s", poolPath, volName)
 }
 
-func NewLibvirtVolume(pool LibvirtPool, fsImage filesystemImage, xmlDataFn func(string, vmconfig.PoolType) pulumi.StringOutput, volNamerFn func(string) namer.Namer) LibvirtVolume {
+func NewLibvirtVolume(
+	pool LibvirtPool,
+	fsImage filesystemImage,
+	xmlDataFn func(string, vmconfig.PoolType) pulumi.StringOutput,
+	volNamerFn func(string) namer.Namer,
+	mountpoint string,
+) LibvirtVolume {
 	volKey := generateVolumeKey(pool.Path(), fsImage.imageName)
 	return &volume{
 		filesystemImage: fsImage,
@@ -44,6 +52,7 @@ func NewLibvirtVolume(pool LibvirtPool, fsImage filesystemImage, xmlDataFn func(
 		volumeXML:       xmlDataFn(volKey, pool.Type()),
 		volumeNamer:     volNamerFn(volKey),
 		pool:            pool,
+		mountpoint:      mountpoint,
 	}
 }
 
@@ -126,4 +135,8 @@ func (v *volume) Key() string {
 
 func (v *volume) Pool() LibvirtPool {
 	return v.pool
+}
+
+func (v *volume) Mountpoint() string {
+	return v.mountpoint
 }

--- a/scenarios/aws/microVMs/microvms/volume.go
+++ b/scenarios/aws/microVMs/microvms/volume.go
@@ -1,0 +1,129 @@
+package microvms
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/DataDog/test-infra-definitions/common/namer"
+	"github.com/DataDog/test-infra-definitions/components/command"
+	"github.com/pulumi/pulumi-libvirt/sdk/go/libvirt"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+type LibvirtVolume interface {
+	SetupLibvirtVMVolume(ctx *pulumi.Context, runner *Runner, providerFn LibvirtProviderFn, isLocal bool, depends []pulumi.Resource) (pulumi.Resource, error)
+	UnderlyingImage() *filesystemImage
+	FullResourceName(string) string
+	Key() string
+}
+
+type filesystemImage struct {
+	imageName   string
+	imagePath   string
+	imageSource string
+}
+
+type volume struct {
+	filesystemImage
+	pool        LibvirtPool
+	volumeKey   string
+	volumeXML   pulumi.StringOutput
+	volumeNamer namer.Namer
+}
+
+func generateVolumeKey(poolPathFn func() string, volName string) string {
+	return fmt.Sprintf("%s/%s", poolPathFn(), volName)
+}
+
+func getImagePath(name string) string {
+	return filepath.Join(rootFSDir(), name)
+}
+
+func NewLibvirtVolume(pool LibvirtPool, fsImage filesystemImage, xmlDataFn func(string) pulumi.StringOutput, volNamerFn func(string) namer.Namer) LibvirtVolume {
+	volKey := generateVolumeKey(func() string { return generateGlobalPoolPath(pool.Name()) }, fsImage.imageName)
+	return &volume{
+		filesystemImage: fsImage,
+		volumeKey:       volKey,
+		volumeXML:       xmlDataFn(volKey),
+		volumeNamer:     volNamerFn(volKey),
+		pool:            pool,
+	}
+}
+
+func remoteLibvirtVolume(v *volume, runner *Runner, depends []pulumi.Resource) (pulumi.Resource, error) {
+	var baseVolumeReady pulumi.Resource
+
+	volumeXMLPath := fmt.Sprintf("/tmp/volume-%s.xml", v.filesystemImage.imageName)
+
+	volXMLWrittenArgs := command.Args{
+		Create: pulumi.Sprintf("echo \"%s\" > %s", v.volumeXML, volumeXMLPath),
+		Delete: pulumi.Sprintf("rm -f %s", volumeXMLPath),
+	}
+	// XML write does not need to depend on anything other than the instance being ready.
+	// Instance state is handled by the runner automatically.
+	volXMLWritten, err := runner.Command(
+		v.volumeNamer.ResourceName("write-vol-xml"),
+		&volXMLWrittenArgs,
+	)
+	if err != nil {
+		return baseVolumeReady, err
+	}
+
+	depends = append(depends, volXMLWritten)
+
+	baseVolumeReadyArgs := command.Args{
+		Create: pulumi.Sprintf("virsh vol-create %s %s", v.pool.Name(), volumeXMLPath),
+		Delete: pulumi.Sprintf("virsh vol-delete %s --pool %s", v.volumeKey, v.pool.Name()),
+		Sudo:   true,
+	}
+
+	baseVolumeReady, err = runner.Command(v.volumeNamer.ResourceName("build-libvirt-basevolume"), &baseVolumeReadyArgs, pulumi.DependsOn(depends))
+	if err != nil {
+		return baseVolumeReady, err
+	}
+
+	return baseVolumeReady, err
+}
+
+func localLibvirtVolume(v *volume, ctx *pulumi.Context, providerFn LibvirtProviderFn, depends []pulumi.Resource) (pulumi.Resource, error) {
+	var stgvolReady pulumi.Resource
+
+	provider, err := providerFn()
+	if err != nil {
+		return stgvolReady, err
+	}
+
+	stgvolReady, err = libvirt.NewVolume(ctx, v.volumeNamer.ResourceName("build-libvirt-basevolume"), &libvirt.VolumeArgs{
+		Name:   pulumi.String(v.filesystemImage.imageName),
+		Pool:   pulumi.String(v.pool.Name()),
+		Source: pulumi.String(v.filesystemImage.imagePath),
+		Xml: libvirt.VolumeXmlArgs{
+			Xslt: v.volumeXML,
+		},
+	}, pulumi.Provider(provider), pulumi.DependsOn(depends))
+	if err != nil {
+		return stgvolReady, err
+	}
+
+	return stgvolReady, nil
+}
+
+func (v *volume) SetupLibvirtVMVolume(ctx *pulumi.Context, runner *Runner, providerFn LibvirtProviderFn, isLocal bool, depends []pulumi.Resource) (pulumi.Resource, error) {
+	if isLocal {
+		return localLibvirtVolume(v, ctx, providerFn, depends)
+	}
+
+	return remoteLibvirtVolume(v, runner, depends)
+}
+
+func (v *volume) UnderlyingImage() *filesystemImage {
+	return &v.filesystemImage
+}
+
+func (v *volume) FullResourceName(name string) string {
+	return v.volumeNamer.ResourceName(name)
+}
+
+func (v *volume) Key() string {
+	return v.volumeKey
+}

--- a/scenarios/aws/microVMs/microvms/volume.go
+++ b/scenarios/aws/microVMs/microvms/volume.go
@@ -13,7 +13,7 @@ import (
 type LibvirtVolume interface {
 	SetupLibvirtVMVolume(ctx *pulumi.Context, runner *Runner, providerFn LibvirtProviderFn, isLocal bool, depends []pulumi.Resource) (pulumi.Resource, error)
 	UnderlyingImage() *filesystemImage
-	FullResourceName(string) string
+	FullResourceName(...string) string
 	Key() string
 	Pool() LibvirtPool
 }
@@ -38,6 +38,7 @@ func generateVolumeKey(poolPath string, volName string) string {
 
 func NewLibvirtVolume(pool LibvirtPool, fsImage filesystemImage, xmlDataFn func(string, vmconfig.PoolType) pulumi.StringOutput, volNamerFn func(string) namer.Namer) LibvirtVolume {
 	volKey := generateVolumeKey(pool.Path(), fsImage.imageName)
+	fmt.Printf("%s\n", volKey)
 	return &volume{
 		filesystemImage: fsImage,
 		volumeKey:       volKey,
@@ -116,8 +117,8 @@ func (v *volume) UnderlyingImage() *filesystemImage {
 	return &v.filesystemImage
 }
 
-func (v *volume) FullResourceName(name string) string {
-	return v.volumeNamer.ResourceName(name)
+func (v *volume) FullResourceName(name ...string) string {
+	return v.volumeNamer.ResourceName(name...)
 }
 
 func (v *volume) Key() string {

--- a/scenarios/aws/microVMs/microvms/volume.go
+++ b/scenarios/aws/microVMs/microvms/volume.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/common/namer"
 	"github.com/DataDog/test-infra-definitions/components/command"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/microVMs/vmconfig"
 	"github.com/pulumi/pulumi-libvirt/sdk/go/libvirt"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -35,12 +36,12 @@ func generateVolumeKey(poolPath string, volName string) string {
 	return fmt.Sprintf("%s/%s", poolPath, volName)
 }
 
-func NewLibvirtVolume(pool LibvirtPool, fsImage filesystemImage, xmlDataFn func(string) pulumi.StringOutput, volNamerFn func(string) namer.Namer) LibvirtVolume {
+func NewLibvirtVolume(pool LibvirtPool, fsImage filesystemImage, xmlDataFn func(string, vmconfig.PoolType) pulumi.StringOutput, volNamerFn func(string) namer.Namer) LibvirtVolume {
 	volKey := generateVolumeKey(pool.Path(), fsImage.imageName)
 	return &volume{
 		filesystemImage: fsImage,
 		volumeKey:       volKey,
-		volumeXML:       xmlDataFn(volKey),
+		volumeXML:       xmlDataFn(volKey, pool.Type()),
 		volumeNamer:     volNamerFn(volKey),
 		pool:            pool,
 	}

--- a/scenarios/aws/microVMs/vmconfig/config.go
+++ b/scenarios/aws/microVMs/vmconfig/config.go
@@ -19,6 +19,7 @@ type Disk struct {
 	BackingStore string   `json:"source"`
 	Target       string   `json:"target"`
 	Size         string   `json:"size,omitempty"`
+	Mountpoint   string   `json:"mount_point"`
 }
 
 type Kernel struct {

--- a/scenarios/aws/microVMs/vmconfig/config.go
+++ b/scenarios/aws/microVMs/vmconfig/config.go
@@ -16,7 +16,8 @@ const (
 
 type Disk struct {
 	Type         PoolType `json:"type"`
-	BackingStore string   `json:"backing_store"`
+	BackingStore string   `json:"source"`
+	Target       string   `json:"target"`
 	Size         string   `json:"size,omitempty"`
 }
 

--- a/scenarios/aws/microVMs/vmconfig/config.go
+++ b/scenarios/aws/microVMs/vmconfig/config.go
@@ -1,5 +1,7 @@
 package vmconfig
 
+type PoolType string
+
 type VMSetID string
 
 const (
@@ -11,6 +13,13 @@ const (
 	RecipeDistroLocal = "distro-local"
 	RecipeDefault     = "default"
 )
+
+type Disk struct {
+	Type         PoolType `json:"type"`
+	BackingStore string   `json:"backing_store"`
+	ImageName    string   `json:"image_name"`
+	Size         string   `json:"size,omitempty"`
+}
 
 type Kernel struct {
 	Dir         string            `json:"dir"`
@@ -34,6 +43,7 @@ type VMSet struct {
 	Machine string   `json:"machine,omitempty"`
 	Arch    string
 	ID      VMSetID `json:"omitempty"`
+	Disks   []Disk  `json:"disks,omitempty"`
 }
 
 type Config struct {

--- a/scenarios/aws/microVMs/vmconfig/config.go
+++ b/scenarios/aws/microVMs/vmconfig/config.go
@@ -17,7 +17,6 @@ const (
 type Disk struct {
 	Type         PoolType `json:"type"`
 	BackingStore string   `json:"backing_store"`
-	ImageName    string   `json:"image_name"`
 	Size         string   `json:"size,omitempty"`
 }
 


### PR DESCRIPTION
What does this PR do?
---------------------
This PR allows the user to specify multiple disks to boot a VM from.
This PR also adds support for attaching a ram-backed file as a block device to a VM.

This facility will be used to share dependencies with the mircovms.
It has an advantage over baking the dependencies directly in the microvm, since it keeps the size of the microvms small which allows faster downloads. The dependency disk is also downloaded only once and shared with the VMs using a COW overlay.

When used in the datadog-agent CI, this approach should help eliminate the expensive step of downloading docker images into each microvm.

https://datadoghq.atlassian.net/browse/EBPF-243

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
