### PR TITLE
Use InstanceName for instance name instead of ImageName

### DIFF
--- a/scenarios/aws/vm/ec2vm/ec2VM.go
+++ b/scenarios/aws/vm/ec2vm/ec2VM.go
@@ -53,7 +53,7 @@ func NewEC2VMWithEnv(env aws.Environment, options ...ec2params.Option) (*EC2VM, 
 	}
 	instance, err := awsEc2.NewEC2Instance(
 		env,
-		env.CommonNamer.ResourceName(commonParams.ImageName),
+		env.CommonNamer.ResourceName(commonParams.InstanceName),
 		commonParams.ImageName,
 		osValue.GetAMIArch(commonParams.Arch),
 		commonParams.InstanceType,


### PR DESCRIPTION
What does this PR do?
---------------------
Use InstanceName for instance name instead of ImageName

Which scenarios this will impact?
-------------------

Motivation
----------
The name was based off ImageName so creating two VMs from the same AMI resulted a name collision

Additional Notes
----------------
