### PR TITLE
Add event platform endpoints to Agent config when using Fake Intake

### DIFF
--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -196,34 +196,29 @@ func WithTelemetry() func(*Params) error {
 // WithFakeintake installs the fake intake and configures the Agent to use it.
 func WithFakeintake(fakeintake *fakeintake.ConnectionExporter) func(*Params) error {
 	return func(p *Params) error {
-		// configure metrics and check run intake
-		args := make([]interface{}, 12) // number of %s in the configuration (horribly hardcoded)
-		for idx := range args {
-			args[idx] = fakeintake.Host
-		}
-		extraConfig := pulumi.Sprintf(`dd_url: http://%s:80
-logs_config.logs_dd_url: %s:80
+		extraConfig := pulumi.Sprintf(`dd_url: http://%[1]s:80
+logs_config.logs_dd_url: %[1]s:80
 logs_config.logs_no_ssl: true
 logs_config.force_use_http: true
-process_config.process_dd_url: http://%s:80
-database_monitoring.metrics.logs_dd_url: %s:80
+process_config.process_dd_url: http://%[1]s:80
+database_monitoring.metrics.logs_dd_url: %[1]s:80
 database_monitoring.metrics.logs_no_ssl: true
-database_monitoring.activity.logs_dd_url: %s:80
+database_monitoring.activity.logs_dd_url: %[1]s:80
 database_monitoring.activity.logs_no_ssl: true
-database_monitoring.samples.logs_dd_url: %s:80
+database_monitoring.samples.logs_dd_url: %[1]s:80
 database_monitoring.samples.logs_no_ssl: true
-network_devices.metadata.logs_dd_url: %s:80
+network_devices.metadata.logs_dd_url: %[1]s:80
 network_devices.metadata.logs_no_ssl: true
-network_devices.snmp_traps.forwarder.logs_dd_url: %s:80
+network_devices.snmp_traps.forwarder.logs_dd_url: %[1]s:80
 network_devices.snmp_traps.forwarder.logs_no_ssl: true
-network_devices.netflow.forwarder.logs_dd_url: %s:80
+network_devices.netflow.forwarder.logs_dd_url: %[1]s:80
 network_devices.netflow.forwarder.logs_no_ssl: true
-container_lifecycle.logs_dd_url: %s:80
+container_lifecycle.logs_dd_url: %[1]s:80
 container_lifecycle.logs_no_ssl: true
-container_image.logs_dd_url: %s:80
+container_image.logs_dd_url: %[1]s:80
 container_image.logs_no_ssl: true
-sbom.logs_dd_url: %s:80
-sbom.logs_no_ssl: true`, args...)
+sbom.logs_dd_url: %[1]s:80
+sbom.logs_no_ssl: true`, fakeintake.Host)
 		p.ExtraAgentConfig = append(p.ExtraAgentConfig, extraConfig)
 		return nil
 	}

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -197,11 +197,33 @@ func WithTelemetry() func(*Params) error {
 func WithFakeintake(fakeintake *fakeintake.ConnectionExporter) func(*Params) error {
 	return func(p *Params) error {
 		// configure metrics and check run intake
+		args := make([]interface{}, 12) // number of %s in the configuration (horribly hardcoded)
+		for idx := range args {
+			args[idx] = fakeintake.Host
+		}
 		extraConfig := pulumi.Sprintf(`dd_url: http://%s:80
 logs_config.logs_dd_url: %s:80
 logs_config.logs_no_ssl: true
 logs_config.force_use_http: true
-process_config.process_dd_url: http://%s:80`, fakeintake.Host, fakeintake.Host, fakeintake.Host)
+process_config.process_dd_url: http://%s:80
+database_monitoring.metrics.logs_dd_url: %s:80
+database_monitoring.metrics.logs_no_ssl: true
+database_monitoring.activity.logs_dd_url: %s:80
+database_monitoring.activity.logs_no_ssl: true
+database_monitoring.samples.logs_dd_url: %s:80
+database_monitoring.samples.logs_no_ssl: true
+network_devices.metadata.logs_dd_url: %s:80
+network_devices.metadata.logs_no_ssl: true
+network_devices.snmp_traps.forwarder.logs_dd_url: %s:80
+network_devices.snmp_traps.forwarder.logs_no_ssl: true
+network_devices.netflow.forwarder.logs_dd_url: %s:80
+network_devices.netflow.forwarder.logs_no_ssl: true
+container_lifecycle.logs_dd_url: %s:80
+container_lifecycle.logs_no_ssl: true
+container_image.logs_dd_url: %s:80
+container_image.logs_no_ssl: true
+sbom.logs_dd_url: %s:80
+sbom.logs_no_ssl: true`, args...)
 		p.ExtraAgentConfig = append(p.ExtraAgentConfig, extraConfig)
 		return nil
 	}

--- a/components/datadog/apps/fakeintake/fargateFakeintakeService.go
+++ b/components/datadog/apps/fakeintake/fargateFakeintakeService.go
@@ -95,7 +95,7 @@ func NewECSFargateInstance(e aws.Environment) (*Instance, error) {
 			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
 				containerName: {
 					Name:        pulumi.String(containerName),
-					Image:       pulumi.String("public.ecr.aws/datadog/fakeintake:latest"),
+					Image:       pulumi.String("kaderinho/fakeintake:0.0.3"),
 					Essential:   pulumi.BoolPtr(true),
 					MountPoints: ecs.TaskDefinitionMountPointArray{},
 					Environment: ecs.TaskDefinitionKeyValuePairArray{},
@@ -152,7 +152,7 @@ func fargateLinuxTaskDefinition(e aws.Environment, name string) (*ecs.FargateTas
 func fargateLinuxContainerDefinition() *ecs.TaskDefinitionContainerDefinitionArgs {
 	return &ecs.TaskDefinitionContainerDefinitionArgs{
 		Name:        pulumi.String(containerName),
-		Image:       pulumi.String("public.ecr.aws/datadog/fakeintake:latest"),
+		Image:       pulumi.String("kaderinho/fakeintake:0.0.3"),
 		Essential:   pulumi.BoolPtr(true),
 		MountPoints: ecs.TaskDefinitionMountPointArray{},
 		Environment: ecs.TaskDefinitionKeyValuePairArray{},

--- a/components/datadog/apps/fakeintake/fargateFakeintakeService.go
+++ b/components/datadog/apps/fakeintake/fargateFakeintakeService.go
@@ -95,7 +95,7 @@ func NewECSFargateInstance(e aws.Environment) (*Instance, error) {
 			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
 				containerName: {
 					Name:        pulumi.String(containerName),
-					Image:       pulumi.String("kaderinho/fakeintake:0.0.3"),
+					Image:       pulumi.String("public.ecr.aws/datadog/fakeintake:latest"),
 					Essential:   pulumi.BoolPtr(true),
 					MountPoints: ecs.TaskDefinitionMountPointArray{},
 					Environment: ecs.TaskDefinitionKeyValuePairArray{},
@@ -152,7 +152,7 @@ func fargateLinuxTaskDefinition(e aws.Environment, name string) (*ecs.FargateTas
 func fargateLinuxContainerDefinition() *ecs.TaskDefinitionContainerDefinitionArgs {
 	return &ecs.TaskDefinitionContainerDefinitionArgs{
 		Name:        pulumi.String(containerName),
-		Image:       pulumi.String("kaderinho/fakeintake:0.0.3"),
+		Image:       pulumi.String("public.ecr.aws/datadog/fakeintake:latest"),
 		Essential:   pulumi.BoolPtr(true),
 		MountPoints: ecs.TaskDefinitionMountPointArray{},
 		Environment: ecs.TaskDefinitionKeyValuePairArray{},


### PR DESCRIPTION
What does this PR do?
---------------------

Add event platform endpoints to the Agent config when using the fake intake.

Which scenarios this will impact?
-------------------

I'm currently testing the diagnose command and the command is failing because the Agent is sending request to the real backend with a dummy API Key.

Motivation
----------

Additional Notes
----------------
