### PR TITLE
[CONTINT-3593] Support creating kata-enabled AKS cluster

### DIFF
--- a/resources/azure/aks/cluster.go
+++ b/resources/azure/aks/cluster.go
@@ -16,6 +16,10 @@ const (
 	adminUsername = "azureuser"
 
 	kataNodePoolName = "kata"
+
+	// Kata runtime constants
+	kataSku     = "AzureLinux"
+	kataRuntime = "KataMshvVmIsolation"
 )
 
 func NewCluster(e azure.Environment, name string, nodePool containerservice.ManagedClusterAgentPoolProfileArray, opts ...pulumi.ResourceOption) (*containerservice.ManagedCluster, pulumi.StringOutput, error) {
@@ -102,11 +106,11 @@ func kataNodePool(e azure.Environment) containerservice.ManagedClusterAgentPoolP
 		Environment:     e,
 		Name:            kataNodePoolName,
 		Mode:            string(containerservice.AgentPoolModeSystem),
-		InstanceType:    e.DefaultInstanceType(),
+		InstanceType:    e.KataInstanceType(),
 		OSType:          string(containerservice.OSTypeLinux),
 		NodeCount:       2,
-		WorkloadRuntime: e.KataRuntime(),
-		OsSku:           e.KataOsSku(),
+		WorkloadRuntime: kataRuntime,
+		OsSku:           kataSku,
 	})
 }
 

