### PR TITLE
Add updater install

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -20,6 +20,7 @@ const (
 	DDAgentConfigNamespace     = "ddagent"
 	DDTestingWorkloadNamespace = "ddtestworkload"
 	DDDogstatsdNamespace       = "dddogstatsd"
+	DDUpdaterConfigNamespace   = "ddupdater"
 
 	// Infra namespace
 	DDInfraEnvironment                      = "env"
@@ -43,6 +44,9 @@ const (
 	DDAgentAPPKeyParamName               = "appKey"
 	DDAgentFakeintake                    = "fakeintake"
 
+	// Updater Namespace
+	DDUpdaterParamName = "deploy"
+
 	// Testing workload namerNamespace
 	DDTestingWorkloadDeployParamName = "deploy"
 
@@ -61,6 +65,7 @@ type CommonEnvironment struct {
 	AgentConfig           *sdkconfig.Config
 	TestingWorkloadConfig *sdkconfig.Config
 	DogstatsdConfig       *sdkconfig.Config
+	UpdaterConfig         *sdkconfig.Config
 
 	username string
 }
@@ -72,6 +77,7 @@ func NewCommonEnvironment(ctx *pulumi.Context) (CommonEnvironment, error) {
 		AgentConfig:           sdkconfig.New(ctx, DDAgentConfigNamespace),
 		TestingWorkloadConfig: sdkconfig.New(ctx, DDTestingWorkloadNamespace),
 		DogstatsdConfig:       sdkconfig.New(ctx, DDDogstatsdNamespace),
+		UpdaterConfig:         sdkconfig.New(ctx, DDUpdaterConfigNamespace),
 		CommonNamer:           namer.NewNamer(ctx, ""),
 		providerRegistry:      newProviderRegistry(ctx),
 	}
@@ -209,6 +215,11 @@ func (e *CommonEnvironment) DogstatsdDeploy() bool {
 
 func (e *CommonEnvironment) DogstatsdFullImagePath() string {
 	return e.GetStringWithDefault(e.DogstatsdConfig, DDDogstatsdFullImagePathParamName, "gcr.io/datadoghq/dogstatsd")
+}
+
+// Updater namespace
+func (e *CommonEnvironment) UpdaterDeploy() bool {
+	return e.GetBoolWithDefault(e.UpdaterConfig, DDUpdaterParamName, false)
 }
 
 // Generic methods

--- a/components/datadog/updater/install.go
+++ b/components/datadog/updater/install.go
@@ -1,0 +1,71 @@
+package updater
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/common/namer"
+	"github.com/DataDog/test-infra-definitions/components"
+	"github.com/DataDog/test-infra-definitions/components/command"
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	remoteComp "github.com/DataDog/test-infra-definitions/components/remote"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+//go:embed install_script.sh
+var installScript string
+
+type HostUpdaterOutput struct {
+	components.JSONImporter
+}
+
+// HostUpdater is an installer for the Agent on a virtual machine
+type HostUpdater struct {
+	pulumi.ResourceState
+	components.Component
+
+	namer namer.Namer
+	host  *remoteComp.Host
+}
+
+func (h *HostUpdater) Export(ctx *pulumi.Context, out *HostUpdaterOutput) error {
+	return components.Export(ctx, h, out)
+}
+
+// NewHostUpdater creates a new instance of a on-host Updater
+func NewHostUpdater(e *config.CommonEnvironment, host *remoteComp.Host, options ...agentparams.Option) (*HostUpdater, error) {
+	hostInstallComp, err := components.NewComponent(*e, host.Name(), func(comp *HostUpdater) error {
+		comp.namer = e.CommonNamer.WithPrefix(comp.Name())
+		comp.host = host
+
+		params, err := agentparams.NewParams(e, options...)
+		if err != nil {
+			return err
+		}
+
+		err = comp.installUpdater(params, pulumi.Parent(comp))
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}, pulumi.Parent(host), pulumi.DeletedWith(host))
+	if err != nil {
+		return nil, err
+	}
+
+	return hostInstallComp, nil
+}
+
+func (h *HostUpdater) installUpdater(params *agentparams.Params, baseOpts ...pulumi.ResourceOption) error {
+	arch := h.host.OS.Descriptor().Architecture
+	testAPTRepoVersion := fmt.Sprintf(`DD_TEST_APT_REPO_VERSION="%v-u7-%s 7"`, params.Version.PipelineID, arch)
+	installCmdStr := fmt.Sprintf(`export %v && bash -c %s`, testAPTRepoVersion, installScript)
+	_, err := h.host.OS.Runner().Command(
+		h.namer.ResourceName("install-updater"),
+		&command.Args{
+			Create: pulumi.Sprintf(installCmdStr),
+		}, baseOpts...)
+	return err
+}

--- a/components/datadog/updater/install_script.sh
+++ b/components/datadog/updater/install_script.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# (C) Datadog, Inc. 2010-present
+# All rights reserved
+# Licensed under Apache-2.0 License (see LICENSE)
+set -e
+
+
+# Set up a named pipe for logging
+npipe=/tmp/$$.tmp
+mknod $npipe p
+
+# Log all output to a log for error checking
+tee <$npipe $logfile &
+exec 1>&-
+exec 1>$npipe 2>&1
+trap "rm -f $npipe" EXIT
+
+# Root user detection
+if [ "$UID" == "0" ]; then
+    sudo_cmd=""
+else
+    sudo_cmd="sudo"
+fi
+
+agent_major_version=7
+
+apt_url="apttesting.datad0g.com"
+apt_repo_version="${DD_TEST_APT_REPO_VERSION}"
+apt_usr_share_keyring="/usr/share/keyrings/datadog-archive-keyring.gpg"
+apt_trusted_d_keyring="/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg"
+DD_APT_INSTALL_ERROR_MSG=/tmp/ddog_install_error_msg
+MAX_RETRY_NB=10
+keys_url="keys.datadoghq.com"
+
+printf "\033[34m\n* Installing APT package sources for Datadog\n\033[0m\n"
+$sudo_cmd sh -c "echo 'deb [signed-by=${apt_usr_share_keyring}] https://${apt_url}/ ${apt_repo_version}' > /etc/apt/sources.list.d/datadog.list"
+$sudo_cmd sh -c "chmod a+r /etc/apt/sources.list.d/datadog.list"
+
+if [ ! -f $apt_usr_share_keyring ]; then
+    $sudo_cmd touch $apt_usr_share_keyring
+fi
+# ensure that the _apt user used on Ubuntu/Debian systems to read GPG keyrings
+# can read our keyring
+$sudo_cmd chmod a+r $apt_usr_share_keyring
+
+APT_GPG_KEYS=("DATADOG_APT_KEY_CURRENT.public" "DATADOG_APT_KEY_C0962C7D.public" "DATADOG_APT_KEY_F14F620E.public" "DATADOG_APT_KEY_382E94DE.public")
+for key in "${APT_GPG_KEYS[@]}"; do
+    $sudo_cmd curl --retry 5 -o "/tmp/${key}" "https://${keys_url}/${key}"
+    $sudo_cmd cat "/tmp/${key}" | $sudo_cmd gpg --import --batch --no-default-keyring --keyring "$apt_usr_share_keyring"
+done
+
+release_version="$(grep VERSION_ID /etc/os-release | cut -d = -f 2 | xargs echo | cut -d "." -f 1)"
+if { [ "$DISTRIBUTION" == "Debian" ] && [ "$release_version" -lt 9 ]; } || \
+   { [ "$DISTRIBUTION" == "Ubuntu" ] && [ "$release_version" -lt 16 ]; }; then
+    # copy with -a to preserve file permissions
+    $sudo_cmd cp -a $apt_usr_share_keyring $apt_trusted_d_keyring
+fi
+
+for i in $(seq 1 $MAX_RETRY_NB); do
+    printf "\033[34m\n* Installing apt-transport-https, curl and gnupg\n\033[0m\n"
+    $sudo_cmd apt-get update || printf "\033[31m\"apt-get update\" failed, the script will not install the latest version of apt-transport-https.\033[0m\n"
+    apt_exit_code=0
+    if [ -z "$sudo_cmd" ]; then
+        DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl gnupg 2>$DD_APT_INSTALL_ERROR_MSG  || apt_exit_code=$?
+    else
+        $sudo_cmd DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https curl gnupg 2>$DD_APT_INSTALL_ERROR_MSG || apt_exit_code=$?
+    fi
+
+    if grep "Could not get lock" $DD_APT_INSTALL_ERROR_MSG; then
+        RETRY_TIME=$((i*5))
+        printf "\033[31mInstallation failed: Unable to get lock.\nRetrying in ${RETRY_TIME}s ($i/$MAX_RETRY_NB).\033[0m\n"
+        sleep $RETRY_TIME
+    elif [ $apt_exit_code -ne 0 ]; then
+        cat $DD_APT_INSTALL_ERROR_MSG
+        exit $apt_exit_code
+    else
+        break
+    fi
+done
+
+$sudo_cmd apt-get install -y --force-yes "datadog-updater" 2> >(tee /tmp/ddog_install_error_msg >&2)

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -22,6 +22,7 @@ def deploy(
     stack_name: Optional[str] = None,
     pipeline_id: Optional[str] = None,
     install_agent: Optional[bool] = None,
+    install_updater: Optional[bool] = None,
     install_workload: Optional[bool] = None,
     agent_version: Optional[str] = None,
     debug: Optional[bool] = False,
@@ -35,7 +36,8 @@ def deploy(
 
     if install_agent is None:
         install_agent = tool.get_default_agent_install()
-    flags["ddagent:deploy"] = install_agent
+    flags["ddagent:deploy"] = install_agent and not install_updater
+    flags["ddupdater:deploy"] = install_updater
 
     if install_workload is None:
         install_workload = tool.get_default_workload_install()

--- a/tasks/doc.py
+++ b/tasks/doc.py
@@ -1,6 +1,7 @@
 from . import tool
 
 install_agent: str = f"Install the Agent (default {tool.get_default_agent_install()})."
+install_updater: str = "Install the Updater (default False)."
 install_workload: str = f"Install test workload (default {tool.get_default_workload_install()})."
 pipeline_id: str = (
     "The pipeline id of the custom Agent build for example '16497585' (may be taken form the gitlab url)'"

--- a/tasks/vm.py
+++ b/tasks/vm.py
@@ -18,6 +18,7 @@ scenario_name = "aws/vm"
     help={
         "config_path": doc.config_path,
         "install_agent": doc.install_agent,
+        "install_updater": doc.install_updater,
         "pipeline_id": doc.pipeline_id,
         "agent_version": doc.agent_version,
         "stack_name": doc.stack_name,
@@ -38,6 +39,7 @@ def create_vm(
     stack_name: Optional[str] = None,
     pipeline_id: Optional[str] = None,
     install_agent: Optional[bool] = True,
+    install_updater: Optional[bool] = False,
     agent_version: Optional[str] = None,
     debug: Optional[bool] = False,
     os_family: Optional[str] = None,
@@ -80,6 +82,7 @@ def create_vm(
         stack_name=stack_name,
         pipeline_id=pipeline_id,
         install_agent=install_agent,
+        install_updater=install_updater,
         agent_version=agent_version,
         debug=debug,
         extra_flags=extra_flags,


### PR DESCRIPTION
What does this PR do?
---------------------

Add installation of the Updater component.
When we move the updater installation to the s3 agent install script, the light `install_script.sh` and the updater installation will be removed

Requirement
- merge https://github.com/DataDog/datadog-agent/pull/21681

Follow ups
- updater package e2e tests
- when the new agent is available, add agent config + use injected api key


Which scenarios this will impact?
-------------------
This will be used in future scenarios on the impact. Confirmed that it's working by running the following commands on a [pipeline where the updater is packaged](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/406498780)

```
test-infra-definitions $ invoke create-vm -i -o=ubuntu --install-updater --pipeline-id=26350333 --architecture=arm64
$ ssh ubuntu@(instance_ip)

$ ls /lib/systemd/system | grep datadog
datadog-agent-exp.service
datadog-agent-process-exp.service
datadog-agent-process.service
datadog-agent-security-exp.service
datadog-agent-security.service
datadog-agent-sysprobe-exp.service
datadog-agent-sysprobe.service
datadog-agent-trace-exp.service
datadog-agent-trace.service
datadog-agent.service
datadog-updater.service

$ /opt/datadog/updater/bin/updater/updater run
updater running
```
Motivation
----------

Additional Notes
----------------
