### PR TITLE
Default deploy fakeintake without LB on VM stack

### DIFF
--- a/scenarios/aws/dockerVM/run.go
+++ b/scenarios/aws/dockerVM/run.go
@@ -35,8 +35,8 @@ func Run(ctx *pulumi.Context) error {
 		if env.AgentUseFakeintake() {
 			fakeIntakeOptions := []fakeintakeparams.Option{}
 
-			if !vm.Infra.GetAwsEnvironment().InfraShouldDeployFakeintakeWithLB() {
-				fakeIntakeOptions = append(fakeIntakeOptions, fakeintakeparams.WithoutLoadBalancer())
+			if vm.Infra.GetAwsEnvironment().InfraShouldDeployFakeintakeWithLB() {
+				fakeIntakeOptions = append(fakeIntakeOptions, fakeintakeparams.WithLoadBalancer())
 			}
 			fakeintake, err := aws.NewEcsFakeintake(vm.Infra.GetAwsEnvironment(), fakeIntakeOptions...)
 			if err != nil {

--- a/scenarios/aws/ecs/run.go
+++ b/scenarios/aws/ecs/run.go
@@ -12,6 +12,7 @@ import (
 	resourcesAws "github.com/DataDog/test-infra-definitions/resources/aws"
 	"github.com/DataDog/test-infra-definitions/resources/aws/ecs"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/fakeintake/fakeintakeparams"
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ssm"
 	ecsx "github.com/pulumi/pulumi-awsx/sdk/go/awsx/ecs"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -89,7 +90,13 @@ func Run(ctx *pulumi.Context) error {
 	if awsEnv.AgentDeploy() {
 		var fakeintake *ddfakeintake.ConnectionExporter
 		if awsEnv.GetCommonEnvironment().AgentUseFakeintake() {
-			if fakeintake, err = aws.NewEcsFakeintake(awsEnv); err != nil {
+			fakeIntakeOptions := []fakeintakeparams.Option{}
+
+			if awsEnv.GetCommonEnvironment().InfraShouldDeployFakeintakeWithLB() {
+				fakeIntakeOptions = append(fakeIntakeOptions, fakeintakeparams.WithLoadBalancer())
+			}
+
+			if fakeintake, err = aws.NewEcsFakeintake(awsEnv, fakeIntakeOptions...); err != nil {
 				return err
 			}
 		}

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -14,6 +14,7 @@ import (
 	resourcesAws "github.com/DataDog/test-infra-definitions/resources/aws"
 	localEks "github.com/DataDog/test-infra-definitions/resources/aws/eks"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/fakeintake/fakeintakeparams"
 
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ec2"
 	awsEks "github.com/pulumi/pulumi-aws/sdk/v5/go/aws/eks"
@@ -190,7 +191,13 @@ func Run(ctx *pulumi.Context) error {
 
 	var fakeIntake *ddfakeintake.ConnectionExporter
 	if awsEnv.GetCommonEnvironment().AgentUseFakeintake() {
-		if fakeIntake, err = aws.NewEcsFakeintake(awsEnv); err != nil {
+		fakeIntakeOptions := []fakeintakeparams.Option{}
+
+		if awsEnv.GetCommonEnvironment().InfraShouldDeployFakeintakeWithLB() {
+			fakeIntakeOptions = append(fakeIntakeOptions, fakeintakeparams.WithLoadBalancer())
+		}
+
+		if fakeIntake, err = aws.NewEcsFakeintake(awsEnv, fakeIntakeOptions...); err != nil {
 			return err
 		}
 	}

--- a/scenarios/aws/fakeintake/fakeintakeparams/params.go
+++ b/scenarios/aws/fakeintake/fakeintakeparams/params.go
@@ -13,17 +13,17 @@ type Option = func(*Params) error
 // NewParams returns a new instance of Fakeintake Params
 func NewParams(options ...Option) (*Params, error) {
 	params := &Params{
-		LoadBalancerEnabled: true,
+		LoadBalancerEnabled: false,
 		Name:                "fakeintake",
 		ImageURL:            "public.ecr.aws/datadog/fakeintake:latest",
 	}
 	return common.ApplyOption(params, options)
 }
 
-// WithoutLoadBalancer disable load balancer in front of the fakeintake
-func WithoutLoadBalancer() Option {
+// WithLoadBalancer enable load balancer in front of the fakeintake
+func WithLoadBalancer() Option {
 	return func(p *Params) error {
-		p.LoadBalancerEnabled = false
+		p.LoadBalancerEnabled = true
 		return nil
 	}
 }

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -2,6 +2,7 @@ package kindvm
 
 import (
 	"fmt"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/fakeintake/fakeintakeparams"
 
 	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
@@ -48,7 +49,13 @@ func Run(ctx *pulumi.Context) error {
 
 	var fakeIntake *ddfakeintake.ConnectionExporter
 	if awsEnv.GetCommonEnvironment().AgentUseFakeintake() {
-		if fakeIntake, err = aws.NewEcsFakeintake(awsEnv); err != nil {
+		fakeIntakeOptions := []fakeintakeparams.Option{}
+
+		if awsEnv.GetCommonEnvironment().InfraShouldDeployFakeintakeWithLB() {
+			fakeIntakeOptions = append(fakeIntakeOptions, fakeintakeparams.WithLoadBalancer())
+		}
+
+		if fakeIntake, err = aws.NewEcsFakeintake(awsEnv, fakeIntakeOptions...); err != nil {
 			return err
 		}
 	}

--- a/scenarios/aws/vm/run.go
+++ b/scenarios/aws/vm/run.go
@@ -49,8 +49,8 @@ func Run(ctx *pulumi.Context) error {
 
 			fakeIntakeOptions := []fakeintakeparams.Option{}
 
-			if !vm.Infra.GetAwsEnvironment().InfraShouldDeployFakeintakeWithLB() {
-				fakeIntakeOptions = append(fakeIntakeOptions, fakeintakeparams.WithoutLoadBalancer())
+			if vm.Infra.GetAwsEnvironment().InfraShouldDeployFakeintakeWithLB() {
+				fakeIntakeOptions = append(fakeIntakeOptions, fakeintakeparams.WithLoadBalancer())
 			}
 
 			fakeintake, err := aws.NewEcsFakeintake(vm.Infra.GetAwsEnvironment(), fakeIntakeOptions...)


### PR DESCRIPTION
What does this PR do?
---------------------

Set the `LoadBalancerEnabled` to `false` by default. Adding `WithLoadBalancer` method to enable the loadbalancer.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------

Modifying existing tests to work with these changes on [PR#21535](https://github.com/DataDog/datadog-agent/pull/21535)
