### PR TITLE
Prepend stack name to poolname

### DIFF
--- a/scenarios/aws/microVMs/microvms/pool.go
+++ b/scenarios/aws/microVMs/microvms/pool.go
@@ -13,8 +13,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-const globalPoolName = "global-pool"
-
 type LibvirtPool interface {
 	SetupLibvirtPool(ctx *pulumi.Context, runner *Runner, providerFn LibvirtProviderFn, isLocal bool, depends []pulumi.Resource) ([]pulumi.Resource, error)
 	Name() string
@@ -36,20 +34,21 @@ func generateGlobalPoolPath(name string) string {
 }
 
 func NewGlobalLibvirtPool(ctx *pulumi.Context) LibvirtPool {
+	poolName := libvirtResourceName(ctx.Stack(), "global-pool")
 	rc := resources.NewResourceCollection(vmconfig.RecipeDefault)
-	poolPath := generateGlobalPoolPath(globalPoolName)
+	poolPath := generateGlobalPoolPath(poolName)
 	poolXML := rc.GetPoolXML(
 		map[string]pulumi.StringInput{
-			resources.PoolName: pulumi.String(globalPoolName),
+			resources.PoolName: pulumi.String(poolName),
 			resources.PoolPath: pulumi.String(poolPath),
 		},
 	)
 
 	return &globalLibvirtPool{
-		poolName:    globalPoolName,
+		poolName:    poolName,
 		poolXML:     poolXML,
-		poolXMLPath: fmt.Sprintf("/tmp/pool-%s.tmp", globalPoolName),
-		poolNamer:   libvirtResourceNamer(ctx, globalPoolName),
+		poolXMLPath: fmt.Sprintf("/tmp/pool-%s.tmp", poolName),
+		poolNamer:   libvirtResourceNamer(ctx, poolName),
 		poolType:    resources.DefaultPool,
 		poolPath:    poolPath,
 	}


### PR DESCRIPTION
What does this PR do?
---------------------
This PR fixes a regression introduced by https://github.com/DataDog/test-infra-definitions/pull/469.
Pool name needs to be deduplicated when we are setting up multiple stacks, which is the case in the local dev scenario.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
