### PR TITLE
[CONTINT-3520] Increase the Redis app verbosity

### DIFF
--- a/components/datadog/apps/redis/ecs.go
+++ b/components/datadog/apps/redis/ecs.go
@@ -54,8 +54,12 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...
 		TaskDefinitionArgs: &ecs.EC2ServiceTaskDefinitionArgs{
 			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
 				"redis": {
-					Name:   pulumi.String("redis"),
-					Image:  pulumi.String("redis:latest"),
+					Name:  pulumi.String("redis"),
+					Image: pulumi.String("redis:latest"),
+					Command: pulumi.StringArray{
+						pulumi.String("--loglevel"),
+						pulumi.String("verbose"),
+					},
 					Cpu:    pulumi.IntPtr(100),
 					Memory: pulumi.IntPtr(32),
 					PortMappings: ecs.TaskDefinitionPortMappingArray{


### PR DESCRIPTION
What does this PR do?
---------------------

Increase the `redis` application verbosity.

Which scenarios this will impact?
-------------------

* `aws/ecs`

Motivation
----------

With the default log level, redis logs things only at startup and not at each request.
The problem is that, if the fake intake restarts in the middle of the tests, after redis pods have started, the tests will never find any redis logs from the fake intake client anymore.

In order to be more resilient to fake intake restarts, it’s better to be sure that the source of logs that are asserted are producing a continuous flow of logs.

Additional Notes
----------------
