### PR TITLE
[CONS-3310, CONS-3314] Make the Nginx and Redis deployments scale faster

### DIFF
--- a/components/datadog/apps/nginx/k8s.go
+++ b/components/datadog/apps/nginx/k8s.go
@@ -274,6 +274,14 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("query"),
 							Image: pulumi.String("ghcr.io/datadog/apps-http-client:main"),
+							Args: pulumi.StringArray{
+								pulumi.String("-min-tps"),
+								pulumi.String("1"),
+								pulumi.String("-max-tps"),
+								pulumi.String("60"),
+								pulumi.String("-period"),
+								pulumi.String("20m"),
+							},
 							Resources: &corev1.ResourceRequirementsArgs{
 								Limits: pulumi.StringMap{
 									"cpu":    pulumi.String("100m"),

--- a/components/datadog/apps/redis/k8s.go
+++ b/components/datadog/apps/redis/k8s.go
@@ -224,6 +224,14 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("query"),
 							Image: pulumi.String("ghcr.io/datadog/apps-redis-client:main"),
+							Args: pulumi.StringArray{
+								pulumi.String("-min-tps"),
+								pulumi.String("1"),
+								pulumi.String("-max-tps"),
+								pulumi.String("60"),
+								pulumi.String("-period"),
+								pulumi.String("20m"),
+							},
 							Resources: &corev1.ResourceRequirementsArgs{
 								Limits: pulumi.StringMap{
 									"cpu":    pulumi.String("100m"),


### PR DESCRIPTION
What does this PR do?
---------------------

Make the `nginx` and `redis` Kubernetes deployments scale up and down faster.

Which scenarios this will impact?
-------------------

* `kind` and
* `eks`

Motivation
----------

The tests that are validating that the Kubernetes HPA is properly scaling up and down are sometimes failing because they don’t wait long enough.

Here is an example of such a job: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/353184628
The error is:
```
=== Failed
=== FAIL: tests/containers TestKindSuite/TestNginx/kubernetes_state.deployment.replicas_available{kube_namespace:workload-nginx,kube_deployment:nginx} (1200.00s)
    k8s_test.go:361: No scale down detected
    k8s_test.go:361: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:361
        	            				/go/pkg/mod/github.com/stretchr/testify@v1.8.5-0.20231013065317-89920137cdfa/suite/suite.go:112
        	Error:      	Condition never satisfied
        	Test:       	TestKindSuite/TestNginx/kubernetes_state.deployment.replicas_available{kube_namespace:workload-nginx,kube_deployment:nginx}
        	Messages:   	Failed to witness scale up and scale down of workload-nginx.nginx
        --- FAIL: TestKindSuite/TestNginx/kubernetes_state.deployment.replicas_available{kube_namespace:workload-nginx,kube_deployment:nginx} (1200.00s)
```

And indeed, that’s true: during the test, there has been only scale up: https://dddev.datadoghq.com/dashboard/qcp-brm-ysc/e2e-tests-containers-k8s?refresh_mode=paused&tpl_var_kube_cluster_name%5B0%5D=ci-22025215-4670-kind-cluster&from_ts=1697737881500&to_ts=1697739208989&live=false
![image](https://github.com/DataDog/test-infra-definitions/assets/1437785/3db87614-bdbd-4a03-88d1-149e78fdd06b)


Additional Notes
----------------

I’ve checked that the TPS still remain low or high long enough to have the HPA scaling: 
![image](https://github.com/DataDog/test-infra-definitions/assets/1437785/a6ff19f6-2289-46fc-a15c-584cef21d8a2)
