### PR TITLE
Use HTTP for process and orchestrator additional endpoints

### DIFF
--- a/components/datadog/agent/helm.go
+++ b/components/datadog/agent/helm.go
@@ -310,11 +310,11 @@ func (values HelmValues) configureFakeintake(fakeintake *ddfakeintake.Connection
 		},
 		pulumi.Map{
 			"name":  pulumi.String("DD_PROCESS_ADDITIONAL_ENDPOINTS"),
-			"value": pulumi.Sprintf(`{"https://%s": ["FAKEAPIKEY"]}`, fakeintake.Host),
+			"value": pulumi.Sprintf(`{"http://%s": ["FAKEAPIKEY"]}`, fakeintake.Host),
 		},
 		pulumi.Map{
 			"name":  pulumi.String("DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_ADDITIONAL_ENDPOINTS"),
-			"value": pulumi.Sprintf(`{"https://%s": ["FAKEAPIKEY"]}`, fakeintake.Host),
+			"value": pulumi.Sprintf(`{"http://%s": ["FAKEAPIKEY"]}`, fakeintake.Host),
 		},
 		pulumi.Map{
 			"name":  pulumi.String("DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS"),


### PR DESCRIPTION
What does this PR do?
---------------------
Use HTTP instead of HTTPS for process and orchestrator additional endpoints. This is necessary because the fake intake only listens on port 80, and does not accept TLS payloads.

Which scenarios this will impact?
-------------------
EKS, Kind VM

Motivation
----------
Fix fake intake for process and orchestrator payloads

Additional Notes
----------------
Additional endpoints originally added in https://github.com/DataDog/test-infra-definitions/pull/531.
Tests that use this functionality added in https://github.com/DataDog/datadog-agent/pull/21802