### PR TITLE
[CONTINT-3310] Increase the fake intake memory

### DIFF
--- a/components/datadog/apps/fakeintake/fargateFakeintakeService.go
+++ b/components/datadog/apps/fakeintake/fargateFakeintakeService.go
@@ -68,7 +68,7 @@ func NewECSFargateInstance(e aws.Environment, option ...fakeintakeparams.Option)
 		return nil, err
 	}
 
-	taskDef, err := ecsClient.FargateTaskDefinitionWithAgent(e, namer.ResourceName("taskdef"), pulumi.String("fakeintake-ecs"), map[string]ecs.TaskDefinitionContainerDefinitionArgs{"fakeintake": *fargateLinuxContainerDefinition(params.ImageURL, apiKeyParam.Name)}, apiKeyParam.Name, nil)
+	taskDef, err := ecsClient.FargateTaskDefinitionWithAgent(e, namer.ResourceName("taskdef"), pulumi.String("fakeintake-ecs"), 1024, 4096, map[string]ecs.TaskDefinitionContainerDefinitionArgs{"fakeintake": *fargateLinuxContainerDefinition(params.ImageURL, apiKeyParam.Name)}, apiKeyParam.Name, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func fargateLinuxContainerDefinition(imageURL string, apiKeySSMParamName pulumi.
 		Environment: ecs.TaskDefinitionKeyValuePairArray{
 			ecs.TaskDefinitionKeyValuePairArgs{
 				Name:  pulumi.StringPtr("GOMEMLIMIT"),
-				Value: pulumi.StringPtr("1536MiB"),
+				Value: pulumi.StringPtr("3072MiB"),
 			},
 		},
 		PortMappings: ecs.TaskDefinitionPortMappingArray{

--- a/scenarios/aws/ecs/run.go
+++ b/scenarios/aws/ecs/run.go
@@ -104,7 +104,7 @@ func Run(ctx *pulumi.Context) error {
 
 		// Deploy Fargate Agent
 		testContainer := ecs.FargateRedisContainerDefinition(apiKeyParam.Arn)
-		taskDef, err := ecs.FargateTaskDefinitionWithAgent(awsEnv, "fg-datadog-agent", pulumi.String("fg-datadog-agent"), map[string]ecsx.TaskDefinitionContainerDefinitionArgs{"redis": *testContainer}, apiKeyParam.Name, fakeintake)
+		taskDef, err := ecs.FargateTaskDefinitionWithAgent(awsEnv, "fg-datadog-agent", pulumi.String("fg-datadog-agent"), 1024, 2048, map[string]ecsx.TaskDefinitionContainerDefinitionArgs{"redis": *testContainer}, apiKeyParam.Name, fakeintake)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
What does this PR do?
---------------------

Increase the memory for the fake intake.

Which scenarios this will impact?
-------------------

Motivation
----------

Fake intake is OOM killed in the middle of tests.
See for ex [this dashboard](https://dddev.datadoghq.com/dashboard/qcp-brm-ysc/e2e-tests-containers-k8s?refresh_mode=paused&tpl_var_fake_intake_task_family%5B0%5D=ci-24080255-4670-kind-cluster-fakeintake-ecs&tpl_var_kube_cluster_name%5B0%5D=ci-24080255-4670-kind-cluster&from_ts=1701688436218&to_ts=1701689956524&live=false) and scroll down to the `Fake intake` group.
![image](https://github.com/DataDog/test-infra-definitions/assets/1437785/b0e44d5b-dccf-44da-a772-0f57d69f7b00)

We can see that the fake intake `Memory usage` is plateaued by `GOMEMLIMIT` while the `Number of payloads collected` keeps on growing.
Just before being killed we see a CPU spike caused by the GC.

Additional Notes
----------------
