### PR TITLE
Adds SSH config to microvm provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ Pulumi.*.yaml
 
 # config file, should never be in this folder
 .test_infra_config.yaml
+
+# JetBrains IDE
+.idea/

--- a/components/command/runner.go
+++ b/components/command/runner.go
@@ -3,12 +3,13 @@ package command
 import (
 	"fmt"
 
-	"github.com/DataDog/test-infra-definitions/common/config"
-	"github.com/DataDog/test-infra-definitions/common/namer"
-	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/pulumi/pulumi-command/sdk/go/command/local"
 	"github.com/pulumi/pulumi-command/sdk/go/command/remote"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/common/namer"
+	"github.com/DataDog/test-infra-definitions/common/utils"
 )
 
 type Args struct {
@@ -81,12 +82,14 @@ func NewRunner(e config.CommonEnvironment, args RunnerArgs) (*Runner, error) {
 		runner.options = append(runner.options, pulumi.Parent(args.ParentResource), pulumi.DeletedWith(args.ParentResource))
 	}
 
-	var err error
-	runner.waitCommand, err = args.ReadyFunc(runner)
-	if err != nil {
-		return nil, err
+	if args.ReadyFunc != nil {
+		var err error
+		runner.waitCommand, err = args.ReadyFunc(runner)
+		if err != nil {
+			return nil, err
+		}
+		runner.options = append(runner.options, utils.PulumiDependsOn(runner.waitCommand))
 	}
-	runner.options = append(runner.options, utils.PulumiDependsOn(runner.waitCommand))
 
 	return runner, nil
 }

--- a/scenarios/aws/microVMs/microvms/domain.go
+++ b/scenarios/aws/microVMs/microvms/domain.go
@@ -5,13 +5,14 @@ import (
 	"net"
 	"path/filepath"
 
+	"github.com/pulumi/pulumi-libvirt/sdk/go/libvirt"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/namer"
 	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/microVMs/microvms/resources"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/microVMs/vmconfig"
-	"github.com/pulumi/pulumi-libvirt/sdk/go/libvirt"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 const dhcpEntriesTemplate = "<host mac='%s' name='%s' ip='%s'/>"
@@ -31,6 +32,7 @@ type Domain struct {
 	domainNamer namer.Namer
 	ip          string
 	mac         pulumi.StringOutput
+	lvDomain    *libvirt.Domain
 }
 
 func generateDomainIdentifier(vcpu, memory int, vmsetName, tag, arch string) string {

--- a/scenarios/aws/microVMs/microvms/libvirt.go
+++ b/scenarios/aws/microVMs/microvms/libvirt.go
@@ -6,12 +6,13 @@ import (
 	"path/filepath"
 	"sort"
 
+	"github.com/pulumi/pulumi-libvirt/sdk/go/libvirt"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
 	"github.com/DataDog/test-infra-definitions/common/namer"
 	"github.com/DataDog/test-infra-definitions/components/command"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/microVMs/microvms/resources"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/microVMs/vmconfig"
-	"github.com/pulumi/pulumi-libvirt/sdk/go/libvirt"
-	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 const domainSocketCreateCmd = `rm -f /tmp/%s.sock && python3 -c "import socket as s; sock = s.socket(s.AF_UNIX); sock.bind('/tmp/%s.sock')"`
@@ -329,21 +330,11 @@ func LaunchVMCollections(vmCollections []*VMCollection, depends []pulumi.Resourc
 			if err != nil {
 				return libvirtDomains, err
 			}
+			domain.lvDomain = d
 
 			libvirtDomains = append(libvirtDomains, d)
 		}
 	}
 
 	return libvirtDomains, nil
-}
-
-func GetDomainIPMap(vmCollections []*VMCollection) map[string]string {
-	ipInformation := make(map[string]string)
-	for _, collection := range vmCollections {
-		for _, domain := range collection.domains {
-			ipInformation[domain.domainID] = domain.ip
-		}
-	}
-
-	return ipInformation
 }

--- a/scenarios/aws/microVMs/microvms/network.go
+++ b/scenarios/aws/microVMs/microvms/network.go
@@ -6,12 +6,13 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/DataDog/test-infra-definitions/common/namer"
-	"github.com/DataDog/test-infra-definitions/components/command"
-	"github.com/DataDog/test-infra-definitions/scenarios/aws/microVMs/microvms/resources"
 	"github.com/pulumi/pulumi-libvirt/sdk/go/libvirt"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+
+	"github.com/DataDog/test-infra-definitions/common/namer"
+	"github.com/DataDog/test-infra-definitions/components/command"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/microVMs/microvms/resources"
 )
 
 // The microvm subnet changed from /16 to /24 because the underlying libvirt sdk would identify
@@ -60,6 +61,13 @@ func freeSubnet(subnet string) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func getMicroVMGroupSubnetPattern(subnet string) string {
+	ip, _, _ := net.ParseCIDR(subnet)
+	ipv4 := ip.To4()
+	// this assumes a /24
+	return fmt.Sprintf("%d.%d.%d.*", ipv4[0], ipv4[1], ipv4[2])
 }
 
 func getMicroVMGroupSubnet() (string, error) {

--- a/scenarios/aws/microVMs/microvms/proxy.go
+++ b/scenarios/aws/microVMs/microvms/proxy.go
@@ -1,0 +1,30 @@
+package microvms
+
+import (
+	"github.com/pulumi/pulumi-command/sdk/go/command/remote"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func createProxyConnection(ip pulumi.StringInput, user string, sshKeyContent pulumi.StringOutput, proxyConn remote.ConnectionOutput) remote.ConnectionOutput {
+	conn := remote.ConnectionArgs{
+		Host:           ip,
+		PerDialTimeout: pulumi.IntPtr(5),
+		DialErrorLimit: pulumi.IntPtr(60),
+		User:           pulumi.StringPtr(user),
+		PrivateKey:     sshKeyContent,
+	}
+
+	conn.Proxy = remote.ProxyConnectionPtr(&remote.ProxyConnectionArgs{
+		AgentSocketPath:    proxyConn.AgentSocketPath(),
+		DialErrorLimit:     proxyConn.DialErrorLimit(),
+		Host:               proxyConn.Host(),
+		Password:           proxyConn.Password(),
+		PerDialTimeout:     proxyConn.PerDialTimeout(),
+		Port:               proxyConn.Port(),
+		PrivateKey:         proxyConn.PrivateKey(),
+		PrivateKeyPassword: proxyConn.PrivateKeyPassword(),
+		User:               proxyConn.User(),
+	})
+
+	return conn.ToConnectionOutput()
+}

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -38,9 +38,24 @@ type sshKeyPair struct {
 }
 
 const (
-	LocalVMSet            = "local"
-	defaultShutdownPeriod = 360 // minutes
+	LocalVMSet              = "local"
+	defaultShutdownPeriod   = 360 // minutes
+	libvirtSSHPrivateKeyX86 = "libvirt_rsa-x86"
+	libvirtSSHPrivateKeyArm = "libvirt_rsa-arm"
 )
+
+var SSHKeyFileNames = map[string]string{
+	ec2.AMD64Arch: libvirtSSHPrivateKeyX86,
+	ec2.ARM64Arch: libvirtSSHPrivateKeyArm,
+}
+
+var GetWorkingDirectory func() string
+
+func getKernelVersionTestingWorkingDir(m *config.DDMicroVMConfig) func() string {
+	return func() string {
+		return m.GetStringWithDefault(m.MicroVMConfig, config.DDMicroVMWorkingDirectory, "/tmp")
+	}
+}
 
 func getSSHKeyPairFiles(m *config.DDMicroVMConfig, arch string) sshKeyPair {
 	var pair sshKeyPair

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -370,7 +370,7 @@ func run(e commonConfig.CommonEnvironment) (*ScenarioDone, error) {
 				command.RunnerArgs{
 					ParentResource: domain.lvDomain,
 					Connection:     pc,
-					ConnectionName: collection.instance.instanceNamer.ResourceName("conn-" + domain.ip),
+					ConnectionName: collection.instance.instanceNamer.ResourceName("conn", domain.ip),
 					OSCommand:      command.NewUnixOSCommand(),
 				},
 			)

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -374,6 +374,9 @@ func run(e commonConfig.CommonEnvironment) (*ScenarioDone, error) {
 					OSCommand:      command.NewUnixOSCommand(),
 				},
 			)
+			if err != nil {
+				return nil, err
+			}
 			microRunner := NewRunner(WithRemoteRunner(remoteRunner))
 
 			allowEnvDone, err := setupSSHAllowEnv(microRunner, append(readKeyDone, domain.lvDomain))


### PR DESCRIPTION
What does this PR do?
---------------------

Adds SSH config to microvm provisioning:
- Add `AcceptEnv DD_API_KEY` to `sshd_config`
- Setup SSH config files

Which scenarios this will impact?
-------------------
microVMs

Motivation
----------
- Ability to send metrics from metal instances and micro vms.
- Prevent repeating of SSH options
- Easier SSH to metal instance and microvm from commands

Additional Notes
----------------

https://datadoghq.atlassian.net/browse/EBPF-237
