### PR TITLE
Use last version of install_script on all cases

### DIFF
--- a/components/os/unix.go
+++ b/components/os/unix.go
@@ -27,10 +27,8 @@ func (*Unix) CheckIsAbsPath(path string) bool {
 }
 
 func (*Unix) GetAgentInstallCmd(version AgentVersion) (string, error) {
-	if version.PipelineID != "" {
-		return getUnixInstallFormatString("install_script_agent7.sh", version), nil
-	}
-	return getUnixInstallFormatString("install_script.sh", version), nil
+	return getUnixInstallFormatString("install_script_agent7.sh", version), nil
+
 }
 
 func (*Unix) GetType() Type {


### PR DESCRIPTION
What does this PR do?
---------------------
Remove the usage of `install_script.sh` which should not be used anymore, I guess

Which scenarios this will impact?
-------------------
All scenarios where the agent is installed

Motivation
----------
Maintenance

Additional Notes
----------------
