### PR TITLE
remove e2e from codeowners for microvms

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,4 @@
 # and another the rest of the directory.
 
 *                                       @DataDog/agent-e2e-testing
-/scenarios/aws/microVMs/                @DataDog/ebpf-platform @DataDog/agent-e2e-testing
+/scenarios/aws/microVMs/                @DataDog/ebpf-platform


### PR DESCRIPTION
What does this PR do?
---------------------
remove e2e from codeowners for microvms

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
