### PR TITLE
[docker] increase max attempts for calls to aws ssm

### DIFF
--- a/.awsconfig
+++ b/.awsconfig
@@ -1,0 +1,3 @@
+[default]
+retry_mode = standard
+max_attempts = 10

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,5 +106,8 @@ RUN pip3 install "cython<3.0.0" && \
   pip3 install -r https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/requirements/e2e.txt & \
   go install gotest.tools/gotestsum@latest
 
+# Configure aws retries
+COPY .awsconfig $HOME/.aws/config
+
 # I think it's safe to say if we're using this mega image, we want pulumi
 ENTRYPOINT ["pulumi"]


### PR DESCRIPTION
What does this PR do?
---------------------

Set default awsconfig, used at startup by test-infra image.

Which scenarios this will impact?
-------------------

None

Motivation
----------

Reduce flakiness in e2e tests due to connection issues at first `aws ssm` call. We will need to update the retries configuration on all `awsconfig` downloaded from ssm.

Additional Notes
----------------
