### PR TITLE
Define fakeintake healthcheck, enforce fakeintake health during deployment

### DIFF
--- a/components/datadog/apps/fakeintake/fargateFakeintakeService.go
+++ b/components/datadog/apps/fakeintake/fargateFakeintakeService.go
@@ -217,10 +217,10 @@ func fargateServiceFakeintakeWithoutLoadBalancer(e aws.Environment, name, imageU
 
 		// fail the deployment if the fakeintake is not healthy
 		e.Ctx.Log.Info(fmt.Sprintf("Waiting for fakeintake at %s to be healthy", ipAddress), nil)
+		fakeintakeURL := getFakeintakeHealthURL(ipAddress)
 		err = backoff.Retry(func() error {
-			url := getFakeintakeHealthURL(ipAddress)
-			e.Ctx.Log.Debug(fmt.Sprintf("getting fakeintake health at %s", url), nil)
-			resp, err := http.Get(url)
+			e.Ctx.Log.Debug(fmt.Sprintf("getting fakeintake health at %s", fakeintakeURL), nil)
+			resp, err := http.Get(fakeintakeURL)
 			if err != nil {
 				return err
 			}

--- a/components/datadog/apps/fakeintake/fargateFakeintakeService.go
+++ b/components/datadog/apps/fakeintake/fargateFakeintakeService.go
@@ -172,6 +172,8 @@ func fargateLinuxContainerDefinition() *ecs.TaskDefinitionContainerDefinitionArg
 		},
 		VolumesFrom: ecs.TaskDefinitionVolumeFromArray{},
 		HealthCheck: &ecs.TaskDefinitionHealthCheckArgs{
+			// note that a failing health check doesn't fail the deployment,
+			// but it allows seeing the health of the task directly in AWS
 			Command: pulumi.StringArray{
 				pulumi.String("curl"),
 				pulumi.String("-L"),
@@ -215,6 +217,7 @@ func fargateServiceFakeintakeWithoutLoadBalancer(e aws.Environment, name string)
 	return ipAddress, err
 }
 
+// checkFakeintakeHealth fails the deployment if it isn't healthy
 func checkFakeintakeHealth(ctx *pulumi.Context, host pulumi.StringOutput) {
 	ctx.Export("fakeintake-healthy", host.ApplyT(
 		func(host string) (any, error) {


### PR DESCRIPTION
What does this PR do?
---------------------
- enforce fakeintake health during deployment, have pulumi fail if fakeintake is not healthy
- define health check command of the fakeintake task in AWS

Which scenarios this will impact?
-------------------
Fakeintake

Motivation
----------
Test could start before the fakeintake was healthy, we want to be able to
1. fail the deployment if the fakeintake was not healthy after some time
2. as a bonus, see from the AWS interface whether a fakeintake is healthy

Additional Notes
----------------
Noticed that the definition of the fakeintake service was duplicated so factored that.

The health check in AWS uses `curl`, so this PR depends on https://github.com/DataDog/datadog-agent/pull/20940 which adds `curl` to the container.