### PR TITLE
[CONTINT-3399] Fix some objects naming

### DIFF
--- a/components/datadog/agent/ecsFargate.go
+++ b/components/datadog/agent/ecsFargate.go
@@ -23,6 +23,10 @@ func ECSFargateLinuxContainerDefinition(e config.CommonEnvironment, apiKeySSMPar
 				Name:  pulumi.StringPtr("ECS_FARGATE"),
 				Value: pulumi.StringPtr("true"),
 			},
+			ecs.TaskDefinitionKeyValuePairArgs{
+				Name:  pulumi.StringPtr("DD_CHECKS_TAG_CARDINALITY"),
+				Value: pulumi.StringPtr("high"),
+			},
 		}, ecsFakeintakeAdditionalEndpointsEnv(fakeintake)...),
 		Secrets: ecs.TaskDefinitionSecretArray{
 			ecs.TaskDefinitionSecretArgs{


### PR DESCRIPTION
What does this PR do?
---------------------

Fix some objects naming.

Which scenarios this will impact?
-------------------

* `aws/ecs`

Motivation
----------

* Use `namer.ResourceName(…)` for naming Pulumi resources
* Use `e.CommonNamer.DisplayName(…)` for naming AWS resources

Additional Notes
----------------

Here it how resources are now named:
![image](https://github.com/DataDog/test-infra-definitions/assets/1437785/81083812-67ad-425c-91a9-1ee94701717f)
