### PR TITLE
[components/datadog/dogstatsd-standalone] Set DD_CLUSTER_NAME

### DIFF
--- a/components/datadog/dogstatsd-standalone/k8s.go
+++ b/components/datadog/dogstatsd-standalone/k8s.go
@@ -26,7 +26,7 @@ type K8sComponent struct {
 	pulumi.ResourceState
 }
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, fakeIntake *ddfakeintake.ConnectionExporter, kubeletTLSVerify bool, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, fakeIntake *ddfakeintake.ConnectionExporter, kubeletTLSVerify bool, clusterName string, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &K8sComponent{}
@@ -93,6 +93,16 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 			&corev1.EnvVarArgs{
 				Name:  pulumi.String("DD_ADDITIONAL_ENDPOINTS"),
 				Value: pulumi.Sprintf(`{"http://%s": ["FAKEAPIKEY"]}`, fakeIntake.Host),
+			},
+		)
+	}
+
+	if clusterName != "" {
+		envVars = append(
+			envVars,
+			&corev1.EnvVarArgs{
+				Name:  pulumi.String("DD_CLUSTER_NAME"),
+				Value: pulumi.String(clusterName),
 			},
 		)
 	}

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -218,7 +218,7 @@ func Run(ctx *pulumi.Context) error {
 
 	// Deploy standalone dogstatsd
 	if awsEnv.DogstatsdDeploy() {
-		if _, err := dogstatsdstandalone.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "dogstatsd-standalone", fakeIntake, true); err != nil {
+		if _, err := dogstatsdstandalone.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "dogstatsd-standalone", fakeIntake, true, ""); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Sets `DD_CLUSTER_NAME` in the dogstatsd-standalone deployment.
It follows the same pattern as the agent, sets the cluster name when running on Kind and doesn't when running on EKS.
