### PR TITLE
Change WithPipeline to work with new arm64 and x86 repo for deb on datadog-agent

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -106,7 +106,7 @@ func (e *CommonEnvironment) InfraOSFamily() string {
 }
 
 func (e *CommonEnvironment) InfraOSArchitecture() string {
-	return e.GetStringWithDefault(e.InfraConfig, DDInfraOSArchitecture, "")
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraOSArchitecture, "x86_64")
 }
 
 func (e *CommonEnvironment) InfraOSAmiID() string {

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -18,7 +18,7 @@ import (
 // The available options are:
 //   - [WithLatest]
 //   - [WithVersion]
-//   - [WithPipelineID]
+//   - [WithPipeline]
 //   - [WithAgentConfig]
 //   - [WithSystemProbeConfig]
 //   - [WithSecurityAgentConfig]
@@ -55,7 +55,7 @@ func NewParams(env *config.CommonEnvironment, options ...Option) (*Params, error
 	}
 	defaultVersion := WithLatest()
 	if env.PipelineID() != "" {
-		defaultVersion = WithPipelineID(env.PipelineID())
+		defaultVersion = WithPipeline(env.PipelineID(), env.InfraOSArchitecture())
 	}
 	if env.AgentVersion() != "" {
 		defaultVersion = WithVersion(env.AgentVersion())
@@ -87,11 +87,10 @@ func WithVersion(version string) func(*Params) error {
 	}
 }
 
-// WithPipelineID use a specific version of the Agent by pipeline id. For example: `16497585` uses the version `pipeline-16497585`
-func WithPipelineID(version string) func(*Params) error {
+// WithPipeline use a specific version of the Agent by pipeline id. For example: `16497585` uses the version `pipeline-16497585`
+func WithPipeline(pipelineID string, arch string) func(*Params) error {
 	return func(p *Params) error {
-		p.Version = parsePipelineVersion(version)
-
+		p.Version = parsePipelineVersion(pipelineID, arch)
 		return nil
 	}
 }
@@ -115,9 +114,10 @@ func parseVersion(s string) (os.AgentVersion, error) {
 	return version, nil
 }
 
-func parsePipelineVersion(s string) os.AgentVersion {
+func parsePipelineVersion(s string, arch string) os.AgentVersion {
 	version := os.AgentVersion{}
 	version.PipelineID = "pipeline-" + s
+	version.Arch = arch
 	return version
 }
 

--- a/components/datadog/agentparams/params_test.go
+++ b/components/datadog/agentparams/params_test.go
@@ -28,9 +28,10 @@ func TestParams(t *testing.T) {
 		})
 	})
 	t.Run("parsePipelineVersion should correctly parse a pipeline ID and format the agent version pipeline", func(t *testing.T) {
-		version := parsePipelineVersion("16362517")
+		version := parsePipelineVersion("16362517", "x86_64")
 		assert.Equal(t, version, os.AgentVersion{
 			PipelineID: "pipeline-16362517",
+			Arch:       "x86_64",
 		})
 	})
 	t.Run("WithIntegration should correctly add conf.d/integration/conf.yaml to the path", func(t *testing.T) {

--- a/components/os/os.go
+++ b/components/os/os.go
@@ -23,6 +23,7 @@ type AgentVersion struct {
 	Minor       string // Empty means latest
 	BetaChannel bool
 	PipelineID  string
+	Arch        string
 }
 
 type OS interface {

--- a/components/os/unix.go
+++ b/components/os/unix.go
@@ -58,7 +58,7 @@ func getUnixInstallFormatString(scriptName string, version AgentVersion) string 
 		testEnvVars = append(testEnvVars, "TESTING_APT_URL=apttesting.datad0g.com")
 		// apt testing repo
 		// TESTING_APT_REPO_VERSION="pipeline-xxxxx-a7 7"
-		testEnvVars = append(testEnvVars, fmt.Sprintf(`TESTING_APT_REPO_VERSION="%v-a7 7"`, version.PipelineID))
+		testEnvVars = append(testEnvVars, fmt.Sprintf(`TESTING_APT_REPO_VERSION="%v-a7-%s 7"`, version.PipelineID, version.Arch))
 		testEnvVars = append(testEnvVars, "TESTING_YUM_URL=yumtesting.datad0g.com")
 		// yum testing repo
 		// TESTING_YUM_VERSION_PATH="testing/pipeline-xxxxx-a7/7"


### PR DESCRIPTION

What does this PR do?
---------------------

To fix an issue we have on Datadog-agent kitchen/new-e2e-tests install script tests, due to concurrent update on deb package repository by ARM and X86_64 jobs , we created two dfiferent repo `pipeline-<pipeline-id>-arm64' and `pipeline-<pipeline-id>-x86_64'
This PR update the `WithPipeline` option to match with these two new repository on apt repository
Required for PR: https://github.com/DataDog/datadog-agent/pull/20532

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
