### PR TITLE
Fix Kind cluster name

### DIFF
--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -36,9 +36,9 @@ func Run(ctx *pulumi.Context) error {
 		return err
 	}
 
-	clusterName := ctx.Stack()
+	kindClusterName := ctx.Stack()
 
-	kindCluster, err := localKubernetes.NewKindCluster(*awsEnv.CommonEnvironment, vm, clusterName, awsEnv.KubernetesVersion())
+	kindCluster, err := localKubernetes.NewKindCluster(*awsEnv.CommonEnvironment, vm, awsEnv.CommonNamer.ResourceName("kind"), kindClusterName, awsEnv.KubernetesVersion())
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ datadog:
   clusterName: "%s"
 agents:
   useHostNetwork: true
-`, clusterName)
+`, kindClusterName)
 
 		helmComponent, err := agent.NewHelmInstallation(*awsEnv.CommonEnvironment, agent.HelmInstallationArgs{
 			KubeProvider: kindKubeProvider,
@@ -103,7 +103,7 @@ agents:
 
 	// Deploy standalone dogstatsd
 	if awsEnv.DogstatsdDeploy() {
-		if _, err := dogstatsdstandalone.K8sAppDefinition(*awsEnv.CommonEnvironment, kindKubeProvider, "dogstatsd-standalone", fakeIntake, false, clusterName); err != nil {
+		if _, err := dogstatsdstandalone.K8sAppDefinition(*awsEnv.CommonEnvironment, kindKubeProvider, "dogstatsd-standalone", fakeIntake, false, kindClusterName); err != nil {
 			return err
 		}
 	}

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -36,7 +36,9 @@ func Run(ctx *pulumi.Context) error {
 		return err
 	}
 
-	kindCluster, err := localKubernetes.NewKindCluster(*awsEnv.CommonEnvironment, vm, awsEnv.CommonNamer.ResourceName("kind"), awsEnv.KubernetesVersion())
+	clusterName := ctx.Stack()
+
+	kindCluster, err := localKubernetes.NewKindCluster(*awsEnv.CommonEnvironment, vm, clusterName, awsEnv.KubernetesVersion())
 	if err != nil {
 		return err
 	}
@@ -69,8 +71,6 @@ func Run(ctx *pulumi.Context) error {
 			return err
 		}
 	}
-
-	clusterName := ctx.Stack()
 
 	// Deploy the agent
 	if awsEnv.AgentDeploy() {


### PR DESCRIPTION
What does this PR do?
---------------------

Fix the link to the [e2e dashboard](https://dddev.datadoghq.com/dashboard/qcp-brm-ysc/e2e-tests-containers-k8s) displayed at the end of the tests run.
Currently, the tests are printing a link to [an empty dashboard](https://dddev.datadoghq.com/dashboard/qcp-brm-ysc/e2e-tests-containers-k8s?refresh_mode=paused&tpl_var_kube_cluster_name%5B0%5D=kind&tpl_var_fake_intake_task_family%5B0%5D=kind-fakeintake-ecs&from_ts=1705638423430&to_ts=1705639015684&live=false).

Here is an example.
This CI job: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/412702092
gave this link: https://dddev.datadoghq.com/dashboard/qcp-brm-ysc/e2e-tests-containers-k8s?refresh_mode=paused&tpl_var_kube_cluster_name%5B0%5D=kind&tpl_var_fake_intake_task_family%5B0%5D=kind-fakeintake-ecs&from_ts=1705638423430&to_ts=1705639015684&live=false
which is an empty dashboard because it has been pre-filled with:

* `kube_cluster_name: kind` and
* `fake_intake_task_family: kind-fakeintake-ecs`

whereas it should have been pre-filled with:
* `kube_cluster_name: ci-26798820-4670-kind-cluster` and
* `fake_intake_task_family: ci-26798820-4670-kind-cluster-fakeintake-ecs`

instead. Here is [the “fixed/expected” dashboard link](https://dddev.datadoghq.com/dashboard/qcp-brm-ysc/e2e-tests-containers-k8s?refresh_mode=paused&tpl_var_fake_intake_task_family%5B0%5D=ci-26798820-4670-kind-cluster-fakeintake-ecs&tpl_var_kube_cluster_name%5B0%5D=ci-26798820-4670-kind-cluster&view=spans&from_ts=1705638423430&to_ts=1705639015684&live=false).

The `kind` value comes from https://github.com/DataDog/test-infra-definitions/blob/ce65c57f04c5e8427cd33afc0c7445c319c49f2d/components/kubernetes/kind.go#L106 where `clusterName` his set to `kind` here: https://github.com/DataDog/test-infra-definitions/blob/ce65c57f04c5e8427cd33afc0c7445c319c49f2d/scenarios/aws/kindvm/run.go#L39

The issue with that `kind` cluster name is that:
* It doesn’t match what the agent considers as a cluster name set here: https://github.com/DataDog/test-infra-definitions/blob/ce65c57f04c5e8427cd33afc0c7445c319c49f2d/scenarios/aws/kindvm/run.go#L73-L84
* If all the kind clusters have the same cluster name, we cannot distinguish their data in `dddev`. (Each stack has its own fake intake, but they all share the same `dddev`)

Which scenarios this will impact?
-------------------

* `aws/kind`

Motivation
----------

Fix the link to the e2e dashboard in the tests logs.

Additional Notes
----------------

The regression might come from:
* https://github.com/DataDog/test-infra-definitions/commit/4b6449f1208f2b8daaca3def919b4b9198609ff5#diff-01c5d769d54d64d3cfdbb65ba7123801fc1bdd7e4864c95c6d41a04f4f1b70e2L95
* https://github.com/DataDog/test-infra-definitions/commit/4b6449f1208f2b8daaca3def919b4b9198609ff5#diff-327b38eb6820f75d01b49327e922df8bd7b5cd975e5a218308b15d1bfa2fdc85R106