### PR TITLE
fix: remove health check command which breaks updateEnv

### DIFF
--- a/components/datadog/apps/fakeintake/fargateFakeintakeService.go
+++ b/components/datadog/apps/fakeintake/fargateFakeintakeService.go
@@ -259,17 +259,6 @@ func fargateLinuxContainerDefinition(imageURL string) *ecs.TaskDefinitionContain
 			},
 		},
 		VolumesFrom: ecs.TaskDefinitionVolumeFromArray{},
-		HealthCheck: &ecs.TaskDefinitionHealthCheckArgs{
-			// note that a failing health check doesn't fail the deployment,
-			// but it allows seeing the health of the task directly in AWS
-			Command: pulumi.StringArray{
-				pulumi.String("curl"),
-				pulumi.String("-L"),
-				pulumi.String(getFakeintakeHealthURL("localhost")),
-			},
-			Interval: pulumi.Int(5), // seconds
-			Retries:  pulumi.Int(4),
-		},
 	}
 }
 


### PR DESCRIPTION
What does this PR do?
---------------------
Remove the health check command from the fakeintake task definition.

Which scenarios this will impact?
-------------------
Fakeintake

Motivation
----------
When performing an `UpdateEnv`, pulumi redeploys the fakeintake (which shouldn't have changed), so the one the agent is using doesn't exist anymore.
It is not clear why but removing the health command removes this issue.

Additional Notes
----------------
