### PR TITLE
[CONTINT-3310] Increase the Redis app verbosity

### DIFF
--- a/components/datadog/apps/redis/k8s.go
+++ b/components/datadog/apps/redis/k8s.go
@@ -74,6 +74,10 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("redis"),
 							Image: pulumi.String("redis:latest"),
+							Args: pulumi.StringArray{
+								pulumi.String("--loglevel"),
+								pulumi.String("verbose"),
+							},
 							Resources: &corev1.ResourceRequirementsArgs{
 								Limits: pulumi.StringMap{
 									"cpu":    pulumi.String("100m"),


### PR DESCRIPTION
What does this PR do?
---------------------

Increase the `redis` application verbosity.

Which scenarios this will impact?
-------------------

* `aws/eks`
* `aws/kind`

Motivation
----------

With the default log level, redis logs things only at startup and not at each request.
The problem is that, if the fake intake restarts in the middle of the tests, after redis pods have started, the tests will never find any redis logs from the fake intake client anymore.

In order to be more resilient to fake intake restarts, it’s better to be sure that the source of logs that are asserted are producing a continuous flow of logs.

Additional Notes
----------------
