### PR TITLE
Make Pulumi wait for Fargate tasks to be ready

### DIFF
--- a/components/datadog/apps/fakeintake/fargateFakeintakeService.go
+++ b/components/datadog/apps/fakeintake/fargateFakeintakeService.go
@@ -300,9 +300,8 @@ func fargateServiceFakeIntakeWithLoadBalancer(e aws.Environment, name string, na
 			SecurityGroups: pulumi.ToStringArray(e.DefaultSecurityGroups()),
 			Subnets:        e.RandomSubnets(),
 		},
-		LoadBalancers:             balancerArray,
-		TaskDefinition:            taskDef.TaskDefinition.Arn(),
-		ContinueBeforeSteadyState: pulumi.BoolPtr(true),
+		LoadBalancers:  balancerArray,
+		TaskDefinition: taskDef.TaskDefinition.Arn(),
 	}, opts...); err != nil {
 		return pulumi.StringOutput{}, err
 	}

--- a/resources/aws/ecs/fargateService.go
+++ b/resources/aws/ecs/fargateService.go
@@ -29,9 +29,8 @@ func FargateService(e aws.Environment, name string, clusterArn pulumi.StringInpu
 			SecurityGroups: pulumi.ToStringArray(e.DefaultSecurityGroups()),
 			Subnets:        e.RandomSubnets(),
 		},
-		TaskDefinition:            taskDefArn,
-		EnableExecuteCommand:      pulumi.BoolPtr(true),
-		ContinueBeforeSteadyState: pulumi.BoolPtr(true),
+		TaskDefinition:       taskDefArn,
+		EnableExecuteCommand: pulumi.BoolPtr(true),
 	}, e.WithProviders(config.ProviderAWS, config.ProviderAWSX))
 }
 


### PR DESCRIPTION
What does this PR do?
---------------------

Make Pulumi wait for Fargate tasks to be ready before considering the service as being successfully created.

Which scenarios this will impact?
-------------------

* `aws/ecs`
* `fakeintake`

Motivation
----------

I’ve seen some tests starting with a waiting loop for the fake intake to become healthy.

https://github.com/DataDog/datadog-agent/blob/f665d31db13044ae4ad2f113faef7aaebfab9be9/test/new-e2e/tests/agent-subcommands/diagnose_test.go#L50-L52

https://github.com/DataDog/datadog-agent/blob/f665d31db13044ae4ad2f113faef7aaebfab9be9/test/new-e2e/tests/agent-subcommands/flare/flare_common_test.go#L43-L46

This should normally not be needed if Pulumi is correctly waiting for resources to be fully created.

Additional Notes
----------------