--- a/resources/azure/aks/cluster.go
+++ b/resources/azure/aks/cluster.go
@@ -31,7 +31,7 @@ func NewCluster(e azure.Environment, name string, nodePool containerservice.Mana
 	// Warning: we're modifying passed array as it should normally never be used anywhere else
 	nodePool = append(nodePool, systemNodePool(e, "system"))
 
-	if e.DeployKata() {
+	if e.LinuxKataNodeGroup() {
 		nodePool = append(nodePool, kataNodePool(e))
 	}
 
@@ -106,7 +106,7 @@ func kataNodePool(e azure.Environment) containerservice.ManagedClusterAgentPoolP
 		Environment:     e,
 		Name:            kataNodePoolName,
 		Mode:            string(containerservice.AgentPoolModeSystem),
-		InstanceType:    e.KataInstanceType(),
+		InstanceType:    e.DefaultInstanceType(),
 		OSType:          string(containerservice.OSTypeLinux),
 		NodeCount:       2,
 		WorkloadRuntime: kataRuntime,

--- a/resources/azure/environment.go
+++ b/resources/azure/environment.go
@@ -22,8 +22,7 @@ const (
 	DDInfraDefaultPublicKeyPath            = "az/defaultPublicKeyPath"
 	DDInfraDefaultPrivateKeyPath           = "az/defaultPrivateKeyPath"
 	DDInfraDefaultPrivateKeyPassword       = "az/defaultPrivateKeyPassword"
-	DDInfraAksDeployKata                   = "az/aks/deployKata"
-	DDInfraAksLinuxKataInstanceType        = "az/aks/linuxKataInstanceType"
+	DDInfraAksLinuxKataNodeGroup           = "az/aks/linuxKataNodeGroup"
 )
 
 type Environment struct {
@@ -100,12 +99,7 @@ func (e *Environment) GetCommonEnvironment() *config.CommonEnvironment {
 	return e.CommonEnvironment
 }
 
-// DeployKata Whether to deploy a kata node pool
-func (e *Environment) DeployKata() bool {
-	return e.GetBoolWithDefault(e.InfraConfig, DDInfraAksDeployKata, e.envDefault.ddInfra.aks.defaultDeployKata)
-}
-
-// KataInstanceType returns the instance type that should be used for kata nodes
-func (e *Environment) KataInstanceType() string {
-	return e.GetStringWithDefault(e.InfraConfig, DDInfraAksLinuxKataInstanceType, e.envDefault.ddInfra.aks.defaultKataInstanceType)
+// LinuxKataNodeGroup Whether to deploy a kata node pool
+func (e *Environment) LinuxKataNodeGroup() bool {
+	return e.GetBoolWithDefault(e.InfraConfig, DDInfraAksLinuxKataNodeGroup, e.envDefault.ddInfra.aks.linuxKataNodeGroup)
 }

--- a/resources/azure/environment.go
+++ b/resources/azure/environment.go
@@ -22,9 +22,8 @@ const (
 	DDInfraDefaultPublicKeyPath            = "az/defaultPublicKeyPath"
 	DDInfraDefaultPrivateKeyPath           = "az/defaultPrivateKeyPath"
 	DDInfraDefaultPrivateKeyPassword       = "az/defaultPrivateKeyPassword"
-	DDInfraDefaultDeployKata               = "az/defaultDeployKata"
-	DDInfraDefaultKataRuntime              = "az/defaultKataRuntime"
-	DDInfraDefaultKataOsSku                = "az/defaultKataOsSku"
+	DDInfraAksDeployKata                   = "az/aks/deployKata"
+	DDInfraAksLinuxKataInstanceType        = "az/aks/linuxKataInstanceType"
 )
 
 type Environment struct {
@@ -103,15 +102,10 @@ func (e *Environment) GetCommonEnvironment() *config.CommonEnvironment {
 
 // DeployKata Whether to deploy a kata node pool
 func (e *Environment) DeployKata() bool {
-	return e.GetBoolWithDefault(e.InfraConfig, DDInfraDefaultDeployKata, e.envDefault.ddInfra.defaultDeployKata)
+	return e.GetBoolWithDefault(e.InfraConfig, DDInfraAksDeployKata, e.envDefault.ddInfra.aks.defaultDeployKata)
 }
 
-// KataRuntime returns the kata runtime that should be used
-func (e *Environment) KataRuntime() string {
-	return e.GetStringWithDefault(e.InfraConfig, DDInfraDefaultKataRuntime, e.envDefault.ddInfra.defaultKataRuntime)
-}
-
-// KataOsSku The os-sku of the kata node pool.
-func (e *Environment) KataOsSku() string {
-	return e.GetStringWithDefault(e.InfraConfig, DDInfraDefaultKataOsSku, e.envDefault.ddInfra.defaultKataOsSku)
+// KataInstanceType returns the instance type that should be used for kata nodes
+func (e *Environment) KataInstanceType() string {
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraAksLinuxKataInstanceType, e.envDefault.ddInfra.aks.defaultKataInstanceType)
 }

--- a/resources/azure/environment.go
+++ b/resources/azure/environment.go
@@ -22,6 +22,9 @@ const (
 	DDInfraDefaultPublicKeyPath            = "az/defaultPublicKeyPath"
 	DDInfraDefaultPrivateKeyPath           = "az/defaultPrivateKeyPath"
 	DDInfraDefaultPrivateKeyPassword       = "az/defaultPrivateKeyPassword"
+	DDInfraDefaultDeployKata               = "az/defaultDeployKata"
+	DDInfraDefaultKataRuntime              = "az/defaultKataRuntime"
+	DDInfraDefaultKataOsSku                = "az/defaultKataOsSku"
 )
 
 type Environment struct {
@@ -96,4 +99,19 @@ func (e *Environment) DefaultPrivateKeyPassword() string {
 
 func (e *Environment) GetCommonEnvironment() *config.CommonEnvironment {
 	return e.CommonEnvironment
+}
+
+// DeployKata Whether to deploy a kata node pool
+func (e *Environment) DeployKata() bool {
+	return e.GetBoolWithDefault(e.InfraConfig, DDInfraDefaultDeployKata, e.envDefault.ddInfra.defaultDeployKata)
+}
+
+// KataRuntime returns the kata runtime that should be used
+func (e *Environment) KataRuntime() string {
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraDefaultKataRuntime, e.envDefault.ddInfra.defaultKataRuntime)
+}
+
+// KataOsSku The os-sku of the kata node pool.
+func (e *Environment) KataOsSku() string {
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraDefaultKataOsSku, e.envDefault.ddInfra.defaultKataOsSku)
 }

--- a/resources/azure/environmentDefaults.go
+++ b/resources/azure/environmentDefaults.go
@@ -25,8 +25,7 @@ type ddInfra struct {
 }
 
 type ddInfraAks struct {
-	defaultDeployKata       bool
-	defaultKataInstanceType string
+	linuxKataNodeGroup bool
 }
 
 func getEnvironmentDefault(envName string) environmentDefault {
@@ -49,11 +48,10 @@ func sandboxDefault() environmentDefault {
 			defaultVNet:            "/subscriptions/8c56d827-5f07-45ce-8f2b-6c5001db5c6f/resourceGroups/datadog-agent-testing/providers/Microsoft.Network/virtualNetworks/default-vnet",
 			defaultSubnet:          "/subscriptions/8c56d827-5f07-45ce-8f2b-6c5001db5c6f/resourceGroups/datadog-agent-testing/providers/Microsoft.Network/virtualNetworks/default-vnet/subnets/default-subnet",
 			defaultSecurityGroup:   "/subscriptions/8c56d827-5f07-45ce-8f2b-6c5001db5c6f/resourceGroups/datadog-agent-testing/providers/Microsoft.Network/networkSecurityGroups/default",
-			defaultInstanceType:    "Standard_D4ps_v5",
+			defaultInstanceType:    "Standard_D4s_v5",  // Allows nested virtualization for kata runtimes
 			defaultARMInstanceType: "Standard_D4ps_v5", // No azure arm instance supports nested virtualization
 			aks: ddInfraAks{
-				defaultKataInstanceType: "Standard_D4s_v3", // Allows nested virtualization for kata runtimes
-				defaultDeployKata:       true,
+				linuxKataNodeGroup: true,
 			},
 		},
 	}

--- a/resources/azure/environmentDefaults.go
+++ b/resources/azure/environmentDefaults.go
@@ -21,9 +21,12 @@ type ddInfra struct {
 	defaultSecurityGroup   string
 	defaultInstanceType    string
 	defaultARMInstanceType string
-	defaultDeployKata      bool
-	defaultKataRuntime     string
-	defaultKataOsSku       string
+	aks                    ddInfraAks
+}
+
+type ddInfraAks struct {
+	defaultDeployKata       bool
+	defaultKataInstanceType string
 }
 
 func getEnvironmentDefault(envName string) environmentDefault {
@@ -46,11 +49,12 @@ func sandboxDefault() environmentDefault {
 			defaultVNet:            "/subscriptions/8c56d827-5f07-45ce-8f2b-6c5001db5c6f/resourceGroups/datadog-agent-testing/providers/Microsoft.Network/virtualNetworks/default-vnet",
 			defaultSubnet:          "/subscriptions/8c56d827-5f07-45ce-8f2b-6c5001db5c6f/resourceGroups/datadog-agent-testing/providers/Microsoft.Network/virtualNetworks/default-vnet/subnets/default-subnet",
 			defaultSecurityGroup:   "/subscriptions/8c56d827-5f07-45ce-8f2b-6c5001db5c6f/resourceGroups/datadog-agent-testing/providers/Microsoft.Network/networkSecurityGroups/default",
-			defaultInstanceType:    "Standard_D4s_v3",  // Allows nested virtualization for kata runtimes
+			defaultInstanceType:    "Standard_D4ps_v5",
 			defaultARMInstanceType: "Standard_D4ps_v5", // No azure arm instance supports nested virtualization
-			defaultKataOsSku:       "Mariner",
-			defaultDeployKata:      true,
-			defaultKataRuntime:     "KataMshvVmIsolation", // Azure also supports KataCcIsolation
+			aks: ddInfraAks{
+				defaultKataInstanceType: "Standard_D4s_v3", // Allows nested virtualization for kata runtimes
+				defaultDeployKata:       true,
+			},
 		},
 	}
 }

--- a/resources/azure/environmentDefaults.go
+++ b/resources/azure/environmentDefaults.go
@@ -21,6 +21,9 @@ type ddInfra struct {
 	defaultSecurityGroup   string
 	defaultInstanceType    string
 	defaultARMInstanceType string
+	defaultDeployKata      bool
+	defaultKataRuntime     string
+	defaultKataOsSku       string
 }
 
 func getEnvironmentDefault(envName string) environmentDefault {
@@ -43,8 +46,11 @@ func sandboxDefault() environmentDefault {
 			defaultVNet:            "/subscriptions/8c56d827-5f07-45ce-8f2b-6c5001db5c6f/resourceGroups/datadog-agent-testing/providers/Microsoft.Network/virtualNetworks/default-vnet",
 			defaultSubnet:          "/subscriptions/8c56d827-5f07-45ce-8f2b-6c5001db5c6f/resourceGroups/datadog-agent-testing/providers/Microsoft.Network/virtualNetworks/default-vnet/subnets/default-subnet",
 			defaultSecurityGroup:   "/subscriptions/8c56d827-5f07-45ce-8f2b-6c5001db5c6f/resourceGroups/datadog-agent-testing/providers/Microsoft.Network/networkSecurityGroups/default",
-			defaultInstanceType:    "Standard_B4ms",
-			defaultARMInstanceType: "Standard_D4ps_v5",
+			defaultInstanceType:    "Standard_D4s_v3",  // Allows nested virtualization for kata runtimes
+			defaultARMInstanceType: "Standard_D4ps_v5", // No azure arm instance supports nested virtualization
+			defaultKataOsSku:       "Mariner",
+			defaultDeployKata:      true,
+			defaultKataRuntime:     "KataMshvVmIsolation", // Azure also supports KataCcIsolation
 		},
 	}
 }


### PR DESCRIPTION
What does this PR do?
---------------------
This PR adds support of kata-enabled AKS clusters. It creates a new nodepool for kata runtimes.

Which scenarios this will impact?
-------------------
az/aks

Motivation
----------
We would like to add e2e tests for kata enabled runtime

Additional Notes
----------------
