### PR TITLE
[ASCII-813] Use fullpath for filemanager.CreateDirectory URN to avoid collisions

### DIFF
--- a/components/command/filemanager.go
+++ b/components/command/filemanager.go
@@ -32,8 +32,12 @@ func (fm *FileManager) CreateDirectoryFromPulumiString(name string, remotePath p
 }
 
 // CreateDirectory if it does not exist
+// To avoid pulumi.URN colisions if multiple files use the same directory, use the full filePath as URN and path.Split out the folderPath for creation
 func (fm *FileManager) CreateDirectory(remotePath string, useSudo bool, opts ...pulumi.ResourceOption) (*remote.Command, error) {
-	return fm.command.CreateDirectory(fm.runner, "create-directory-"+remotePath, pulumi.String(remotePath), useSudo, opts...)
+	// if given just a directory path, path.Split returns "" as file
+	//  eg. path.Split("/a/b/c/") -> "/a/b/c/", ""
+	folderPath, _ := path.Split(remotePath)
+	return fm.command.CreateDirectory(fm.runner, "create-directory-"+remotePath, pulumi.String(folderPath), useSudo, opts...)
 }
 
 // TempDirectory creates a temporary directory

--- a/components/datadog/agent/install.go
+++ b/components/datadog/agent/install.go
@@ -201,10 +201,9 @@ func writeFileDefinition(
 	lastCommand *remote.Command) (*remote.Command, error) {
 
 	var err error
-	folderPath, _ := path.Split(fullPath)
 
 	// create directory, if it does not exist
-	lastCommand, err = fileManager.CreateDirectory(folderPath, useSudo, utils.PulumiDependsOn(lastCommand))
+	lastCommand, err = fileManager.CreateDirectory(fullPath, useSudo, utils.PulumiDependsOn(lastCommand))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
What does this PR do?
---------------------
https://datadoghq.atlassian.net/browse/ASCII-813

A [regression](https://github.com/DataDog/test-infra-definitions/pull/370/files#diff-d6270b8251ada7206e555490824170a9ea17dbdac920e01ca051764c21369460L207-R207) stopped using a full filepath for the filemanager.CreateDirectory pulumi.URN which now has a collision bug with multiple files attempting to be created in the same folder.

<img width="1508" alt="Screenshot 2023-10-17 at 4 26 30 PM" src="https://github.com/DataDog/test-infra-definitions/assets/16483405/ec476ab1-1a0e-4f66-abb9-90768038bc6c">

This fixes the collision issue by moving the path.Split to the filemanager.CreateDirectory step and using the fullpath as the URN again

<img width="1501" alt="Screenshot 2023-10-17 at 4 19 39 PM" src="https://github.com/DataDog/test-infra-definitions/assets/16483405/2c142d64-74d4-4919-8ce3-89b48340b231">


Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
