### PR TITLE
Provision local microvms

### DIFF
--- a/scenarios/aws/microVMs/microvms/domain.go
+++ b/scenarios/aws/microVMs/microvms/domain.go
@@ -188,17 +188,6 @@ func GenerateDomainConfigurationsForVMSet(e *config.CommonEnvironment, providerF
 				lastDisk := getVolumeDiskTarget(true, "")
 				for _, vol := range libvirtVolumes {
 					lastDisk = getVolumeDiskTarget(vol.Mountpoint() == RootMountpoint, lastDisk)
-					if vol.Pool().Type() != resources.DefaultPool {
-						domain.Disks = append(domain.Disks, resources.DomainDisk{
-							VolumeID:   pulumi.String(vol.Key()),
-							Attach:     resources.AttachAsFile,
-							Target:     lastDisk,
-							Mountpoint: vol.Mountpoint(),
-						})
-
-						// For disks to be attached as Files, we do not create an overlay
-						continue
-					}
 					rootVolume, err := setupDomainVolume(
 						e.Ctx,
 						providerFn,
@@ -212,7 +201,6 @@ func GenerateDomainConfigurationsForVMSet(e *config.CommonEnvironment, providerF
 					}
 					domain.Disks = append(domain.Disks, resources.DomainDisk{
 						VolumeID:   pulumi.StringPtrInput(rootVolume.ID()),
-						Attach:     resources.AttachAsVolume,
 						Target:     lastDisk,
 						Mountpoint: vol.Mountpoint(),
 					})

--- a/scenarios/aws/microVMs/microvms/resources/amd64.go
+++ b/scenarios/aws/microVMs/microvms/resources/amd64.go
@@ -47,17 +47,9 @@ func (a *AMD64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomain
 		return args.Disks[i].Target < args.Disks[j].Target
 	})
 	for _, disk := range args.Disks {
-		switch disk.Attach {
-		case AttachAsFile:
-			disks = append(disks, libvirt.DomainDiskArgs{
-				File: disk.VolumeID,
-			})
-		case AttachAsVolume:
-			disks = append(disks, libvirt.DomainDiskArgs{
-				VolumeId: disk.VolumeID,
-			})
-		default:
-		}
+		disks = append(disks, libvirt.DomainDiskArgs{
+			VolumeId: disk.VolumeID,
+		})
 	}
 
 	console, err := setupConsole(args.ConsoleType, args.DomainName)

--- a/scenarios/aws/microVMs/microvms/resources/arm64.go
+++ b/scenarios/aws/microVMs/microvms/resources/arm64.go
@@ -48,17 +48,9 @@ func (a *ARM64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirtDomain
 		return args.Disks[i].Target < args.Disks[j].Target
 	})
 	for _, disk := range args.Disks {
-		switch disk.Attach {
-		case AttachAsFile:
-			disks = append(disks, libvirt.DomainDiskArgs{
-				File: disk.VolumeID,
-			})
-		case AttachAsVolume:
-			disks = append(disks, libvirt.DomainDiskArgs{
-				VolumeId: disk.VolumeID,
-			})
-		default:
-		}
+		disks = append(disks, libvirt.DomainDiskArgs{
+			VolumeId: disk.VolumeID,
+		})
 	}
 
 	console, err := setupConsole(args.ConsoleType, args.DomainName)

--- a/scenarios/aws/microVMs/microvms/resources/distro.go
+++ b/scenarios/aws/microVMs/microvms/resources/distro.go
@@ -44,17 +44,9 @@ func (a *DistroAMD64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirt
 		return args.Disks[i].Target < args.Disks[j].Target
 	})
 	for _, disk := range args.Disks {
-		switch disk.Attach {
-		case AttachAsFile:
-			disks = append(disks, libvirt.DomainDiskArgs{
-				File: disk.VolumeID,
-			})
-		case AttachAsVolume:
-			disks = append(disks, libvirt.DomainDiskArgs{
-				VolumeId: disk.VolumeID,
-			})
-		default:
-		}
+		disks = append(disks, libvirt.DomainDiskArgs{
+			VolumeId: disk.VolumeID,
+		})
 	}
 
 	console, err := setupConsole(args.ConsoleType, args.DomainName)
