### PR TITLE
Shorten Libvirt Volume and Pool URNs

### DIFF
--- a/scenarios/aws/microVMs/microvms/pool.go
+++ b/scenarios/aws/microVMs/microvms/pool.go
@@ -34,7 +34,8 @@ func generateGlobalPoolPath(name string) string {
 }
 
 func NewGlobalLibvirtPool(ctx *pulumi.Context) LibvirtPool {
-	poolName := libvirtResourceName(ctx.Stack(), "global-pool")
+	//	poolName := libvirtResourceName(ctx.Stack(), "global-pool")
+	poolName := "global-pool"
 	rc := resources.NewResourceCollection(vmconfig.RecipeDefault)
 	poolPath := generateGlobalPoolPath(poolName)
 	poolXML := rc.GetPoolXML(

--- a/scenarios/aws/microVMs/microvms/pool.go
+++ b/scenarios/aws/microVMs/microvms/pool.go
@@ -13,6 +13,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
+const globalPoolName = "global-pool"
+
 type LibvirtPool interface {
 	SetupLibvirtPool(ctx *pulumi.Context, runner *Runner, providerFn LibvirtProviderFn, isLocal bool, depends []pulumi.Resource) ([]pulumi.Resource, error)
 	Name() string
@@ -34,22 +36,20 @@ func generateGlobalPoolPath(name string) string {
 }
 
 func NewGlobalLibvirtPool(ctx *pulumi.Context) LibvirtPool {
-	//	poolName := libvirtResourceName(ctx.Stack(), "global-pool")
-	poolName := "global-pool"
 	rc := resources.NewResourceCollection(vmconfig.RecipeDefault)
-	poolPath := generateGlobalPoolPath(poolName)
+	poolPath := generateGlobalPoolPath(globalPoolName)
 	poolXML := rc.GetPoolXML(
 		map[string]pulumi.StringInput{
-			resources.PoolName: pulumi.String(poolName),
+			resources.PoolName: pulumi.String(globalPoolName),
 			resources.PoolPath: pulumi.String(poolPath),
 		},
 	)
 
 	return &globalLibvirtPool{
-		poolName:    poolName,
+		poolName:    globalPoolName,
 		poolXML:     poolXML,
-		poolXMLPath: fmt.Sprintf("/tmp/pool-%s.tmp", poolName),
-		poolNamer:   libvirtResourceNamer(ctx, poolName),
+		poolXMLPath: fmt.Sprintf("/tmp/pool-%s.tmp", globalPoolName),
+		poolNamer:   libvirtResourceNamer(ctx, globalPoolName),
 		poolType:    resources.DefaultPool,
 		poolPath:    poolPath,
 	}

--- a/scenarios/aws/microVMs/microvms/volume.go
+++ b/scenarios/aws/microVMs/microvms/volume.go
@@ -50,7 +50,7 @@ func NewLibvirtVolume(
 		filesystemImage: fsImage,
 		volumeKey:       volKey,
 		volumeXML:       xmlDataFn(volKey, pool.Type()),
-		volumeNamer:     volNamerFn(volKey),
+		volumeNamer:     volNamerFn(fsImage.imageName),
 		pool:            pool,
 		mountpoint:      mountpoint,
 	}


### PR DESCRIPTION
What does this PR do?
---------------------
This PR shortens the URNs generated for some libvirt resources. It was observed that the URNs were going beyond the 255 character limit in come cases.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
