### PR TITLE
Fix Windows SSH service installation

### DIFF
--- a/scenarios/aws/vm/ec2vm/ec2VM.go
+++ b/scenarios/aws/vm/ec2vm/ec2VM.go
@@ -124,7 +124,7 @@ func GetOpenSSHInstallCmd(publicKeyPath string) (string, error) {
 	$service = Get-Service -Name sshd -ErrorAction SilentlyContinue
 	# Don't try to reinstall OpenSSH if the user uses <persist>true</persist> on UserData.
 	if ($service -eq $null) {
-		Add-WindowsCapability -Online -Name OpenSSH.Server
+		Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
 		Set-Service -Name sshd -StartupType Automatic
 		Add-Content -Path $env:ProgramData\ssh\administrators_authorized_keys -Value '%v'
 		icacls.exe ""$env:ProgramData\ssh\administrators_authorized_keys"" /inheritance:r /grant ""Administrators:F"" /grant ""SYSTEM:F""


### PR DESCRIPTION
- The full package name is required to install sshd on Windows

What does this PR do?
---------------------
Updates the PowerShell install script to include the full specification for the OpenSSH server package.

Which scenarios this will impact?
-------------------
All Windows.

Motivation
----------
When attempting to use the `inv create-vm` tool, with an AMI for Windows 2019, the SSH setup step silently failed and the sshd service wasn't installed. This prevented any SSH connections.

Additional Notes
----------------
This is a quick fix for Windows servers, however, there is a slightly better option we should consider in the long run that installs openssh from a known Github MSI package. Right now, an example of that exists in dev branch in a file within datadog-agent. A future PR should consolidate this functionality into 1 source of true, but for the time being to unblock resource provisioning in this repo, this is sufficient.