### PR TITLE
Add jq to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,8 @@ RUN apt-get update -y && \
   google-cloud-sdk-gke-gcloud-auth-plugin \
   kubectl \
   # xsltproc is required by libvirt-sdk used in the micro-vms scenario
-  xsltproc && \
+  xsltproc \
+  jq && \
   # Clean up the lists work
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
What does this PR do?
---------------------
This PR adds `jq` to the Dockerfile. 

Which scenarios this will impact?
-------------------

Motivation
----------
Used for parsing aws-cli output as a json. It is neater to parse aws-cli output as json than text.

Additional Notes
----------------
