### PR TITLE
Disable host metadata collection on dogstatsd standalone

### DIFF
--- a/components/datadog/dogstatsd-standalone/k8s.go
+++ b/components/datadog/dogstatsd-standalone/k8s.go
@@ -71,6 +71,10 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 			Value: e.AgentAPIKey(),
 		},
 		&corev1.EnvVarArgs{
+			Name:  pulumi.String("DD_ENABLE_METADATA_COLLECTION"),
+			Value: pulumi.String("false"),
+		},
+		&corev1.EnvVarArgs{
 			Name: pulumi.String("DD_KUBERNETES_KUBELET_HOST"),
 			ValueFrom: corev1.EnvVarSourceArgs{
 				FieldRef: corev1.ObjectFieldSelectorArgs{


### PR DESCRIPTION
What does this PR do?
---------------------

Disable host metadata collection on dogstatsd standalone.

Which scenarios this will impact?
-------------------

* `aws/eks`
* `aws/kind`

Motivation
----------

Host metadata are already sent by the agent running on the same nodes.

Additional Notes
----------------