@@ -111,17 +103,9 @@ func (a *DistroARM64ResourceCollection) GetLibvirtDomainArgs(args *RecipeLibvirt
 		return args.Disks[i].Target < args.Disks[j].Target
 	})
 	for _, disk := range args.Disks {
-		switch disk.Attach {
-		case AttachAsFile:
-			disks = append(disks, libvirt.DomainDiskArgs{
-				File: disk.VolumeID,
-			})
-		case AttachAsVolume:
-			disks = append(disks, libvirt.DomainDiskArgs{
-				VolumeId: disk.VolumeID,
-			})
-		default:
-		}
+		disks = append(disks, libvirt.DomainDiskArgs{
+			VolumeId: disk.VolumeID,
+		})
 	}
 
 	console, err := setupConsole(args.ConsoleType, args.DomainName)

--- a/scenarios/aws/microVMs/microvms/resources/resources.go
+++ b/scenarios/aws/microVMs/microvms/resources/resources.go
@@ -65,18 +65,10 @@ type ResourceCollection interface {
 	GetLibvirtDomainArgs(*RecipeLibvirtDomainArgs) (*libvirt.DomainArgs, error)
 }
 
-type AttachMethod int
-
-const (
-	AttachAsFile AttachMethod = iota
-	AttachAsVolume
-)
-
 type DiskTarget string
 
 type DomainDisk struct {
 	VolumeID   pulumi.StringPtrInput
-	Attach     AttachMethod
 	Target     string
 	Mountpoint string
 }

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -323,68 +323,14 @@ func run(e commonConfig.CommonEnvironment) (*ScenarioDone, error) {
 		}
 	}
 
-	// provision microVMs
-	for _, collection := range vmCollections {
-		if collection.instance.Arch == LocalVMSet {
-			continue
-		}
-
-		sshConfigDone, err := setupMicroVMSSHConfig(collection.instance, microVMGroupSubnet, waitFor)
-		if err != nil {
-			return nil, err
-		}
-
-		microVMSSHKey, readKeyDone, err := readMicroVMSSHKey(collection.instance, sshConfigDone)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, domain := range collection.domains {
-			if domain.lvDomain == nil {
-				continue
-			}
-
-			// create new ssh connection to build proxy
-			conn, err := remoteComp.NewConnection(collection.instance.instance.Address, "ubuntu", instanceEnv.DefaultPrivateKeyPath(), instanceEnv.DefaultPrivateKeyPassword(), "")
-			if err != nil {
-				return nil, err
-			}
-
-			pc := createProxyConnection(pulumi.String(domain.ip), "root", microVMSSHKey, conn.ToConnectionOutput())
-			remoteRunner, err := command.NewRunner(
-				*collection.instance.e.CommonEnvironment,
-				command.RunnerArgs{
-					ParentResource: domain.lvDomain,
-					Connection:     pc,
-					ConnectionName: collection.instance.instanceNamer.ResourceName("conn", domain.ip),
-					OSCommand:      command.NewUnixOSCommand(),
-				},
-			)
-			if err != nil {
-				return nil, err
-			}
-			microRunner := NewRunner(WithRemoteRunner(remoteRunner))
-
-			allowEnvDone, err := setupSSHAllowEnv(microRunner, append(readKeyDone, domain.lvDomain))
-			if err != nil {
-				return nil, err
-			}
-			mountDisksDone, err := mountMicroVMDisks(microRunner, domain.Disks, domain.domainNamer, []pulumi.Resource{domain.lvDomain})
-			if err != nil {
-				return nil, err
-			}
-
-			setDockerDataRootDone, err := setDockerDataRoot(microRunner, domain.Disks, domain.domainNamer, mountDisksDone)
-			if err != nil {
-				return nil, err
-			}
-
-			_, err = reloadSSHD(microRunner, append(allowEnvDone, setDockerDataRootDone...))
-			if err != nil {
-				return nil, err
-			}
-		}
+	if _, err := provisionRemoteMicroVMs(vmCollections, instanceEnv); err != nil {
+		return nil, err
 	}
+
+	if _, err := provisionLocalMicroVMs(vmCollections); err != nil {
+		return nil, err
+	}
+
 	return &scenarioReady, nil
 }
 


### PR DESCRIPTION
What does this PR do?
---------------------
This PR
- adds support to provision local microvms. This allows us to attach docker disks for VMs launched locally as well.
- attaches all disks as volumes with two layers of overlays: base -> overlay-1 -> overlay-2. This is different behavior from before where disks other than the root filesystem were attached as files, with a single overlay. Overlay-1 is a libvirt volume backed by the base file. Overlay-2 is a unique writable volume shared with each microvm.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
https://datadoghq.atlassian.net/browse/EBPF-372
