### PR TITLE
[ASCII-749] Add WithIntakeHostname

### DIFF
--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -224,14 +224,18 @@ sbom.logs_no_ssl: true`, hostname)
 	}
 }
 
-// WithIntakeName configures the agent to use the given hostname as intake
-// This option is incompatible with `WithFakeintake`.
+// WithIntakeName configures the agent to use the given hostname as intake.
+//
+// To use a fakeintake, see WithFakeintake.
+//
+// This option is overwritten by `WithFakeintake`.
 func WithIntakeHostname(hostname string) func(*Params) error {
 	return withIntakeHostname(pulumi.String(hostname))
 }
 
 // WithFakeintake installs the fake intake and configures the Agent to use it.
-// This option is incompatible with `WithIntakeHostname`.
+//
+// This option is overwritten by `WithIntakeHostname`.
 func WithFakeintake(fakeintake *fakeintake.ConnectionExporter) func(*Params) error {
 	return withIntakeHostname(fakeintake.Host)
 }

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -26,6 +26,7 @@ import (
 //   - [WithIntegration]
 //   - [WithTelemetry]
 //   - [WithFakeintake]
+//   - [WithIntakeHostname]
 //   - [WithLogs]
 //
 // [Functional options pattern]: https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
@@ -193,8 +194,7 @@ func WithTelemetry() func(*Params) error {
 	}
 }
 
-// WithFakeintake installs the fake intake and configures the Agent to use it.
-func WithFakeintake(fakeintake *fakeintake.ConnectionExporter) func(*Params) error {
+func withIntakeHostname(hostname pulumi.StringInput) func(*Params) error {
 	return func(p *Params) error {
 		extraConfig := pulumi.Sprintf(`dd_url: http://%[1]s:80
 logs_config.logs_dd_url: %[1]s:80
@@ -218,10 +218,22 @@ container_lifecycle.logs_no_ssl: true
 container_image.logs_dd_url: %[1]s:80
 container_image.logs_no_ssl: true
 sbom.logs_dd_url: %[1]s:80
-sbom.logs_no_ssl: true`, fakeintake.Host)
+sbom.logs_no_ssl: true`, hostname)
 		p.ExtraAgentConfig = append(p.ExtraAgentConfig, extraConfig)
 		return nil
 	}
+}
+
+// WithIntakeName configures the agent to use the given hostname as intake
+// This option is incompatible with `WithFakeintake`.
+func WithIntakeHostname(hostname string) func(*Params) error {
+	return withIntakeHostname(pulumi.String(hostname))
+}
+
+// WithFakeintake installs the fake intake and configures the Agent to use it.
+// This option is incompatible with `WithIntakeHostname`.
+func WithFakeintake(fakeintake *fakeintake.ConnectionExporter) func(*Params) error {
+	return withIntakeHostname(fakeintake.Host)
 }
 
 // WithLogs enables the log agent


### PR DESCRIPTION
What does this PR do?
---------------------
Add a `WithIntakeHostname` agent option.

Which scenarios this will impact?
-------------------
Agent using a Fakeintake, although the change should be transparent (backward compatible).

Motivation
----------
Use a custom intake name in a test, without copy pasting the implementation of `WithFakeintake`.

Additional Notes
----------------
Implementation is exactly the same as `WithFakeintake`.
