### PR TITLE
[CONTINT-3310] Set GOMEMLIMIT to the fake intake

### DIFF
--- a/components/datadog/apps/fakeintake/fargateFakeintakeService.go
+++ b/components/datadog/apps/fakeintake/fargateFakeintakeService.go
@@ -98,7 +98,12 @@ func NewECSFargateInstance(e aws.Environment) (*Instance, error) {
 					Image:       pulumi.String("public.ecr.aws/datadog/fakeintake:latest"),
 					Essential:   pulumi.BoolPtr(true),
 					MountPoints: ecs.TaskDefinitionMountPointArray{},
-					Environment: ecs.TaskDefinitionKeyValuePairArray{},
+					Environment: ecs.TaskDefinitionKeyValuePairArray{
+						ecs.TaskDefinitionKeyValuePairArgs{
+							Name:  pulumi.StringPtr("GOMEMLIMIT"),
+							Value: pulumi.StringPtr("768MiB"),
+						},
+					},
 					PortMappings: ecs.TaskDefinitionPortMappingArray{
 						ecs.TaskDefinitionPortMappingArgs{
 							ContainerPort: pulumi.Int(port),


### PR DESCRIPTION
What does this PR do?
---------------------

Set `GOMEMLIMIT` to the fake intake to ¾ of its memory limit.
As `GOMEMLIMIT` is a “soft” memory limit, it’s safer to take a security margin.

Which scenarios this will impact?
-------------------

Motivation
----------

Without it, the memory is never released. The memory consumed by the fake intake keeps on increasing forever until it is OOM killed.

Additional Notes
----------------

![image](https://github.com/DataDog/test-infra-definitions/assets/1437785/f1b62370-cced-408e-a9e1-321e917d0668)
