### PR TITLE
remove unattended-upgrades on microvm instances

### DIFF
--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -92,6 +92,10 @@ func (i *Instance) GetIP() pulumi.StringOutput {
 	return i.instance.GetIP()
 }
 
+const metalUserData = `#!/bin/bash
+apt-get -y remove unattended-upgrades
+`
+
 func newMetalInstance(instanceEnv *InstanceEnvironment, name, arch string, m config.DDMicroVMConfig) (*Instance, error) {
 	var instanceType string
 	var ami string
@@ -112,7 +116,12 @@ func newMetalInstance(instanceEnv *InstanceEnvironment, name, arch string, m con
 		return nil, fmt.Errorf("unsupported arch: %s", arch)
 	}
 
-	awsInstance, err := ec2vm.NewEC2VMWithEnv(*awsEnv, ec2params.WithImageName(ami, os.Architecture(arch), ec2os.UbuntuOS), ec2params.WithInstanceType(instanceType), ec2params.WithName(name))
+	awsInstance, err := ec2vm.NewEC2VMWithEnv(*awsEnv,
+		ec2params.WithImageName(ami, os.Architecture(arch), ec2os.UbuntuOS),
+		ec2params.WithInstanceType(instanceType),
+		ec2params.WithName(name),
+		ec2params.WithUserData(metalUserData),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -92,6 +92,8 @@ func (i *Instance) GetIP() pulumi.StringOutput {
 	return i.instance.GetIP()
 }
 
+// User data shell scripts must start with the #! characters and the path to the interpreter you want to read the
+// script (commonly /bin/bash).
 const metalUserData = `#!/bin/bash
 apt-get -y remove unattended-upgrades
 `


### PR DESCRIPTION
What does this PR do?
---------------------
Removes the `unattended-upgrades` package on boot of the metal instances during the microvm scenario.

Which scenarios this will impact?
-------------------
`aws/microVMs`

Motivation
----------
A failure installing packages due to `unattended-upgrades` already holding the `dpkg` lock.

Additional Notes
----------------
https://datadoghq.atlassian.net/browse/EBPF-358