### PR TITLE
[scenarios/aws/{kindvm,eks}] Add option to deploy standalone dogstatsd

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -19,6 +19,7 @@ const (
 	DDInfraConfigNamespace     = "ddinfra"
 	DDAgentConfigNamespace     = "ddagent"
 	DDTestingWorkloadNamespace = "ddtestworkload"
+	DDDogstatsdNamespace       = "dddogstatsd"
 
 	// Infra namespace
 	DDInfraEnvironment                      = "env"
@@ -45,6 +46,10 @@ const (
 
 	// Testing workload namerNamespace
 	DDTestingWorkloadDeployParamName = "deploy"
+
+	// Dogstatsd namespace
+	DDDogstatsdDeployParamName        = "deploy"
+	DDDogstatsdFullImagePathParamName = "fullImagePath"
 )
 
 type CommonEnvironment struct {
@@ -56,6 +61,7 @@ type CommonEnvironment struct {
 	InfraConfig           *sdkconfig.Config
 	AgentConfig           *sdkconfig.Config
 	TestingWorkloadConfig *sdkconfig.Config
+	DogstatsdConfig       *sdkconfig.Config
 
 	username string
 }
@@ -66,6 +72,7 @@ func NewCommonEnvironment(ctx *pulumi.Context) (CommonEnvironment, error) {
 		InfraConfig:           sdkconfig.New(ctx, DDInfraConfigNamespace),
 		AgentConfig:           sdkconfig.New(ctx, DDAgentConfigNamespace),
 		TestingWorkloadConfig: sdkconfig.New(ctx, DDTestingWorkloadNamespace),
+		DogstatsdConfig:       sdkconfig.New(ctx, DDDogstatsdNamespace),
 		CommonNamer:           namer.NewNamer(ctx, ""),
 		providerRegistry:      newProviderRegistry(ctx),
 	}
@@ -271,4 +278,14 @@ type Environment interface {
 // Testing workload namespace
 func (e *CommonEnvironment) TestingWorkloadDeploy() bool {
 	return e.GetBoolWithDefault(e.TestingWorkloadConfig, DDTestingWorkloadDeployParamName, true)
+}
+
+// Dogstatsd namespace
+
+func (e *CommonEnvironment) DogstatsdDeploy() bool {
+	return e.GetBoolWithDefault(e.DogstatsdConfig, DDDogstatsdDeployParamName, true)
+}
+
+func (e *CommonEnvironment) DogstatsdFullImagePath() string {
+	return e.GetStringWithDefault(e.DogstatsdConfig, DDDogstatsdFullImagePathParamName, "gcr.io/datadoghq/dogstatsd")
 }

--- a/components/datadog/dogstatsd-standalone/k8s.go
+++ b/components/datadog/dogstatsd-standalone/k8s.go
@@ -1,6 +1,8 @@
 package dogstatsdstandalone
 
 import (
+	"strconv"
+
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
 	ddfakeintake "github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
@@ -24,7 +26,7 @@ type K8sComponent struct {
 	pulumi.ResourceState
 }
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, fakeIntake *ddfakeintake.ConnectionExporter, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, fakeIntake *ddfakeintake.ConnectionExporter, kubeletTLSVerify bool, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &K8sComponent{}
@@ -81,7 +83,7 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 		},
 		&corev1.EnvVarArgs{
 			Name:  pulumi.String("DD_KUBELET_TLS_VERIFY"),
-			Value: pulumi.StringPtr("false"),
+			Value: pulumi.String(strconv.FormatBool(kubeletTLSVerify)),
 		},
 	}
 

--- a/components/datadog/dogstatsd-standalone/k8s.go
+++ b/components/datadog/dogstatsd-standalone/k8s.go
@@ -11,6 +11,14 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
+// HostPort defines the port used by the dogstatsd standalone deployment. The
+// standard port for dogstatsd is 8125, but it's already used by the agent.
+const HostPort = 8128
+
+// Socket defines the socket exposed by the dogstatsd standalone deployment.
+// It's not the default to avoid conflict with the agent.
+const Socket = "/var/run/datadog/dsd-standalone.socket"
+
 type K8sComponent struct {
 	pulumi.ResourceState
 }
@@ -68,7 +76,7 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 							Ports: corev1.ContainerPortArray{
 								&corev1.ContainerPortArgs{
 									ContainerPort: pulumi.Int(8125),
-									HostPort:      pulumi.Int(8125),
+									HostPort:      pulumi.Int(HostPort),
 									Name:          pulumi.StringPtr("dogstatsdport"),
 									Protocol:      pulumi.StringPtr("UDP"),
 								},
@@ -96,7 +104,7 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 								},
 								&corev1.EnvVarArgs{
 									Name:  pulumi.String("DD_DOGSTATSD_SOCKET"),
-									Value: pulumi.StringPtr("/var/run/datadog/dsd.socket"),
+									Value: pulumi.StringPtr(Socket),
 								},
 								&corev1.EnvVarArgs{
 									Name:  pulumi.String("DD_DOGSTATSD_TAG_CARDINALITY"),

--- a/components/datadog/dogstatsd-standalone/k8s.go
+++ b/components/datadog/dogstatsd-standalone/k8s.go
@@ -1,0 +1,246 @@
+package dogstatsdstandalone
+
+import (
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes"
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/apps/v1"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/meta/v1"
+	v1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/rbac/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+type K8sComponent struct {
+	pulumi.ResourceState
+}
+
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
+	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
+
+	k8sComponent := &K8sComponent{}
+	if err := e.Ctx.RegisterComponentResource("dd:dogstatsd-standalone", "dogstatsd", k8sComponent, opts...); err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, pulumi.Parent(k8sComponent))
+
+	ns, err := corev1.NewNamespace(
+		e.Ctx,
+		namespace,
+		&corev1.NamespaceArgs{
+			Metadata: metav1.ObjectMetaArgs{
+				Name: pulumi.String(namespace),
+			},
+		},
+		opts...,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, utils.PulumiDependsOn(ns))
+
+	daemonSetArgs := appsv1.DaemonSetArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.String("dogstatsd-standalone"),
+			Namespace: pulumi.String(namespace),
+		},
+		Spec: &appsv1.DaemonSetSpecArgs{
+			Selector: &metav1.LabelSelectorArgs{
+				MatchLabels: pulumi.StringMap{
+					"app": pulumi.String("dogstatsd-standalone"),
+				},
+			},
+			Template: &corev1.PodTemplateSpecArgs{
+				Metadata: &metav1.ObjectMetaArgs{
+					Labels: pulumi.StringMap{
+						"app": pulumi.String("dogstatsd-standalone"),
+					},
+				},
+				Spec: &corev1.PodSpecArgs{
+					HostPID:            pulumi.BoolPtr(true),
+					ServiceAccountName: pulumi.String("dogstatsd-standalone"),
+					Containers: corev1.ContainerArray{
+						&corev1.ContainerArgs{
+							Name:  pulumi.String("dogstatsd-standalone"),
+							Image: pulumi.String(e.DogstatsdFullImagePath()),
+							Ports: corev1.ContainerPortArray{
+								&corev1.ContainerPortArgs{
+									ContainerPort: pulumi.Int(8125),
+									HostPort:      pulumi.Int(8125),
+									Name:          pulumi.StringPtr("dogstatsdport"),
+									Protocol:      pulumi.StringPtr("UDP"),
+								},
+							},
+							Env: &corev1.EnvVarArray{
+								&corev1.EnvVarArgs{
+									Name:  pulumi.String("DD_API_KEY"),
+									Value: e.AgentAPIKey(),
+								},
+								&corev1.EnvVarArgs{
+									Name: pulumi.String("DD_KUBERNETES_KUBELET_HOST"),
+									ValueFrom: corev1.EnvVarSourceArgs{
+										FieldRef: corev1.ObjectFieldSelectorArgs{
+											FieldPath: pulumi.String("status.hostIP"),
+										},
+									},
+								},
+								&corev1.EnvVarArgs{
+									Name:  pulumi.String("DD_DOGSTATSD_NON_LOCAL_TRAFFIC"),
+									Value: pulumi.StringPtr("true"),
+								},
+								&corev1.EnvVarArgs{
+									Name:  pulumi.String("DD_DOGSTATSD_ORIGIN_DETECTION"),
+									Value: pulumi.StringPtr("true"),
+								},
+								&corev1.EnvVarArgs{
+									Name:  pulumi.String("DD_DOGSTATSD_SOCKET"),
+									Value: pulumi.StringPtr("/var/run/datadog/dsd.socket"),
+								},
+								&corev1.EnvVarArgs{
+									Name:  pulumi.String("DD_DOGSTATSD_TAG_CARDINALITY"),
+									Value: pulumi.StringPtr("orchestrator"),
+								},
+								&corev1.EnvVarArgs{
+									Name:  pulumi.String("DD_KUBELET_TLS_VERIFY"),
+									Value: pulumi.StringPtr("false"),
+								},
+							},
+							Resources: &corev1.ResourceRequirementsArgs{
+								Limits: pulumi.StringMap{
+									"cpu":    pulumi.String("100m"),
+									"memory": pulumi.String("512Mi"),
+								},
+								Requests: pulumi.StringMap{
+									"cpu":    pulumi.String("100m"),
+									"memory": pulumi.String("512Mi"),
+								},
+							},
+							VolumeMounts: &corev1.VolumeMountArray{
+								&corev1.VolumeMountArgs{
+									Name:      pulumi.String("hostvar"),
+									MountPath: pulumi.String("/host/var"),
+									ReadOnly:  pulumi.BoolPtr(true),
+								},
+								&corev1.VolumeMountArgs{
+									Name:      pulumi.String("procdir"),
+									MountPath: pulumi.String("/host/proc"),
+									ReadOnly:  pulumi.BoolPtr(true),
+								},
+								&corev1.VolumeMountArgs{
+									Name:      pulumi.String("cgroups"),
+									MountPath: pulumi.String("/host/sys/fs/cgroup"),
+									ReadOnly:  pulumi.BoolPtr(true),
+								},
+								&corev1.VolumeMountArgs{
+									Name:      pulumi.String("dsdsocket"),
+									MountPath: pulumi.String("/var/run/datadog"),
+								},
+							},
+						},
+					},
+					Volumes: corev1.VolumeArray{
+						&corev1.VolumeArgs{
+							Name: pulumi.String("hostvar"),
+							HostPath: &corev1.HostPathVolumeSourceArgs{
+								Path: pulumi.String("/var"),
+							},
+						},
+						&corev1.VolumeArgs{
+							Name: pulumi.String("procdir"),
+							HostPath: &corev1.HostPathVolumeSourceArgs{
+								Path: pulumi.String("/proc"),
+							},
+						},
+						&corev1.VolumeArgs{
+							Name: pulumi.String("cgroups"),
+							HostPath: &corev1.HostPathVolumeSourceArgs{
+								Path: pulumi.String("/sys/fs/cgroup"),
+							},
+						},
+						&corev1.VolumeArgs{
+							Name: pulumi.String("dsdsocket"),
+							HostPath: &corev1.HostPathVolumeSourceArgs{
+								Path: pulumi.String("/var/run/datadog/"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	serviceAccountArgs := corev1.ServiceAccountArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.String("dogstatsd-standalone"),
+			Namespace: pulumi.String(namespace),
+		},
+	}
+
+	clusterRoleArgs := v1.ClusterRoleArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name: pulumi.String("dogstatsd-standalone"),
+		},
+		Rules: v1.PolicyRuleArray{
+			v1.PolicyRuleArgs{
+				NonResourceURLs: pulumi.StringArray{
+					pulumi.String("/metrics"),
+				},
+				Verbs: pulumi.StringArray{
+					pulumi.String("get"),
+				},
+			},
+			v1.PolicyRuleArgs{ // Kubelet connectivity
+				ApiGroups: pulumi.StringArray{
+					pulumi.String(""),
+				},
+				Resources: pulumi.StringArray{
+					pulumi.String("nodes/metrics"),
+					pulumi.String("nodes/spec"),
+					pulumi.String("nodes/proxy"),
+					pulumi.String("nodes/stats"),
+				},
+				Verbs: pulumi.StringArray{
+					pulumi.String("get"),
+				},
+			},
+		},
+	}
+
+	clusterRoleBindingArgs := v1.ClusterRoleBindingArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name: pulumi.String("dogstatsd-standalone"),
+		},
+		RoleRef: v1.RoleRefArgs{
+			ApiGroup: pulumi.String("rbac.authorization.k8s.io"),
+			Kind:     pulumi.String("ClusterRole"),
+			Name:     pulumi.String("dogstatsd-standalone"),
+		},
+		Subjects: v1.SubjectArray{
+			&v1.SubjectArgs{
+				Kind:      pulumi.String("ServiceAccount"),
+				Name:      pulumi.String("dogstatsd-standalone"),
+				Namespace: pulumi.String(namespace),
+			},
+		},
+	}
+
+	if _, err := corev1.NewServiceAccount(e.Ctx, "dogstatsd-standalone", &serviceAccountArgs, opts...); err != nil {
+		return nil, err
+	}
+
+	if _, err := v1.NewClusterRole(e.Ctx, "dogstatsd-standalone", &clusterRoleArgs, opts...); err != nil {
+		return nil, err
+	}
+
+	if _, err := v1.NewClusterRoleBinding(e.Ctx, "dogstatsd-standalone", &clusterRoleBindingArgs, opts...); err != nil {
+		return nil, err
+	}
+
+	if _, err := appsv1.NewDaemonSet(e.Ctx, "dogstatsd-standalone", &daemonSetArgs, opts...); err != nil {
+		return nil, err
+	}
+
+	return k8sComponent, nil
+}

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -224,7 +224,7 @@ func Run(ctx *pulumi.Context) error {
 			return err
 		}
 
-		if _, err := dogstatsd.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-dogstatsd"); err != nil {
+		if _, err := dogstatsd.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket"); err != nil {
 			return err
 		}
 

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -218,7 +218,7 @@ func Run(ctx *pulumi.Context) error {
 
 	// Deploy standalone dogstatsd
 	if awsEnv.DogstatsdDeploy() {
-		if _, err := dogstatsdstandalone.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "dogstatsd-standalone", fakeIntake); err != nil {
+		if _, err := dogstatsdstandalone.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "dogstatsd-standalone", fakeIntake, true); err != nil {
 			return err
 		}
 	}

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -9,6 +9,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/nginx"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/prometheus"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/redis"
+	dogstatsdstandalone "github.com/DataDog/test-infra-definitions/components/datadog/dogstatsd-standalone"
 	ddfakeintake "github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	localKubernetes "github.com/DataDog/test-infra-definitions/components/kubernetes"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws"
@@ -76,6 +77,13 @@ datadog:
 		ctx.Export("agent-linux-helm-install-status", helmComponent.LinuxHelmReleaseStatus)
 
 		dependsOnCrd = utils.PulumiDependsOn(helmComponent)
+	}
+
+	// Deploy standalone dogstatsd
+	if awsEnv.DogstatsdDeploy() {
+		if _, err := dogstatsdstandalone.K8sAppDefinition(*awsEnv.CommonEnvironment, kindKubeProvider, "dogstatsd-standalone"); err != nil {
+			return err
+		}
 	}
 
 	// Deploy testing workload

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -96,7 +96,13 @@ datadog:
 			return err
 		}
 
