### PR TITLE
Increase the amount of memory granted to `stress-ng`

### DIFF
--- a/components/datadog/apps/cpustress/ecs.go
+++ b/components/datadog/apps/cpustress/ecs.go
@@ -39,7 +39,7 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...
 						pulumi.String("--cpu-load=15"),
 					},
 					Cpu:    pulumi.IntPtr(200),
-					Memory: pulumi.IntPtr(6),
+					Memory: pulumi.IntPtr(64),
 				},
 			},
 			ExecutionRole: &awsx.DefaultRoleWithPolicyArgs{

--- a/components/datadog/apps/cpustress/k8s.go
+++ b/components/datadog/apps/cpustress/k8s.go
@@ -69,11 +69,11 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 							Resources: &corev1.ResourceRequirementsArgs{
 								Limits: pulumi.StringMap{
 									"cpu":    pulumi.String("200m"),
-									"memory": pulumi.String("4Mi"),
+									"memory": pulumi.String("64Mi"),
 								},
 								Requests: pulumi.StringMap{
 									"cpu":    pulumi.String("200m"),
-									"memory": pulumi.String("4Mi"),
+									"memory": pulumi.String("64Mi"),
 								},
 							},
 						},


### PR DESCRIPTION
What does this PR do?
---------------------

Increase the amount of memory granted to the `cpustress` fake application using the `ghcr.io/colinianking/stress-ng:latest` image.

Which scenarios this will impact?
-------------------

* `aws/ecs`
* `aws/eks`
* `aws/kind`

Motivation
----------

The `ghcr.io/colinianking/stress-ng:latest` image has recently been upgraded.
Whereas it used to consume 3 MB of memory, it is now consuming 42 MB.
![image](https://github.com/DataDog/test-infra-definitions/assets/1437785/394f8764-42cc-4aa9-a481-0f688bf14105)

Additional Notes
----------------
