### PR TITLE
Revert "Remove AWS from disable default providers until EKS plugin is fixed"

### DIFF
--- a/Pulumi.yaml
+++ b/Pulumi.yaml
@@ -2,7 +2,4 @@ name: dd
 runtime: go
 description: Generic scenario (check scenario variable)
 config:
-  # we have to disable default providers * again when
-  # https://github.com/pulumi/pulumi-eks/pull/886
-  # is merged
-  pulumi:disable-default-providers: ["kubernetes", "azure-native", "awsx", "eks"]
+  pulumi:disable-default-providers: ["*"]

--- a/components/datadog/apps/fakeintake/fargateFakeintakeService.go
+++ b/components/datadog/apps/fakeintake/fargateFakeintakeService.go
@@ -223,7 +223,7 @@ func fargateServiceFakeIntakeWithLoadBalancer(e aws.Environment, name string, na
 		return pulumi.StringOutput{}, err
 	}
 
-	current, err := paws.GetPartition(e.Ctx, nil, nil)
+	current, err := paws.GetPartition(e.Ctx, e.WithProvider(config.ProviderAWS))
 	if err != nil {
 		return pulumi.StringOutput{}, err
 	}

--- a/resources/aws/environment.go
+++ b/resources/aws/environment.go
@@ -102,7 +102,7 @@ func NewEnvironment(ctx *pulumi.Context, options ...func(*Environment)) (Environ
 	shuffle, err := random.NewRandomShuffle(env.Ctx, env.Namer.ResourceName("rnd-subnet"), &random.RandomShuffleArgs{
 		Inputs:      pulumi.ToStringArray(env.DefaultSubnets()),
 		ResultCount: pulumi.IntPtr(2),
-	})
+	}, env.WithProviders(config.ProviderRandom))
 	if err != nil {
 		return Environment{}, err
 	}


### PR DESCRIPTION
This reverts commit 14270eb9af59b78b88743bdc76320e4c7b3227e2.

What does this PR do?
---------------------

Revert a temporary workaround for a bug in `pulumi-eks` which has now been fixed.

Which scenarios this will impact?
-------------------

Motivation
----------

https://github.com/pulumi/pulumi-eks/pull/886 has been merged.
It has been released in `v1.0.4`: https://github.com/pulumi/pulumi-eks/compare/v1.0.3...v1.0.4
And we’ve upgraded to `pulumi/pulumi-eks:v1.0.4`: https://github.com/DataDog/test-infra-definitions/pull/400

Additional Notes
----------------
