### PR TITLE
Rerun destroy with refresh on failure

### DIFF
--- a/tasks/destroy.py
+++ b/tasks/destroy.py
@@ -54,8 +54,11 @@ def destroy(
         cmd = f"pulumi destroy --remove -s {full_stack_name} {force_destroy}"
         if use_aws_vault:
             cmd = get_aws_wrapper(aws_account) + cmd
-        ctx.run(cmd, pty=True)
-
+        ret = ctx.run(cmd, pty=True, warn=True)
+        if ret is not None and ret.exited != 0:
+            # run with refresh on first destroy attempt failure
+            cmd += " --refresh"
+            ctx.run(cmd, pty=True)
 
 def _get_existing_stacks() -> Tuple[List[str], List[str]]:
     output = subprocess.check_output(["pulumi", "stack", "ls", "--all"])

--- a/tasks/destroy.py
+++ b/tasks/destroy.py
@@ -60,6 +60,7 @@ def destroy(
             cmd += " --refresh"
             ctx.run(cmd, pty=True)
 
+
 def _get_existing_stacks() -> Tuple[List[str], List[str]]:
     output = subprocess.check_output(["pulumi", "stack", "ls", "--all"])
     output = output.decode("utf-8")


### PR DESCRIPTION
What does this PR do?
---------------------

Rerun the pulumi destroy command with refresh in case of failure, to prevent issue when the managed resources are already destroyed

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
