### PR TITLE
dev image: use first 12 chars of `CI_COMMIT_SHA` instead of `CI_COMMIT_SHORT_SHA`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,7 @@ build-runner-image:
     - when: on_success
   script:
     - docker buildx build --no-cache --pull --push --label target=build --tag ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA} .
+    - crane copy ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA} ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHA:0:12}
   retry: 2
 
 


### PR DESCRIPTION
What does this PR do?
---------------------

Currently the dev image is tagged using `CI_COMMIT_SHORT_SHA` which is 8 characters long, but also a different scheme than the release image. This PR syncs all images to use the first 12 characters of the the full sha

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
