### PR TITLE
Add retry on install errors in Pulumi install, fix -1 suffix issue with Windows

### DIFF
--- a/components/datadog/agent/host_linuxos.go
+++ b/components/datadog/agent/host_linuxos.go
@@ -50,7 +50,7 @@ func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersio
 	}
 
 	return fmt.Sprintf(
-		`curl -L https://s3.amazonaws.com/dd-agent/scripts/%v --retry 3 -o install-script.sh && for i in 1 2 3; do DD_API_KEY=%%s %v DD_INSTALL_ONLY=true bash install-script.sh  && break || sleep 15; done`,
+		`curl -L https://s3.amazonaws.com/dd-agent/scripts/%v --retry 3 -o install-script.sh && for i in 1 2 3; do DD_API_KEY=%%s %v DD_INSTALL_ONLY=true bash install-script.sh  && break || sleep 2; done`,
 		fmt.Sprintf("install_script_agent%s.sh", version.Major),
 		commandLine), nil
 }

--- a/components/datadog/agent/host_linuxos.go
+++ b/components/datadog/agent/host_linuxos.go
@@ -50,9 +50,9 @@ func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersio
 	}
 
 	return fmt.Sprintf(
-		`DD_API_KEY=%%s %v DD_INSTALL_ONLY=true bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/%v)"`,
-		commandLine,
-		fmt.Sprintf("install_script_agent%s.sh", version.Major)), nil
+		`curl -L https://s3.amazonaws.com/dd-agent/scripts/%v --retry 3 -o install-script.sh && for i in 1 2 3; do DD_API_KEY=%%s %v DD_INSTALL_ONLY=true bash install-script.sh  && break || sleep 15; done`,
+		fmt.Sprintf("install_script_agent%s.sh", version.Major),
+		commandLine), nil
 }
 
 func (am *agentLinuxManager) getAgentConfigFolder() string {


### PR DESCRIPTION
What does this PR do?
---------------------

Adds a retry on both Linux and Windows when trying to download the agent install script from S3 bucket, this should solve this issue that happens sometimes
```
curl: (35) OpenSSL SSL_connect: SSL_ERROR_ZERO_RETURN in connection to s3.amazonaws.com:443
```
On linux we also add a retry on the execution of the install script itself since we know this is safe and could help to fix some issues encounter within the install script

It also fixes an issue with a `-1` suffix added to Windows version

Which scenarios this will impact?
-------------------
None

Motivation
----------

Additional Notes
----------------

Pulumi does not allow to retry resources on failure, to handle this we use bash/powershell scripting in the Pulumi Command
