### PR TITLE
[task] 🤖 install pulumi plugins at setup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ integration-testing:
     - ssh-add $E2E_PRIVATE_KEY_PATH
     - pip install -r requirements.txt
   script:
-    - go test ./integration-tests -v
+    - go test ./integration-tests -v -timeout 0s
   variables:
     E2E_PUBLIC_KEY_PATH: /tmp/agent-integration-test-ssh-key.pub
     E2E_PRIVATE_KEY_PATH: /tmp/agent-integration-test-ssh-key

--- a/integration-tests/testfixture/config.yaml
+++ b/integration-tests/testfixture/config.yaml
@@ -1,0 +1,11 @@
+configParams:
+  agent:
+    apiKey: '00000000000000000000000000000000'
+    appKey: '0000000000000000000000000000000000000000'
+  aws:
+    account: agent-qa
+    keyPairName: KEY_PAIR_NAME
+    publicKeyPath: PUBLIC_KEY_PATH
+    teamTag: test-ci
+options:
+  checkKeyPair: false

--- a/tasks/doc.py
+++ b/tasks/doc.py
@@ -25,7 +25,6 @@ ami_id: str = "A full Amazon Machine Image (AMI) id (e.g. ami-0123456789abcdef0)
 architecture: str = f"The architecture to use. Possible values are {tool.get_architectures()}. Default '{tool.get_default_architecture()}'"
 yes: str = "Automatically approve and perform the destroy without previewing it"
 use_aws_vault: str = "Wrap aws command with aws-vault, default to True"
-copy_to_clipboard: str = "Enable copy to clipboard, default to True"
 interactive: str = "Enable interactive mode, if set to False notifications and copy to clipboard are disabled"
 config_path: str = "Specify a custom config path to use"
 use_loadBalancer: str = "Use a loadBalancer to instantiate the fakeintake (default False)"

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -28,6 +28,8 @@ def setup(_: Context, config_path: Optional[str] = None, interactive: Optional[b
     else:
         os.system("brew install pulumi/tap/pulumi")
 
+    # install plugins
+    os.system("pulumi --non-interactive plugin install")
     # login to local stack storage
     os.system("pulumi login --local")
 

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -15,10 +15,10 @@ from .tool import ask, info, is_linux, is_windows, warn
 available_aws_accounts = ["agent-sandbox", "sandbox", "agent-qa"]
 
 
-@task(help={"config_path": doc.config_path, "copy_to_clipboard": doc.copy_to_clipboard})
-def setup(_: Context, config_path: Optional[str] = None, copy_to_clipboard: Optional[bool] = True) -> None:
+@task(help={"config_path": doc.config_path, "interactive": doc.interactive})
+def setup(_: Context, config_path: Optional[str] = None, interactive: Optional[bool] = True) -> None:
     """
-    Setup a local environment interactively
+    Setup a local environment, interactively by default
     """
     info("🤖 Install Pulumi")
     if is_windows():
@@ -28,26 +28,29 @@ def setup(_: Context, config_path: Optional[str] = None, copy_to_clipboard: Opti
     else:
         os.system("brew install pulumi/tap/pulumi")
 
+    # login to local stack storage
     os.system("pulumi login --local")
 
     info("🤖 Let's configure your environment for e2e tests! Press ctrl+c to stop me")
     try:
         config = get_local_config(config_path)
     except Exception:
-        config = Config.parse_obj({})
+        config = Config.model_validate({})
 
-    # AWS config
-    setupAWSConfig(config)
-    # Agent config
-    setupAgentConfig(config)
+    if interactive:
+        # AWS config
+        setupAWSConfig(config)
+        # Agent config
+        setupAgentConfig(config)
 
     config.save_to_local_config(config_path)
-    cat_profile_command = f"cat {get_full_profile_path(config_path)}"
-    if copy_to_clipboard:
+
+    if interactive:
+        cat_profile_command = f"cat {get_full_profile_path(config_path)}"
         pyperclip.copy(cat_profile_command)
-    print(
-        f"\nYou can run the following command to print your configuration: `{cat_profile_command}`. This command was copied to the clipboard\n"
-    )
+        print(
+            f"\nYou can run the following command to print your configuration: `{cat_profile_command}`. This command was copied to the clipboard\n"
+        )
 
 
 def setupAWSConfig(config: Config):


### PR DESCRIPTION
What does this PR do?
---------------------

Install pulumi plugins at `inv setup` time

Which scenarios this will impact?
-------------------

None

Motivation
----------

E2E tests in `datadog-agent` do not run invoke tasks to create resources, so do not install plugins out of the box. Adding explicit plugin install from the setup script, that can be safely re-executed as it reloads a existing local profile, plus it can be interrupted after all install steps are executed

Additional Notes
----------------
