### PR TITLE
Disable logs dual shipping towards fake intake

### DIFF
--- a/components/datadog/agent/ecs.go
+++ b/components/datadog/agent/ecs.go
@@ -75,10 +75,6 @@ func ecsFakeintakeAdditionalEndpointsEnv(fakeintake *ddfakeintake.ConnectionExpo
 			Name:  pulumi.StringPtr("DD_ADDITIONAL_ENDPOINTS"),
 			Value: pulumi.Sprintf(`{"http://%s": ["FAKEAPIKEY"]}`, fakeintake.Host),
 		},
-		ecs.TaskDefinitionKeyValuePairArgs{
-			Name:  pulumi.String("DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS"),
-			Value: pulumi.Sprintf(`[{"host": "%s", "port": 80, "is_reliable": true, "usessl": false}]`, fakeintake.Host),
-		},
 	}
 }
 

--- a/components/datadog/agent/ecs.go
+++ b/components/datadog/agent/ecs.go
@@ -169,7 +169,7 @@ func ecsLinuxAgentSingleContainerDefinition(e config.CommonEnvironment, apiKeySS
 		HealthCheck: &ecs.TaskDefinitionHealthCheckArgs{
 			Retries:     pulumi.IntPtr(2),
 			Command:     pulumi.ToStringArray([]string{"CMD-SHELL", "agent health"}),
-			StartPeriod: pulumi.IntPtr(10),
+			StartPeriod: pulumi.IntPtr(30),
 			Interval:    pulumi.IntPtr(30),
 			Timeout:     pulumi.IntPtr(5),
 		},

--- a/components/datadog/agent/helm.go
+++ b/components/datadog/agent/helm.go
@@ -304,10 +304,6 @@ func (values HelmValues) configureFakeintake(fakeintake *ddfakeintake.Connection
 			"name":  pulumi.String("DD_ADDITIONAL_ENDPOINTS"),
 			"value": pulumi.Sprintf(`{"http://%s": ["FAKEAPIKEY"]}`, fakeintake.Host),
 		},
-		pulumi.Map{
-			"name":  pulumi.String("DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS"),
-			"value": pulumi.Sprintf(`[{"host": "%s", "port": 80, "is_reliable": true, "usessl": false}]`, fakeintake.Host),
-		},
 	}
 
 	for _, section := range []string{"datadog", "clusterAgent", "clusterChecksRunner"} {


### PR DESCRIPTION
What does this PR do?
---------------------

Disable the logs dual shipping towards fake intake.

Which scenarios this will impact?
-------------------

* `ECS`
* `K8s`

Motivation
----------

ECS tests are currently very flaky because the agent is endlessly restarting.
It is in fact killed by ECS because its health check fails.

The component whose health check is failing is always the same:
```
2023-11-10 15:42:10 UTC | CORE | INFO | (cmd/agent/api/internal/agent/agent.go:350 in getHealth) | Healthcheck failed on: [ad-servicelistening]
```

Here is the stack trace of the stuck goroutine:
```
goroutine 474 [chan send]:
github.com/DataDog/datadog-agent/pkg/logs/sources.(*LogSources).AddSource(0xc000ea3d40, 0xc000acfe30)
        /home/lenaic/doc/devel/DataDog/datadog-agent/pkg/logs/sources/sources.go:59 +0x350
github.com/DataDog/datadog-agent/pkg/logs/schedulers.(*sourceManager).AddSource(0xc0024a3fe0, 0xc000acfe30)
        /home/lenaic/doc/devel/DataDog/datadog-agent/pkg/logs/schedulers/source_manager.go:26 +0x2c
github.com/DataDog/datadog-agent/pkg/logs/schedulers/ad.(*Scheduler).Schedule(0xc0007f45b8, {0xc0036c9800, 0x2, 0x2})
        /home/lenaic/doc/devel/DataDog/datadog-agent/pkg/logs/schedulers/ad/scheduler.go:78 +0x624
github.com/DataDog/datadog-agent/pkg/logs/internal/util/adlistener.(*ADListener).Schedule(0xc0025fc9c0, {0xc0036c9800, 0x2, 0x2})
        /home/lenaic/doc/devel/DataDog/datadog-agent/pkg/logs/internal/util/adlistener/ad.go:61 +0x36
github.com/DataDog/datadog-agent/pkg/autodiscovery/scheduler.(*MetaScheduler).Schedule(0xc004fee150, {0xc0036c9800, 0x2, 0x2})
        /home/lenaic/doc/devel/DataDog/datadog-agent/pkg/autodiscovery/scheduler/meta.go:81 +0x3a9
github.com/DataDog/datadog-agent/pkg/autodiscovery.(*AutoConfig).applyChanges(0xc000387f40, {{0xc0036c9800, 0x2, 0x2}, {0x0, 0x0, 0x0}})
        /home/lenaic/doc/devel/DataDog/datadog-agent/pkg/autodiscovery/autoconfig.go:472 +0x2dd
github.com/DataDog/datadog-agent/pkg/autodiscovery.(*AutoConfig).processNewService(0xc000387f40, {0xb3d4060, 0xc00494db20}, {0xb3efac0, 0xc001008750})
        /home/lenaic/doc/devel/DataDog/datadog-agent/pkg/autodiscovery/autoconfig.go:431 +0x485
github.com/DataDog/datadog-agent/pkg/autodiscovery.(*AutoConfig).checkTagFreshness(0xc000387f40, {0xb3d4060, 0xc00494db20})
        /home/lenaic/doc/devel/DataDog/datadog-agent/pkg/autodiscovery/autoconfig.go:140 +0x472
github.com/DataDog/datadog-agent/pkg/autodiscovery.(*AutoConfig).serviceListening(0xc000387f40)
        /home/lenaic/doc/devel/DataDog/datadog-agent/pkg/autodiscovery/autoconfig.go:118 +0x308
created by github.com/DataDog/datadog-agent/pkg/autodiscovery.NewAutoConfig in goroutine 447
        /home/lenaic/doc/devel/DataDog/datadog-agent/pkg/autodiscovery/autoconfig.go:71 +0x8d
```

So, the `ad-servicelistening` goroutine is blocked on a full `chan` because the logs component is stuck.


On the other side, without logs dual shipping towards fake intake (with this PR), `agent status` shows:
```
==========
Logs Agent
==========
    Reliable: Sending compressed logs in HTTPS to agent-http-intake.logs.datadoghq.com on port 443
```
which is what is expected.

But with dual shipping setup (without this PR), `agent status` shows:
```
Logs Agent
==========
    Reliable: Sending uncompressed logs in SSL encrypted TCP to agent-intake.logs.datadoghq.com on port 10516
    Reliable: Sending uncompressed logs in SSL encrypted TCP to internal-lenaic-eks-fakeintake-1018237308.us-east-1.elb.amazonaws.com on port 80

    You are currently sending Logs to Datadog through TCP (either because logs_config.force_use_tcp or logs_config.socks5_proxy_address is set or the HTTP connectivity test has failed). To benefit from increased reliability and better network performances, we strongly encourage switching over to compressed HTTPS which is now the default protocol.
```

and the logs are full of:
```
2023-11-16 09:19:13 UTC | CORE | WARN | (pkg/logs/client/tcp/connection_manager.go:116 in NewConnection) | tls: first record does not look like a TLS handshake
```

Not only SSL is enabled on the extra endpoint whereas it shouldn’t but the main endpoint (which wasn’t expected to be impacted by the extra one) is now using the deprecated TCP protocol instead of HTTPS.

All this is because:
* It is not possible to have SSL enabled on the main endpoint (with HTTPS) and disabled on extra-endpoints (plain HTTP): 

https://github.com/DataDog/datadog-agent/blob/aaecb265b539bb2a998074ee0beda6d968dce453/comp/logs/agent/config/config.go#L176-L178

https://github.com/DataDog/datadog-agent/blob/aaecb265b539bb2a998074ee0beda6d968dce453/comp/logs/agent/config/config.go#L249-L251

* Because SSL is enabled on the main endpoint, it probes the extra endpoint in HTTPS.
* It fails because the extra endpoint is plain HTTP.
* It fallback to TCP (with SSL) instead of HTTPS not only on the extra endpoint, but also on the main one.

So, let’s disable the logs dual shipping in the tests until all this is fixed on agent side.

Additional Notes
----------------
