### PR TITLE
[ecs] Create Bottlerocket node group by default with Invoke

### DIFF
--- a/tasks/doc.py
+++ b/tasks/doc.py
@@ -17,7 +17,7 @@ os_family: str = (
 )
 linux_node_group: str = "Install a Linux node group (default True)"
 linux_arm_node_group: str = "Install a Linux ARM node group (default False)"
-bottlerocket_node_group: str = "Install a bottlerocket node group (default False)"
+bottlerocket_node_group: str = "Install a bottlerocket node group (default True)"
 windows_node_group: str = "Install a Windows node group (default False)"
 use_fargate: str = "Use Fargate (default True)"
 fakeintake: str = "Use a dedicated fake Datadog intake (default False)"

--- a/tasks/ecs.py
+++ b/tasks/ecs.py
@@ -35,7 +35,7 @@ def create_ecs(
     use_fargate: bool = True,
     linux_node_group: bool = True,
     linux_arm_node_group: bool = False,
-    bottlerocket_node_group: bool = False,
+    bottlerocket_node_group: bool = True,
     windows_node_group: bool = False,
 ):
     """


### PR DESCRIPTION
What does this PR do?
---------------------
Activate Bottlerocket node group by default with Invoke.

Which scenarios this will impact?
-------------------
This impact the ECS scenario.

Motivation
----------
Without this, the `create-ecs` fails by default because of a Redis port collision.

Additional Notes
----------------
Replaces https://github.com/DataDog/test-infra-definitions/pull/465
