### PR TITLE
Use stable version for fluent-for-bits on ecs

### DIFF
--- a/resources/aws/ecs/fargateService.go
+++ b/resources/aws/ecs/fargateService.go
@@ -81,7 +81,7 @@ func FargateFirelensContainerDefinition() *ecs.TaskDefinitionContainerDefinition
 		Cpu:       pulumi.IntPtr(0),
 		User:      pulumi.StringPtr("0"),
 		Name:      pulumi.String("log_router"),
-		Image:     pulumi.String("amazon/aws-for-fluent-bit:latest"),
+		Image:     pulumi.String("amazon/aws-for-fluent-bit:stable"),
 		Essential: pulumi.BoolPtr(true),
 		FirelensConfiguration: ecs.TaskDefinitionFirelensConfigurationArgs{
 			Type: pulumi.String("fluentbit"),


### PR DESCRIPTION
What does this PR do?
---------------------
Changes the version of ecs

Which scenarios this will impact?
-------------------
ECS e2e testing and test infra definition.

Motivation
----------
Latest is not stable and does not work with `pidMode` set as `task`. It is useful for orchestrator explorer.

Additional Notes
----------------
