### PR TITLE
[APL-2554] Fix SSM parameters name collision

### DIFF
--- a/components/datadog/apps/fakeintake/fargateFakeintakeService.go
+++ b/components/datadog/apps/fakeintake/fargateFakeintakeService.go
@@ -59,8 +59,8 @@ func NewECSFargateInstance(e aws.Environment, option ...fakeintakeparams.Option)
 	}
 	opts = append(opts, pulumi.Parent(instance))
 
-	apiKeyParam, err := ssm.NewParameter(e.Ctx, e.Namer.ResourceName("fakeintake-agent-apikey"), &ssm.ParameterArgs{
-		Name:  e.CommonNamer.DisplayName(1011, pulumi.String("fakeintake-agent-apikey")),
+	apiKeyParam, err := ssm.NewParameter(e.Ctx, namer.ResourceName("agent", "apikey"), &ssm.ParameterArgs{
+		Name:  e.CommonNamer.DisplayName(1011, pulumi.String(params.Name), pulumi.String("apikey")),
 		Type:  ssm.ParameterTypeSecureString,
 		Value: e.AgentAPIKey(),
 	}, opts...)
@@ -68,7 +68,7 @@ func NewECSFargateInstance(e aws.Environment, option ...fakeintakeparams.Option)
 		return nil, err
 	}
 
-	taskDef, err := ecsClient.FargateTaskDefinitionWithAgent(e, namer.ResourceName(params.Name, "taskdef"), pulumi.String("fakeintake-ecs"), map[string]ecs.TaskDefinitionContainerDefinitionArgs{"fakeintake": *fargateLinuxContainerDefinition(params.ImageURL, apiKeyParam.Name)}, apiKeyParam.Name, nil)
+	taskDef, err := ecsClient.FargateTaskDefinitionWithAgent(e, namer.ResourceName("taskdef"), pulumi.String("fakeintake-ecs"), map[string]ecs.TaskDefinitionContainerDefinitionArgs{"fakeintake": *fargateLinuxContainerDefinition(params.ImageURL, apiKeyParam.Name)}, apiKeyParam.Name, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func NewECSFargateInstance(e aws.Environment, option ...fakeintakeparams.Option)
 		instance.Host, err = fargateServiceFakeIntakeWithLoadBalancer(e, params.Name, namer, taskDef, opts...)
 
 	} else {
-		instance.Host, err = fargateServiceFakeintakeWithoutLoadBalancer(e, namer.ResourceName(params.Name, "srv"), taskDef)
+		instance.Host, err = fargateServiceFakeintakeWithoutLoadBalancer(e, namer.ResourceName("srv"), taskDef)
 	}
 
 	if err != nil {


### PR DESCRIPTION
What does this PR do?
---------------------

Fix the [`new-e2e-agent-shared-components` tests](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/379074069) which still have SSM parameters conflict despite #489 because it creates several fake intakes per pulumi stack.

```
@ updating....
 +  dd:fakeintake aws-1fakeintake-grp creating (0s) 
 +  dd:fakeintake aws-2fakeintake-grp creating (0s) 
 +  aws:ssm:Parameter aws-fakeintake-agent-apikey creating (0s) 
 +  aws:ssm:Parameter aws-fakeintake-agent-apikey creating (0s) error: Duplicate resource URN 'urn:pulumi:ci-24023017-4670-mystack000::e2eci::dd:fakeintake$aws:ssm/parameter:Parameter::aws-fakeintake-agent-apikey'; try giving it a unique name
@ updating....
+  aws:ssm:Parameter aws-fakeintake-agent-apikey **creating failed (0.67s)** error: Duplicate resource URN 'urn:pulumi:ci-24023017-4670-mystack000::e2eci::dd:fakeintake$aws:ssm/parameter:Parameter::aws-fakeintake-agent-apikey'; try giving it a unique name
@ updating..............
 +  aws:ec2:Instance aws-vm created (13s) 
 +  dd:fakeintake aws-2fakeintake-grp created 
 +  pulumi:pulumi:Stack e2eci-ci-24023017-4670-mystack000 created 
 +  dd:fakeintake aws-1fakeintake-grp created 
Diagnostics:
  aws:ssm:Parameter (aws-fakeintake-agent-apikey):
    error: Duplicate resource URN 'urn:pulumi:ci-24023017-4670-mystack000::e2eci::dd:fakeintake$aws:ssm/parameter:Parameter::aws-fakeintake-agent-apikey'; try giving it a unique name
```

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------

Followup of #489.