### PR TITLE
[ASCII-749][APL-2241] Allow multiple Fakeintakes

### DIFF
--- a/components/datadog/apps/fakeintake/fargateFakeintakeService.go
+++ b/components/datadog/apps/fakeintake/fargateFakeintakeService.go
@@ -28,8 +28,8 @@ type Instance struct {
 	Host pulumi.StringOutput
 }
 
-func NewECSFargateInstance(e aws.Environment) (*Instance, error) {
-	namer := e.Namer.WithPrefix("fakeintake")
+func NewECSFargateInstance(e aws.Environment, name string) (*Instance, error) {
+	namer := e.Namer.WithPrefix(name)
 	opts := []pulumi.ResourceOption{e.WithProviders(config.ProviderAWS, config.ProviderAWSX)}
 
 	instance := &Instance{}
@@ -44,12 +44,12 @@ func NewECSFargateInstance(e aws.Environment) (*Instance, error) {
 	var err error
 	if e.InfraShouldDeployFakeintakeWithLB() {
 		alb, err = lb.NewApplicationLoadBalancer(e.Ctx, namer.ResourceName("lb"), &lb.ApplicationLoadBalancerArgs{
-			Name:           e.CommonNamer.DisplayName(32, pulumi.String("fakeintake")),
+			Name:           e.CommonNamer.DisplayName(32, pulumi.String(name)),
 			SubnetIds:      e.RandomSubnets(),
 			Internal:       pulumi.BoolPtr(!e.ECSServicePublicIP()),
 			SecurityGroups: pulumi.ToStringArray(e.DefaultSecurityGroups()),
 			DefaultTargetGroup: &lb.TargetGroupArgs{
-				Name:       e.CommonNamer.DisplayName(32, pulumi.String("fakeintake")),
+				Name:       e.CommonNamer.DisplayName(32, pulumi.String(name)),
 				Port:       pulumi.IntPtr(port),
 				Protocol:   pulumi.StringPtr("HTTP"),
 				TargetType: pulumi.StringPtr("ip"),
@@ -82,7 +82,7 @@ func NewECSFargateInstance(e aws.Environment) (*Instance, error) {
 
 	if _, err := ecs.NewFargateService(e.Ctx, namer.ResourceName("srv"), &ecs.FargateServiceArgs{
 		Cluster:              pulumi.StringPtr(e.ECSFargateFakeintakeClusterArn()),
-		Name:                 e.CommonNamer.DisplayName(255, pulumi.String("fakeintake")),
+		Name:                 e.CommonNamer.DisplayName(255, pulumi.String(name)),
 		DesiredCount:         pulumi.IntPtr(1),
 		EnableExecuteCommand: pulumi.BoolPtr(true),
 		NetworkConfiguration: &classicECS.ServiceNetworkConfigurationArgs{

--- a/components/datadog/fakeintake/connectionExporter.go
+++ b/components/datadog/fakeintake/connectionExporter.go
@@ -8,10 +8,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-const (
-	stackKey = "fakeintake-host"
-)
-
 // ConnectionExporter contains pulumi side data and the export key
 type ConnectionExporter struct {
 	Host     pulumi.StringInput
@@ -36,7 +32,8 @@ func (exporter *ConnectionExporter) Deserialize(result auto.UpResult) (*ClientDa
 }
 
 // NewExporter registers a fakeintake url into a Pulumi context.
-func NewExporter(ctx *pulumi.Context, host pulumi.StringInput) *ConnectionExporter {
+func NewExporter(ctx *pulumi.Context, host pulumi.StringInput, name string) *ConnectionExporter {
+	stackKey := fmt.Sprintf("%s-host", name)
 	ctx.Export(stackKey, host)
 	return &ConnectionExporter{
 		stackKey: stackKey,

--- a/scenarios/aws/fakeintake.go
+++ b/scenarios/aws/fakeintake.go
@@ -7,10 +7,14 @@ import (
 )
 
 func NewEcsFakeintake(env resourcesAws.Environment) (*ddfakeintake.ConnectionExporter, error) {
-	fargateInstance, err := fakeintake.NewECSFargateInstance(env)
+	return NewEcsFakeintakeWithName(env, "fakeintake")
+}
+
+func NewEcsFakeintakeWithName(env resourcesAws.Environment, name string) (*ddfakeintake.ConnectionExporter, error) {
+	fargateInstance, err := fakeintake.NewECSFargateInstance(env, name)
 	if err != nil {
 		return nil, err
 	}
 
-	return ddfakeintake.NewExporter(env.Ctx, fargateInstance.Host), nil
+	return ddfakeintake.NewExporter(env.Ctx, fargateInstance.Host, name), nil
 }


### PR DESCRIPTION
What does this PR do?
---------------------
Enable running several Fakeintakes (and their load balancers) in the same test. 

Which scenarios this will impact?
-------------------
AWS Fakeintake 

Motivation
----------
I need to run two Fakeintakes for a test of the agent. 

Additional Notes
----------------
This PR builds on top of https://github.com/DataDog/test-infra-definitions/pull/403 so it shouldn't merged before it.

This change was tested by writing https://github.com/DataDog/datadog-agent/pull/20167.
