### PR TITLE
Change patching of amazon-vpc-cni CM as now the fields are created and owned by amazon-vpc-cni Helm chart

### DIFF
--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -180,6 +180,9 @@ func Run(ctx *pulumi.Context) error {
 				Metadata: metav1.ObjectMetaPatchArgs{
 					Namespace: pulumi.String("kube-system"),
 					Name:      pulumi.String("amazon-vpc-cni"),
+					Annotations: pulumi.StringMap{
+						"pulumi.com/patchForce": pulumi.String("true"),
+					},
 				},
 				Data: pulumi.StringMap{
 					"enable-windows-ipam": pulumi.String("true"),


### PR DESCRIPTION
What does this PR do?
---------------------

Setting `pulumi.com/patchForce` allows to update and own back the field

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
