### PR TITLE
Emit structured stack output for KMT

### DIFF
--- a/scenarios/aws/microVMs/microvms/domain.go
+++ b/scenarios/aws/microVMs/microvms/domain.go
@@ -38,7 +38,7 @@ type Domain struct {
 	mac         pulumi.StringOutput
 	lvDomain    *libvirt.Domain
 	tag         string
-	vmset       *vmconfig.VMSet
+	vmset       vmconfig.VMSet
 }
 
 func generateDomainIdentifier(vcpu, memory int, vmsetTags, tag, arch string) string {
@@ -88,7 +88,9 @@ func newDomainConfiguration(e *config.CommonEnvironment, set *vmconfig.VMSet, vc
 	domain.domainID = generateDomainIdentifier(vcpu, memory, setTags, kernel.Tag, set.Arch)
 	domain.domainNamer = libvirtResourceNamer(e.Ctx, domain.domainID)
 	domain.tag = kernel.Tag
-	domain.vmset = set
+	// copy the vmset tag. The pointer refers to
+	// a local variable and can change causing an incorrect mapping
+	domain.vmset = *set
 
 	domain.mac, err = generateMACAddress(e, domain.domainID)
 	if err != nil {

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -265,7 +265,6 @@ func exportVMInformation(ctx *pulumi.Context, instances map[string]*Instance, vm
 					"ip":         pulumi.ToOutput(domain.ip),
 					"tag":        pulumi.ToOutput(domain.tag),
 					"vmset-tags": pulumi.ToArrayOutput(tags),
-					"arch":       pulumi.ToOutput(domain.vmset.Arch),
 				}))
 			}
 		}

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -261,11 +261,11 @@ func exportVMInformation(ctx *pulumi.Context, instances map[string]*Instance, vm
 					tags = append(tags, pulumi.ToOutput(tag))
 				}
 				vms = append(vms, pulumi.ToMapOutput(map[string]pulumi.Output{
-					"id":       pulumi.Sprintf(domain.domainID),
-					"ip":       pulumi.Sprintf(domain.ip),
-					"tag":      pulumi.Sprintf(domain.tag),
+					"id":       pulumi.ToOutput(domain.domainID),
+					"ip":       pulumi.ToOutput(domain.ip),
+					"tag":      pulumi.ToOutput(domain.tag),
 					"set-tags": pulumi.ToArrayOutput(tags),
-					"arch":     pulumi.Sprintf(domain.vmset.Arch),
+					"arch":     pulumi.ToOutput(domain.vmset.Arch),
 				}))
 			}
 		}

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -261,11 +261,11 @@ func exportVMInformation(ctx *pulumi.Context, instances map[string]*Instance, vm
 					tags = append(tags, pulumi.ToOutput(tag))
 				}
 				vms = append(vms, pulumi.ToMapOutput(map[string]pulumi.Output{
-					"id":       pulumi.ToOutput(domain.domainID),
-					"ip":       pulumi.ToOutput(domain.ip),
-					"tag":      pulumi.ToOutput(domain.tag),
-					"set-tags": pulumi.ToArrayOutput(tags),
-					"arch":     pulumi.ToOutput(domain.vmset.Arch),
+					"id":         pulumi.ToOutput(domain.domainID),
+					"ip":         pulumi.ToOutput(domain.ip),
+					"tag":        pulumi.ToOutput(domain.tag),
+					"vmset-tags": pulumi.ToArrayOutput(tags),
+					"arch":       pulumi.ToOutput(domain.vmset.Arch),
 				}))
 			}
 		}

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -281,7 +281,7 @@ func exportVMInformation(ctx *pulumi.Context, instances map[string]*Instance, vm
 		})
 	}
 
-	ctx.Export("", pulumi.JSONMarshal(pulumi.ToMapOutput(output)))
+	ctx.Export("kmt-stack", pulumi.JSONMarshal(pulumi.ToMapOutput(output)))
 }
 
 func run(e commonConfig.CommonEnvironment) (*ScenarioDone, error) {


### PR DESCRIPTION
What does this PR do?
---------------------
This PR adds support to emit a structured json object as the stack output of the microvms scenario. This structured output is easier to consume, and contains more information about the stack.

Which scenarios this will impact?
-------------------
scenarios/aws/microVMs

Motivation
----------

Additional Notes
----------------

https://datadoghq.atlassian.net/browse/EBPF-380

