### PR TITLE
[components/datadog/dogstatsd-standalone] Set tag cardinality to "high"

### DIFF
--- a/components/datadog/dogstatsd-standalone/k8s.go
+++ b/components/datadog/dogstatsd-standalone/k8s.go
@@ -79,7 +79,7 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 		},
 		&corev1.EnvVarArgs{
 			Name:  pulumi.String("DD_DOGSTATSD_TAG_CARDINALITY"),
-			Value: pulumi.StringPtr("orchestrator"),
+			Value: pulumi.StringPtr("high"),
 		},
 		&corev1.EnvVarArgs{
 			Name:  pulumi.String("DD_KUBELET_TLS_VERIFY"),


### PR DESCRIPTION
To be consistent with the tag cardinality configured in the agent.
This will allow us to reuse the same tests.
