### PR TITLE
Use time.Second to define sleep interval

### DIFF
--- a/components/datadog/apps/fakeintake/fargateFakeintakeService.go
+++ b/components/datadog/apps/fakeintake/fargateFakeintakeService.go
@@ -2,6 +2,7 @@ package fakeintake
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
@@ -16,8 +17,7 @@ import (
 )
 
 const (
-	oneSecond     = 1000
-	sleepInterval = 1 * oneSecond
+	sleepInterval = 1 * time.Second
 	maxRetries    = 120
 	containerName = "fakeintake"
 	port          = 80


### PR DESCRIPTION
What does this PR do?
---------------------

Use `time.Second` for `time.Duration`.
Here we add an `int` with value `1000` which is interpreted as `1000` ns

Which scenarios this will impact?
-------------------

Motivation
----------

Fix some flakiness in tests

Additional Notes
----------------
