### PR TITLE
[CONTINT-3600] Support k8s versions 1.28 and 1.29 in kind

### DIFF
--- a/components/kubernetes/kind_versions.go
+++ b/components/kubernetes/kind_versions.go
@@ -16,7 +16,7 @@ type kindConfig struct {
 var kubeToKindVersion = map[string]kindConfig{
 	"1.29": {
 		kindVersion:      "v0.20.0",
-		nodeImageVersion: "v1.29.0",
+		nodeImageVersion: "v1.29.0@sha256:eaa1450915475849a73a9227b8f201df25e55e268e5d619312131292e324d570",
 	},
 	"1.28": {
 		kindVersion:      "v0.20.0",

--- a/components/kubernetes/kind_versions.go
+++ b/components/kubernetes/kind_versions.go
@@ -14,6 +14,14 @@ type kindConfig struct {
 
 // Source: https://github.com/kubernetes-sigs/kind/releases
 var kubeToKindVersion = map[string]kindConfig{
+	"1.29": {
+		kindVersion:      "v0.20.0",
+		nodeImageVersion: "v1.29.0",
+	},
+	"1.28": {
+		kindVersion:      "v0.20.0",
+		nodeImageVersion: "v1.28.0",
+	},
 	"1.27": {
 		kindVersion:      "v0.20.0",
 		nodeImageVersion: "v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72",

--- a/components/kubernetes/kind_versions.go
+++ b/components/kubernetes/kind_versions.go
@@ -20,7 +20,7 @@ var kubeToKindVersion = map[string]kindConfig{
 	},
 	"1.28": {
 		kindVersion:      "v0.20.0",
-		nodeImageVersion: "v1.28.0",
+		nodeImageVersion: "v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31",
 	},
 	"1.27": {
 		kindVersion:      "v0.20.0",


### PR DESCRIPTION
What does this PR do?
---------------------

Support newer kubernetes versions (1.28 and 1.29) when creating kind clusters.

Which scenarios this will impact?
-------------------
kindvm

Motivation
----------
Being able to run E2E on newer k8s versions.

Testing
----------
The cluster is created correctly when tested with E2E:
```
@ updating.....
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (1s) Creating cluster "kind" ...
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (1s)  • Ensuring node image (kindest/node:v1.29.0) 🖼  ...
@ updating....................
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (18s)  ✓ Ensuring node image (kindest/node:v1.29.0) 🖼
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (18s)  • Preparing nodes 📦   ...
@ updating..............
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (29s)  ✓ Preparing nodes 📦 
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (29s)  • Writing configuration 📜  ...
@ updating....
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (30s)  ✓ Writing configuration 📜
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (30s)  • Starting control-plane 🕹️  ...
@ updating.......................
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (50s)  ✓ Starting control-plane 🕹️
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (50s)  • Installing CNI 🔌  ...
@ updating....
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (51s)  ✓ Installing CNI 🔌
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (51s)  • Installing StorageClass 💾  ...
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (52s)  ✓ Installing StorageClass 💾
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (52s)  • Waiting ≤ 1m0s for control-plane = Ready ⏳  ...
@ updating......................
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (70s)  ✓ Waiting ≤ 1m0s for control-plane = Ready ⏳
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (70s)  • Ready after 18s 💚
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (70s) Set kubectl context to "kind-kind"
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (70s) You can now use your cluster with:
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (70s) 
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (70s) kubectl cluster-info --context kind-kind
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (70s) 
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind creating (70s) Have a nice day! 👋
 +  command:remote:Command remote-vm-connection-cmd-kind-create-cluster-kind created (70s) Have a nice day! 👋
 +  command:remote:Command remote-vm-connection-cmd-kind-kubeconfig-kind creating (0s) 
```

Test report:

```
--- FAIL: TestKindSuite (0.00s)
    --- FAIL: TestKindSuite/TestKind_1.29 (1023.52s)
        --- PASS: TestKindSuite/TestKind_1.29/Test00UpAndRunning (11.18s)
            --- PASS: TestKindSuite/TestKind_1.29/Test00UpAndRunning/agent_pods_are_ready_and_not_restarting (11.18s)
        --- PASS: TestKindSuite/TestKind_1.29/TestCPU (44.04s)
            --- PASS: TestKindSuite/TestKind_1.29/TestCPU/metric___container.cpu.usage{kube_deployment:stress-ng,kube_namespace:workload-cpustress} (11.67s)
            --- PASS: TestKindSuite/TestKind_1.29/TestCPU/metric___container.cpu.limit{kube_deployment:stress-ng,kube_namespace:workload-cpustress} (10.69s)
            --- PASS: TestKindSuite/TestKind_1.29/TestCPU/metric___kubernetes.cpu.usage.total{kube_deployment:stress-ng,kube_namespace:workload-cpustress} (10.89s)
            --- PASS: TestKindSuite/TestKind_1.29/TestCPU/metric___kubernetes.cpu.limits{kube_deployment:stress-ng,kube_namespace:workload-cpustress} (10.80s)
        --- PASS: TestKindSuite/TestKind_1.29/TestControlPlane (32.95s)
            --- PASS: TestKindSuite/TestKind_1.29/TestControlPlane/metric___kube_apiserver.apiserver_request_total{} (10.90s)
            --- PASS: TestKindSuite/TestKind_1.29/TestControlPlane/metric___kube_controller_manager.queue.adds{} (11.03s)
            --- PASS: TestKindSuite/TestKind_1.29/TestControlPlane/metric___kube_scheduler.schedule_attempts{} (11.02s)
        --- PASS: TestKindSuite/TestKind_1.29/TestDogstatsdInAgent (22.63s)
            --- PASS: TestKindSuite/TestKind_1.29/TestDogstatsdInAgent/metric___custom.metric{kube_deployment:dogstatsd-uds,kube_namespace:workload-dogstatsd} (11.21s)
            --- PASS: TestKindSuite/TestKind_1.29/TestDogstatsdInAgent/metric___custom.metric{kube_deployment:dogstatsd-udp,kube_namespace:workload-dogstatsd} (11.42s)
        --- PASS: TestKindSuite/TestKind_1.29/TestDogstatsdStandalone (23.23s)
            --- PASS: TestKindSuite/TestKind_1.29/TestDogstatsdStandalone/metric___custom.metric{kube_deployment:dogstatsd-uds,kube_namespace:workload-dogstatsd-standalone} (11.83s)
            --- PASS: TestKindSuite/TestKind_1.29/TestDogstatsdStandalone/metric___custom.metric{kube_deployment:dogstatsd-udp,kube_namespace:workload-dogstatsd-standalone} (11.40s)
        --- PASS: TestKindSuite/TestKind_1.29/TestNginx (499.77s)
            --- PASS: TestKindSuite/TestKind_1.29/TestNginx/metric___nginx.net.request_per_s{} (11.45s)
            --- PASS: TestKindSuite/TestKind_1.29/TestNginx/metric___network.http.response_time{} (11.45s)
            --- PASS: TestKindSuite/TestKind_1.29/TestNginx/metric___kubernetes_state.deployment.replicas_available{kube_deployment:nginx,kube_namespace:workload-nginx} (11.49s)
            --- PASS: TestKindSuite/TestKind_1.29/TestNginx/log___apps-nginx-server{} (10.58s)
            --- PASS: TestKindSuite/TestKind_1.29/TestNginx/hpa___kubernetes_state.deployment.replicas_available{kube_namespace:workload-nginx,kube_deployment:nginx} (454.80s)
        --- PASS: TestKindSuite/TestKind_1.29/TestPrometheus (14.73s)
            --- PASS: TestKindSuite/TestKind_1.29/TestPrometheus/metric___prom_gauge{kube_deployment:prometheus,kube_namespace:workload-prometheus} (14.73s)
        --- PASS: TestKindSuite/TestKind_1.29/TestRedis (57.57s)
            --- PASS: TestKindSuite/TestKind_1.29/TestRedis/metric___redis.net.instantaneous_ops_per_sec{} (15.47s)
            --- PASS: TestKindSuite/TestKind_1.29/TestRedis/metric___kubernetes_state.deployment.replicas_available{kube_deployment:redis,kube_namespace:workload-redis} (15.28s)
            --- PASS: TestKindSuite/TestKind_1.29/TestRedis/log___redis{} (11.53s)
            --- PASS: TestKindSuite/TestKind_1.29/TestRedis/hpa___kubernetes_state.deployment.replicas_available{kube_namespace:workload-redis,kube_deployment:redis} (15.28s)
        --- FAIL: TestKindSuite/TestKind_1.29/TestVersion (4.09s)
            --- FAIL: TestKindSuite/TestKind_1.29/TestVersion/Linux_agent_pods_are_running_the_good_version (1.66s)
            --- PASS: TestKindSuite/TestKind_1.29/TestVersion/Windows_agent_pods_are_running_the_good_version (0.10s)
            --- FAIL: TestKindSuite/TestKind_1.29/TestVersion/cluster_agent_pods_are_running_the_good_version (1.25s)
            --- FAIL: TestKindSuite/TestKind_1.29/TestVersion/cluster_checks_pods_are_running_the_good_version (1.07s)
        --- PASS: TestKindSuite/TestKind_1.29/TestZZUpAndRunning (10.75s)
            --- PASS: TestKindSuite/TestKind_1.29/TestZZUpAndRunning/agent_pods_are_ready_and_not_restarting (10.75s)

```

