### PR TITLE
Dual-ship `contimage`, `contlcycle` and `sbom` payloads to the fakeintake

### DIFF
--- a/components/datadog/agent/helm.go
+++ b/components/datadog/agent/helm.go
@@ -197,6 +197,34 @@ func buildLinuxHelmValues(installName, agentImagePath, agentImageTag, clusterAge
 			"prometheusScrape": pulumi.Map{
 				"enabled": pulumi.Bool(true),
 			},
+			"sbom": pulumi.Map{
+				"containerImage": pulumi.Map{
+					"enabled": pulumi.Bool(true),
+				},
+			},
+			// The fake intake keeps payloads only for a hardcoded period of 15 minutes.
+			// https://github.com/DataDog/datadog-agent/blob/34922393ce47261da9835d7bf62fb5e090e5fa55/test/fakeintake/server/server.go#L81
+			// So, we need `container_image` and `sbom` checks to resubmit their payloads more frequently than that.
+			"confd": pulumi.Map{
+				"container_image.yaml": pulumi.String(utils.JSONMustMarshal(map[string]interface{}{
+					"ad_identifiers": []string{"_container_image"},
+					"init_config":    map[string]interface{}{},
+					"instances": []map[string]interface{}{
+						{
+							"periodic_refresh_seconds": 600,
+						},
+					},
+				})),
+				"sbom.yaml": pulumi.String(utils.JSONMustMarshal(map[string]interface{}{
+					"ad_identifiers": []string{"_sbom"},
+					"init_config":    map[string]interface{}{},
+					"instances": []map[string]interface{}{
+						{
+							"periodic_refresh_seconds": 600,
+						},
+					},
+				})),
+			},
 		},
 		"agents": pulumi.Map{
 			"image": pulumi.Map{
@@ -323,6 +351,18 @@ func (values HelmValues) configureFakeintake(fakeintake *ddfakeintake.Connection
 		pulumi.Map{
 			"name":  pulumi.String("DD_LOGS_CONFIG_USE_HTTP"),
 			"value": pulumi.String("true"),
+		},
+		pulumi.Map{
+			"name":  pulumi.String("DD_CONTAINER_IMAGE_ADDITIONAL_ENDPOINTS"),
+			"value": pulumi.Sprintf(`[{"host": "%s"}]`, fakeintake.Host),
+		},
+		pulumi.Map{
+			"name":  pulumi.String("DD_CONTAINER_LIFECYCLE_ADDITIONAL_ENDPOINTS"),
+			"value": pulumi.Sprintf(`[{"host": "%s"}]`, fakeintake.Host),
+		},
+		pulumi.Map{
+			"name":  pulumi.String("DD_SBOM_ADDITIONAL_ENDPOINTS"),
+			"value": pulumi.Sprintf(`[{"host": "%s"}]`, fakeintake.Host),
 		},
 	}
 


### PR DESCRIPTION
What does this PR do?
---------------------

Configure the agent on Kubernetes to dual-ship `container image`, `container lifecycle events` and `SBOM` payloads to the fake intake.

Which scenarios this will impact?
-------------------

* `aws/eks`
* `aws/kind`

Motivation
----------

Allow to write e2e tests for the
* `containerimage`
* `contlcycle`
* `sbom`
checks.

Additional Notes
----------------

The fakeintake client has been updated to support those new payloads in DataDog/datadog-agent#21742.