### PR TITLE
Update GO to 1.20 in the GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: "1.20"
 
       - name: Build
         run: go build ./...


### PR DESCRIPTION
What does this PR do?
---------------------

Update GO to 1.20 in the GitHub workflow.

Which scenarios this will impact?
-------------------

Motivation
----------

Since #305, the `go.mod` says that this project needs GO 1.20: https://github.com/DataDog/test-infra-definitions/blob/d08836e5ac08530051cc43c91f7bbf6bc1d8a29a/go.mod#L3

So, we need the CI build to use GO 1.20 as well.

Still using GO 1.19 is actually breaking some dependabot :dependabot: PRs:
#406 [fails with this error](https://github.com/DataDog/test-infra-definitions/actions/runs/6629940242/job/18010292295?pr=406):
```
Error: ../../../go/pkg/mod/github.com/pulumi/esc@v0.5.6/schema/schema.go:306:25: undefined: strings.CutPrefix
note: module requires Go 1.20
Error: Process completed with exit code 1.
```

Additional Notes
----------------
