### PR TITLE
Increase the CPU for the ECS agent

### DIFF
--- a/components/datadog/agent/ecs.go
+++ b/components/datadog/agent/ecs.go
@@ -84,7 +84,7 @@ func ecsFakeintakeAdditionalEndpointsEnv(fakeintake *ddfakeintake.ConnectionExpo
 
 func ecsLinuxAgentSingleContainerDefinition(e config.CommonEnvironment, apiKeySSMParamName pulumi.StringInput, fakeintake *ddfakeintake.ConnectionExporter) ecs.TaskDefinitionContainerDefinitionArgs {
 	return ecs.TaskDefinitionContainerDefinitionArgs{
-		Cpu:       pulumi.IntPtr(100),
+		Cpu:       pulumi.IntPtr(200),
 		Memory:    pulumi.IntPtr(512),
 		Name:      pulumi.String("datadog-agent"),
 		Image:     pulumi.String(DockerAgentFullImagePath(&e, "public.ecr.aws/datadog/agent")),


### PR DESCRIPTION
What does this PR do?
---------------------

Increase the CPU allocated to the agent on ECS.

Which scenarios this will impact?
-------------------

* `ECS`

Motivation
----------

We regularly have ECS flaky tests.
The symptom is random ECS test failing because of missing ECS specific tags.
It turns out that the tags used to be on the metric. But at some point, they disappear.
Investigation shown that the ECS tags disappear because the agent restarts. We can see its `task_arn` changing.

Ex. of notebook showing this: https://dddev.datadoghq.com/notebook/6891346/l%C3%A9na%C3%AFc-nov-07-2023-22-59?view=view-mode

The reason why only ECS tags are missing is because those ones are polled. So, it takes more time to get those ones than tags relying on watch mechanisms.
The agent is killed because the health probe (which simply executes `agent health`) failed.
And we can see a CPU spike at the time at which the health check fails.

![image](https://github.com/DataDog/test-infra-definitions/assets/1437785/7f3441cd-3c87-4ec7-932a-3f8d6e42849d)
![image](https://github.com/DataDog/test-infra-definitions/assets/1437785/d94bd91b-7996-41cc-b833-0416b0624ab3)

So, maybe the agent health check is failing because the agent is CPU starved.

Additional Notes
----------------
