### PR TITLE
[CONTINT-258] Add `stress-ng` test workload

### DIFF
--- a/components/datadog/apps/cpustress/ecs.go
+++ b/components/datadog/apps/cpustress/ecs.go
@@ -1,0 +1,59 @@
+package cpustress
+
+import (
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/resources/aws"
+
+	"github.com/pulumi/pulumi-awsx/sdk/go/awsx/awsx"
+	"github.com/pulumi/pulumi-awsx/sdk/go/awsx/ecs"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+type EcsComponent struct {
+	pulumi.ResourceState
+}
+
+func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...pulumi.ResourceOption) (*EcsComponent, error) {
+	namer := e.Namer.WithPrefix("cpustress")
+	opts = append(opts, e.WithProviders(config.ProviderAWS, config.ProviderAWSX))
+
+	ecsComponent := &EcsComponent{}
+	if err := e.Ctx.RegisterComponentResource("dd:apps", namer.ResourceName("grp"), ecsComponent, opts...); err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, pulumi.Parent(ecsComponent))
+
+	if _, err := ecs.NewEC2Service(e.Ctx, namer.ResourceName("stress-ng"), &ecs.EC2ServiceArgs{
+		Name:                 e.CommonNamer.DisplayName(255, pulumi.String("stress-ng")),
+		Cluster:              clusterArn,
+		DesiredCount:         pulumi.IntPtr(1),
+		EnableExecuteCommand: pulumi.BoolPtr(true),
+		TaskDefinitionArgs: &ecs.EC2ServiceTaskDefinitionArgs{
+			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
+				"stress-ng": {
+					Name:  pulumi.String("stress-ng"),
+					Image: pulumi.String("ghcr.io/colinianking/stress-ng"),
+					Command: pulumi.StringArray{
+						pulumi.String("--cpu=1"),
+						pulumi.String("--cpu-load=15"),
+					},
+					Cpu:    pulumi.IntPtr(200),
+					Memory: pulumi.IntPtr(6),
+				},
+			},
+			ExecutionRole: &awsx.DefaultRoleWithPolicyArgs{
+				RoleArn: pulumi.StringPtr(e.ECSTaskExecutionRole()),
+			},
+			TaskRole: &awsx.DefaultRoleWithPolicyArgs{
+				RoleArn: pulumi.StringPtr(e.ECSTaskRole()),
+			},
+			NetworkMode: pulumi.StringPtr("none"),
+			Family:      e.CommonNamer.DisplayName(255, pulumi.String("stress-ng-ec2")),
+		},
+	}, opts...); err != nil {
+		return nil, err
+	}
+
+	return ecsComponent, nil
+}

--- a/components/datadog/apps/cpustress/k8s.go
+++ b/components/datadog/apps/cpustress/k8s.go
@@ -1,0 +1,89 @@
+package cpustress
+
+import (
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/common/utils"
+
+	"github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes"
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/apps/v1"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+type K8sComponent struct {
+	pulumi.ResourceState
+}
+
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
+	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
+
+	k8sComponent := &K8sComponent{}
+	if err := e.Ctx.RegisterComponentResource("dd:apps", "cpustress", k8sComponent, opts...); err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, pulumi.Parent(k8sComponent))
+
+	ns, err := corev1.NewNamespace(e.Ctx, namespace, &corev1.NamespaceArgs{
+		Metadata: metav1.ObjectMetaArgs{
+			Name: pulumi.String(namespace),
+		},
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, utils.PulumiDependsOn(ns))
+
+	if _, err := appsv1.NewDeployment(e.Ctx, "stress-ng", &appsv1.DeploymentArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.String("stress-ng"),
+			Namespace: pulumi.String(namespace),
+			Labels: pulumi.StringMap{
+				"app": pulumi.String("stress-ng"),
+			},
+		},
+		Spec: &appsv1.DeploymentSpecArgs{
+			Replicas: pulumi.Int(1),
+			Selector: &metav1.LabelSelectorArgs{
+				MatchLabels: pulumi.StringMap{
+					"app": pulumi.String("stress-ng"),
+				},
+			},
+			Template: &corev1.PodTemplateSpecArgs{
+				Metadata: &metav1.ObjectMetaArgs{
+					Labels: pulumi.StringMap{
+						"app": pulumi.String("stress-ng"),
+					},
+				},
+				Spec: &corev1.PodSpecArgs{
+					Containers: corev1.ContainerArray{
+						corev1.ContainerArgs{
+							Name:  pulumi.String("stress-ng"),
+							Image: pulumi.String("ghcr.io/colinianking/stress-ng"),
+							Args: pulumi.StringArray{
+								pulumi.String("--cpu=1"),
+								pulumi.String("--cpu-load=15"),
+							},
+							Resources: &corev1.ResourceRequirementsArgs{
+								Limits: pulumi.StringMap{
+									"cpu":    pulumi.String("200m"),
+									"memory": pulumi.String("4Mi"),
+								},
+								Requests: pulumi.StringMap{
+									"cpu":    pulumi.String("200m"),
+									"memory": pulumi.String("4Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, opts...); err != nil {
+		return nil, err
+	}
+
+	return k8sComponent, nil
+}

--- a/scenarios/aws/ecs/run.go
+++ b/scenarios/aws/ecs/run.go
@@ -3,6 +3,7 @@ package ecs
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/cpustress"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/dogstatsd"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/nginx"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/prometheus"
@@ -137,6 +138,10 @@ func Run(ctx *pulumi.Context) error {
 		}
 
 		if _, err := redis.EcsAppDefinition(awsEnv, ecsCluster.Arn); err != nil {
+			return err
+		}
+
+		if _, err := cpustress.EcsAppDefinition(awsEnv, ecsCluster.Arn); err != nil {
 			return err
 		}
 

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -4,6 +4,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/cpustress"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/dogstatsd"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/nginx"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/prometheus"
@@ -230,6 +231,10 @@ func Run(ctx *pulumi.Context) error {
 		}
 
 		if _, err := redis.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-redis", dependsOnCrd); err != nil {
+			return err
+		}
+
+		if _, err := cpustress.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-cpustress"); err != nil {
 			return err
 		}
 

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/cpustress"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/dogstatsd"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/nginx"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/prometheus"
@@ -96,6 +97,10 @@ datadog:
 		}
 
 		if _, err := redis.K8sAppDefinition(*awsEnv.CommonEnvironment, kindKubeProvider, "workload-redis", dependsOnCrd); err != nil {
+			return err
+		}
+
+		if _, err := cpustress.K8sAppDefinition(*awsEnv.CommonEnvironment, kindKubeProvider, "workload-cpustress"); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
What does this PR do?
---------------------

Add a `cpustress` testing workload.

Which scenarios this will impact?
-------------------

* `EKS`
* `Kind`
* `ECS`

Motivation
----------

Port to the new-e2e tests framework the legacy `cpu-stress` tests: https://github.com/DataDog/datadog-agent/blob/main/test/e2e/argo-workflows/templates/cpu-stress.yaml

Additional Notes
----------------
