### PR TITLE
components/datadog/agent: add apm port mapping in docker & ecs

### DIFF
--- a/components/datadog/agent/docker.go
+++ b/components/datadog/agent/docker.go
@@ -78,7 +78,7 @@ func dockerAgentComposeManifest(agentImagePath string, apiKey pulumi.StringInput
 						"DD_PROCESS_AGENT_ENABLED": true,
 					},
 					Pid:   "host",
-					Ports: []string{"8125:8125/udp"},
+					Ports: []string{"8125:8125/udp", "8126:8126/tcp"},
 				},
 			},
 		}

--- a/components/datadog/agent/ecs.go
+++ b/components/datadog/agent/ecs.go
@@ -167,6 +167,11 @@ func ecsLinuxAgentSingleContainerDefinition(e config.CommonEnvironment, apiKeySS
 				HostPort:      pulumi.IntPtr(8125),
 				Protocol:      pulumi.StringPtr("udp"),
 			},
+			ecs.TaskDefinitionPortMappingArgs{
+				ContainerPort: pulumi.Int(8126),
+				HostPort:      pulumi.IntPtr(8126),
+				Protocol:      pulumi.StringPtr("tcp"),
+			},
 		},
 	}
 }


### PR DESCRIPTION
What does this PR do?
---------------------

Make the trace-agent reachable in docker and ecs

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
