### PR TITLE
feat(logging): fakeintake is an agent option in VM scenario. 

### DIFF
--- a/tasks/vm.py
+++ b/tasks/vm.py
@@ -60,6 +60,11 @@ def create_vm(
     if ami_id is not None:
         extra_flags["ddinfra:osAmiId"] = ami_id
 
+    if use_fakeintake and not install_agent:
+        print(
+            "[WARNING] It is currently not possible to deploy a VM with fakeintake and without agent. Your VM will start without fakeintake."
+        )
+
     full_stack_name = deploy(
         ctx,
         scenario_name,


### PR DESCRIPTION
As a consequence, --no-install-agent and --use-fakeintake are currently incompatible

What does this PR do?
---------------------
Add a warning when using incompatible options

Which scenarios this will impact?
-------------------
VM

Motivation
----------
Sanity

Additional Notes
----------------
