### PR TITLE
[APL-2554] Fix SSM parameters name collision

### DIFF
--- a/components/datadog/apps/fakeintake/fargateFakeintakeService.go
+++ b/components/datadog/apps/fakeintake/fargateFakeintakeService.go
@@ -59,8 +59,8 @@ func NewECSFargateInstance(e aws.Environment, option ...fakeintakeparams.Option)
 	}
 	opts = append(opts, pulumi.Parent(instance))
 
-	apiKeyParam, err := ssm.NewParameter(e.Ctx, e.Namer.ResourceName("agent-apikey"), &ssm.ParameterArgs{
-		Name:  e.CommonNamer.DisplayName(1011, pulumi.String("agent-apikey")),
+	apiKeyParam, err := ssm.NewParameter(e.Ctx, e.Namer.ResourceName("fakeintake-agent-apikey"), &ssm.ParameterArgs{
+		Name:  e.CommonNamer.DisplayName(1011, pulumi.String("fakeintake-agent-apikey")),
 		Type:  ssm.ParameterTypeSecureString,
 		Value: e.AgentAPIKey(),
 	}, opts...)


### PR DESCRIPTION
What does this PR do?
---------------------

Fix the following pulumi error:
```
Diagnostics:
  aws:ssm:Parameter (aws-agent-apikey):
    error: 1 error occurred:
        * creating SSM Parameter (lenaic-ecs-agent-apikey): ParameterAlreadyExists: The parameter already exists. To overwrite this value, set the overwrite option in the request to true.

  pulumi:pulumi:Stack (dd-lenaic-ecs):
    error: update failed
```

Which scenarios this will impact?
-------------------

* `aws/ecs` only.

Motivation
----------

The `ecs` scenario was already defining an SSM parameter with that name: https://github.com/DataDog/test-infra-definitions/blob/894572ece376dd9ac5d1bede114e8995272bde3f/scenarios/aws/ecs/run.go#L96-L99

Additional Notes
----------------

As the fake intake can be deployed in any scenario, it’s best to have a dedicated SSM parameter.