-		if _, err := dogstatsd.K8sAppDefinition(*awsEnv.CommonEnvironment, kindKubeProvider, "workload-dogstatsd"); err != nil {
+		// dogstatsd clients that report to the Agent
+		if _, err := dogstatsd.K8sAppDefinition(*awsEnv.CommonEnvironment, kindKubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket"); err != nil {
+			return err
+		}
+
+		// dogstatsd clients that report to the dogstatsd standalone deployment
+		if _, err := dogstatsd.K8sAppDefinition(*awsEnv.CommonEnvironment, kindKubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket); err != nil {
 			return err
 		}
 

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -82,7 +82,7 @@ datadog:
 
 	// Deploy standalone dogstatsd
 	if awsEnv.DogstatsdDeploy() {
-		if _, err := dogstatsdstandalone.K8sAppDefinition(*awsEnv.CommonEnvironment, kindKubeProvider, "dogstatsd-standalone", fakeIntake); err != nil {
+		if _, err := dogstatsdstandalone.K8sAppDefinition(*awsEnv.CommonEnvironment, kindKubeProvider, "dogstatsd-standalone", fakeIntake, false); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR adds the option to deploy standalone dogstatsd in the `aws/kind` scenario.
The dogstatsd clients already defined in `components/datadog/apps/dogstatsd` can be used to test it.
