### PR TITLE
Enable support of container image uncompressed layers for SBOM scans

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -199,7 +199,8 @@ func buildLinuxHelmValues(installName, agentImagePath, agentImageTag, clusterAge
 			},
 			"sbom": pulumi.Map{
 				"containerImage": pulumi.Map{
-					"enabled": pulumi.Bool(true),
+					"enabled":                   pulumi.Bool(true),
+					"uncompressedLayersSupport": pulumi.Bool(true),
 				},
 			},
 			// The fake intake keeps payloads only for a hardcoded period of 15 minutes.


### PR DESCRIPTION
What does this PR do?
---------------------

Enable `datadog.sbom.containerImage.uncompressedLayersSupport` when deploying the agent.

Which scenarios this will impact?
-------------------

Kubernetes ones:
* `aws/kind`
* `aws/eks`

Motivation
----------

Without this option, SBOM scans just doesn’t work on kind.

Additional Notes
----------------
