### PR TITLE
Use latest version of the agent to monitor fakeintake

### DIFF
--- a/components/datadog/agent/ecsFargate.go
+++ b/components/datadog/agent/ecsFargate.go
@@ -10,7 +10,6 @@ import (
 
 func ECSFargateLinuxContainerDefinition(e config.CommonEnvironment, image string, apiKeySSMParamName pulumi.StringInput, fakeintake *ddfakeintake.ConnectionExporter, logConfig ecs.TaskDefinitionLogConfigurationPtrInput) *ecs.TaskDefinitionContainerDefinitionArgs {
 	var agentImage string
-
 	if image == "" {
 		agentImage = DockerAgentFullImagePath(&e, "public.ecr.aws/datadog/agent")
 	} else {

--- a/components/datadog/agent/ecsFargate.go
+++ b/components/datadog/agent/ecsFargate.go
@@ -8,54 +8,20 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-func ECSFargateLinuxContainerDefinition(e config.CommonEnvironment, apiKeySSMParamName pulumi.StringInput, fakeintake *ddfakeintake.ConnectionExporter, logConfig ecs.TaskDefinitionLogConfigurationPtrInput) *ecs.TaskDefinitionContainerDefinitionArgs {
+func ECSFargateLinuxContainerDefinition(e config.CommonEnvironment, image string, apiKeySSMParamName pulumi.StringInput, fakeintake *ddfakeintake.ConnectionExporter, logConfig ecs.TaskDefinitionLogConfigurationPtrInput) *ecs.TaskDefinitionContainerDefinitionArgs {
 
-	return &ecs.TaskDefinitionContainerDefinitionArgs{
-		Cpu:       pulumi.IntPtr(0),
-		Name:      pulumi.String("datadog-agent"),
-		Image:     pulumi.Sprintf(DockerAgentFullImagePath(&e, "public.ecr.aws/datadog/agent")),
-		Essential: pulumi.BoolPtr(true),
-		Environment: append(ecs.TaskDefinitionKeyValuePairArray{
-			ecs.TaskDefinitionKeyValuePairArgs{
-				Name:  pulumi.StringPtr("DD_DOGSTATSD_SOCKET"),
-				Value: pulumi.StringPtr("/var/run/datadog/dsd.socket"),
-			},
-			ecs.TaskDefinitionKeyValuePairArgs{
-				Name:  pulumi.StringPtr("ECS_FARGATE"),
-				Value: pulumi.StringPtr("true"),
-			},
-		}, ecsFakeintakeAdditionalEndpointsEnv(fakeintake)...),
-		Secrets: ecs.TaskDefinitionSecretArray{
-			ecs.TaskDefinitionSecretArgs{
-				Name:      pulumi.String("DD_API_KEY"),
-				ValueFrom: apiKeySSMParamName,
-			},
-		},
-		MountPoints: ecs.TaskDefinitionMountPointArray{
-			ecs.TaskDefinitionMountPointArgs{
-				ContainerPath: pulumi.StringPtr("/var/run/datadog"),
-				SourceVolume:  pulumi.StringPtr("dd-sockets"),
-			},
-		},
-		HealthCheck: &ecs.TaskDefinitionHealthCheckArgs{
-			Retries:     pulumi.IntPtr(2),
-			Command:     pulumi.ToStringArray([]string{"CMD-SHELL", "/probe.sh"}),
-			StartPeriod: pulumi.IntPtr(10),
-			Interval:    pulumi.IntPtr(30),
-			Timeout:     pulumi.IntPtr(5),
-		},
-		LogConfiguration: logConfig,
-		PortMappings:     ecs.TaskDefinitionPortMappingArray{},
-		VolumesFrom:      ecs.TaskDefinitionVolumeFromArray{},
+	var agentImage string
+
+	if image == "" {
+		agentImage = DockerAgentFullImagePath(&e, "public.ecr.aws/datadog/agent")
+	} else {
+		agentImage = image
 	}
-}
-
-func ECSFargateLinuxContainerDefinitionLatest(apiKeySSMParamName pulumi.StringInput, fakeintake *ddfakeintake.ConnectionExporter, logConfig ecs.TaskDefinitionLogConfigurationPtrInput) *ecs.TaskDefinitionContainerDefinitionArgs {
 
 	return &ecs.TaskDefinitionContainerDefinitionArgs{
 		Cpu:       pulumi.IntPtr(0),
 		Name:      pulumi.String("datadog-agent"),
-		Image:     pulumi.Sprintf("public.ecr.aws/datadog/agent:latest"),
+		Image:     pulumi.Sprintf(agentImage),
 		Essential: pulumi.BoolPtr(true),
 		Environment: append(ecs.TaskDefinitionKeyValuePairArray{
 			ecs.TaskDefinitionKeyValuePairArgs{

--- a/components/datadog/agent/ecsFargate.go
+++ b/components/datadog/agent/ecsFargate.go
@@ -9,10 +9,53 @@ import (
 )
 
 func ECSFargateLinuxContainerDefinition(e config.CommonEnvironment, apiKeySSMParamName pulumi.StringInput, fakeintake *ddfakeintake.ConnectionExporter, logConfig ecs.TaskDefinitionLogConfigurationPtrInput) *ecs.TaskDefinitionContainerDefinitionArgs {
+
 	return &ecs.TaskDefinitionContainerDefinitionArgs{
 		Cpu:       pulumi.IntPtr(0),
 		Name:      pulumi.String("datadog-agent"),
 		Image:     pulumi.Sprintf(DockerAgentFullImagePath(&e, "public.ecr.aws/datadog/agent")),
+		Essential: pulumi.BoolPtr(true),
+		Environment: append(ecs.TaskDefinitionKeyValuePairArray{
+			ecs.TaskDefinitionKeyValuePairArgs{
+				Name:  pulumi.StringPtr("DD_DOGSTATSD_SOCKET"),
+				Value: pulumi.StringPtr("/var/run/datadog/dsd.socket"),
+			},
+			ecs.TaskDefinitionKeyValuePairArgs{
+				Name:  pulumi.StringPtr("ECS_FARGATE"),
+				Value: pulumi.StringPtr("true"),
+			},
+		}, ecsFakeintakeAdditionalEndpointsEnv(fakeintake)...),
+		Secrets: ecs.TaskDefinitionSecretArray{
+			ecs.TaskDefinitionSecretArgs{
+				Name:      pulumi.String("DD_API_KEY"),
+				ValueFrom: apiKeySSMParamName,
+			},
+		},
+		MountPoints: ecs.TaskDefinitionMountPointArray{
+			ecs.TaskDefinitionMountPointArgs{
+				ContainerPath: pulumi.StringPtr("/var/run/datadog"),
+				SourceVolume:  pulumi.StringPtr("dd-sockets"),
+			},
+		},
+		HealthCheck: &ecs.TaskDefinitionHealthCheckArgs{
+			Retries:     pulumi.IntPtr(2),
+			Command:     pulumi.ToStringArray([]string{"CMD-SHELL", "/probe.sh"}),
+			StartPeriod: pulumi.IntPtr(10),
+			Interval:    pulumi.IntPtr(30),
+			Timeout:     pulumi.IntPtr(5),
+		},
+		LogConfiguration: logConfig,
+		PortMappings:     ecs.TaskDefinitionPortMappingArray{},
+		VolumesFrom:      ecs.TaskDefinitionVolumeFromArray{},
+	}
+}
+
+func ECSFargateLinuxContainerDefinitionLatest(apiKeySSMParamName pulumi.StringInput, fakeintake *ddfakeintake.ConnectionExporter, logConfig ecs.TaskDefinitionLogConfigurationPtrInput) *ecs.TaskDefinitionContainerDefinitionArgs {
+
+	return &ecs.TaskDefinitionContainerDefinitionArgs{
+		Cpu:       pulumi.IntPtr(0),
+		Name:      pulumi.String("datadog-agent"),
+		Image:     pulumi.Sprintf("public.ecr.aws/datadog/agent:latest"),
 		Essential: pulumi.BoolPtr(true),
 		Environment: append(ecs.TaskDefinitionKeyValuePairArray{
 			ecs.TaskDefinitionKeyValuePairArgs{

--- a/components/datadog/agent/ecsFargate.go
+++ b/components/datadog/agent/ecsFargate.go
@@ -9,7 +9,6 @@ import (
 )
 
 func ECSFargateLinuxContainerDefinition(e config.CommonEnvironment, image string, apiKeySSMParamName pulumi.StringInput, fakeintake *ddfakeintake.ConnectionExporter, logConfig ecs.TaskDefinitionLogConfigurationPtrInput) *ecs.TaskDefinitionContainerDefinitionArgs {
-
 	var agentImage string
 
 	if image == "" {

--- a/resources/aws/ecs/fargateService.go
+++ b/resources/aws/ecs/fargateService.go
@@ -36,7 +36,7 @@ func FargateService(e aws.Environment, name string, clusterArn pulumi.StringInpu
 }
 
 func FargateTaskDefinitionWithAgent(e aws.Environment, name string, family pulumi.StringInput, cpu, memory int, containers map[string]ecs.TaskDefinitionContainerDefinitionArgs, apiKeySSMParamName pulumi.StringInput, fakeintake *ddfakeintake.ConnectionExporter) (*ecs.FargateTaskDefinition, error) {
-	containers["datadog-agent"] = *agent.ECSFargateLinuxContainerDefinition(*e.CommonEnvironment, apiKeySSMParamName, fakeintake, GetFirelensLogConfiguration(pulumi.String("datadog-agent"), pulumi.String("datadog-agent"), apiKeySSMParamName))
+	containers["datadog-agent"] = *agent.ECSFargateLinuxContainerDefinitionLatest(apiKeySSMParamName, fakeintake, GetFirelensLogConfiguration(pulumi.String("datadog-agent"), pulumi.String("datadog-agent"), apiKeySSMParamName))
 	containers["log_router"] = *FargateFirelensContainerDefinition()
 
 	return ecs.NewFargateTaskDefinition(e.Ctx, e.Namer.ResourceName(name), &ecs.FargateTaskDefinitionArgs{

--- a/resources/aws/ecs/fargateService.go
+++ b/resources/aws/ecs/fargateService.go
@@ -36,7 +36,7 @@ func FargateService(e aws.Environment, name string, clusterArn pulumi.StringInpu
 }
 
 func FargateTaskDefinitionWithAgent(e aws.Environment, name string, family pulumi.StringInput, cpu, memory int, containers map[string]ecs.TaskDefinitionContainerDefinitionArgs, apiKeySSMParamName pulumi.StringInput, fakeintake *ddfakeintake.ConnectionExporter) (*ecs.FargateTaskDefinition, error) {
-	containers["datadog-agent"] = *agent.ECSFargateLinuxContainerDefinition(apiKeySSMParamName, "public.ecr.aws/datadog/agent:latest", fakeintake, GetFirelensLogConfiguration(pulumi.String("datadog-agent"), pulumi.String("datadog-agent"), apiKeySSMParamName))
+	containers["datadog-agent"] = *agent.ECSFargateLinuxContainerDefinition(*e.CommonEnvironment, "public.ecr.aws/datadog/agent:latest", apiKeySSMParamName, fakeintake, GetFirelensLogConfiguration(pulumi.String("datadog-agent"), pulumi.String("datadog-agent"), apiKeySSMParamName))
 	containers["log_router"] = *FargateFirelensContainerDefinition()
 
 	return ecs.NewFargateTaskDefinition(e.Ctx, e.Namer.ResourceName(name), &ecs.FargateTaskDefinitionArgs{

--- a/resources/aws/ecs/fargateService.go
+++ b/resources/aws/ecs/fargateService.go
@@ -36,7 +36,7 @@ func FargateService(e aws.Environment, name string, clusterArn pulumi.StringInpu
 }
 
 func FargateTaskDefinitionWithAgent(e aws.Environment, name string, family pulumi.StringInput, cpu, memory int, containers map[string]ecs.TaskDefinitionContainerDefinitionArgs, apiKeySSMParamName pulumi.StringInput, fakeintake *ddfakeintake.ConnectionExporter) (*ecs.FargateTaskDefinition, error) {
-	containers["datadog-agent"] = *agent.ECSFargateLinuxContainerDefinitionLatest(apiKeySSMParamName, fakeintake, GetFirelensLogConfiguration(pulumi.String("datadog-agent"), pulumi.String("datadog-agent"), apiKeySSMParamName))
+	containers["datadog-agent"] = *agent.ECSFargateLinuxContainerDefinition(apiKeySSMParamName, "public.ecr.aws/datadog/agent:latest", fakeintake, GetFirelensLogConfiguration(pulumi.String("datadog-agent"), pulumi.String("datadog-agent"), apiKeySSMParamName))
 	containers["log_router"] = *FargateFirelensContainerDefinition()
 
 	return ecs.NewFargateTaskDefinition(e.Ctx, e.Namer.ResourceName(name), &ecs.FargateTaskDefinitionArgs{


### PR DESCRIPTION
What does this PR do?
---------------------

Change image used for the agent monitoring fake intake to latest agent image
Since the agent deployed next to the fakeintake is supposed to help to monitor the fakeintake it is better to rely on a stable version of the agent

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
