### PR TITLE
[CONTINT-52] Start the agent with host network on kind

### DIFF
--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -62,6 +62,8 @@ datadog:
   kubelet:
     tlsVerify: false
   clusterName: "%s"
+agents:
+  useHostNetwork: true
 `, clusterName)
 
 		helmComponent, err := agent.NewHelmInstallation(*awsEnv.CommonEnvironment, agent.HelmInstallationArgs{


### PR DESCRIPTION
What does this PR do?
---------------------

Start the agent with host network on `kind`.

Which scenarios this will impact?
-------------------

* `aws/kind`

Motivation
----------

Fix the kubernetes control plane checks `kube_apiserver_metrics`, `kube_controller_manager` and `kube_scheduler`.
Kubernetes control planes components are binding their OpenMetrics endpoint to the loopback interface by default, so that the agent needs host network to be able to connect to them.

Additional Notes
----------------
