### PR TITLE
Give more priority to E2E_VERSION than E2E_PIPELINE_ID

### DIFF
--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -53,11 +53,11 @@ func NewParams(env *config.CommonEnvironment, options ...Option) (*Params, error
 		Files:        make(map[string]*FileDefinition),
 	}
 	defaultVersion := WithLatest()
-	if env.AgentVersion() != "" {
-		defaultVersion = WithVersion(env.AgentVersion())
-	}
 	if env.PipelineID() != "" {
 		defaultVersion = WithPipelineID(env.PipelineID())
+	}
+	if env.AgentVersion() != "" {
+		defaultVersion = WithVersion(env.AgentVersion())
 	}
 	options = append([]Option{defaultVersion}, options...)
 	return common.ApplyOption(p, options)


### PR DESCRIPTION
What does this PR do?
---------------------

Change `if` order so that agent version defined by `E2E_VERSION` has more priority than `E2E_PIPELINE_ID`

Which scenarios this will impact?
-------------------

`E2E_PIPELINE_ID` is [set](https://github.com/DataDog/datadog-agent/blob/f3a8e91bda24d892bc898f3c3e6cdd78bde7d861/.gitlab/e2e.yml#L145) in the Agent which means that whenever we want to use a stable version we need to set both `E2E_VERSION=<version>` and `E2E_PIPELINE_ID=""`

With this change, we'll always take `E2E_VERSION` if set, or `E2E_PIPELINE_ID` otherwise

QQ: are there others scenarios where we absolutely need `E2E_PIPELINE_ID` to have priority ?

Motivation
----------

Allow to use a stable version in the CI with a more straightforward way (1 variable to set VS 1 set + 1 unset)


Additional Notes
----------------
