### PR TITLE
add proc and orch additional endpoints in fakeintake helm chart

### DIFF
--- a/components/datadog/agent/helm.go
+++ b/components/datadog/agent/helm.go
@@ -309,6 +309,14 @@ func (values HelmValues) configureFakeintake(fakeintake *ddfakeintake.Connection
 			"value": pulumi.Sprintf(`{"https://%s": ["FAKEAPIKEY"]}`, fakeintake.Host),
 		},
 		pulumi.Map{
+			"name":  pulumi.String("DD_PROCESS_ADDITIONAL_ENDPOINTS"),
+			"value": pulumi.Sprintf(`{"https://%s": ["FAKEAPIKEY"]}`, fakeintake.Host),
+		},
+		pulumi.Map{
+			"name":  pulumi.String("DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_ADDITIONAL_ENDPOINTS"),
+			"value": pulumi.Sprintf(`{"https://%s": ["FAKEAPIKEY"]}`, fakeintake.Host),
+		},
+		pulumi.Map{
 			"name":  pulumi.String("DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS"),
 			"value": pulumi.Sprintf(`[{"host": "%s"}]`, fakeintake.Host),
 		},


### PR DESCRIPTION
Configures the agent helm chart to include the config in order to send proc and orch payloads to the fake intake