### PR TITLE
Add instance profile and configure creds helper to authorize pulling docker images from ECR

### DIFF
--- a/components/docker/docker.go
+++ b/components/docker/docker.go
@@ -155,24 +155,7 @@ func (d *Manager) install() (*remote.Command, error) {
 		return nil, err
 	}
 
-	ecrCredsHelperInstall, err := d.host.OS.PackageManager().Ensure("amazon-ecr-credential-helper", utils.MergeOptions(d.opts, utils.PulumiDependsOn(groupCmd))...)
-	if err != nil {
-		return nil, err
-	}
-
-	ecrCredsHelperConfig, err := d.host.OS.Runner().Command(
-		d.namer.ResourceName("ecr-config"),
-		&command.Args{
-			Create: pulumi.Sprintf("mkdir -p ~/.docker && echo '{\"credsStore\": \"ecr-login\"}' > ~/.docker/config.json"),
-			Sudo:   false,
-		},
-		utils.MergeOptions(d.opts, utils.PulumiDependsOn(ecrCredsHelperInstall))...,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return ecrCredsHelperConfig, err
+	return groupCmd, err
 }
 
 func (d *Manager) installCompose() (*remote.Command, error) {

--- a/resources/aws/ec2/vm.go
+++ b/resources/aws/ec2/vm.go
@@ -14,10 +14,11 @@ type InstanceArgs struct {
 	AMI string
 
 	// Defaulted
-	InstanceType string // Note that caller must ensure it matches with AMI Architecture
-	KeyPairName  string
-	Tenancy      string
-	StorageSize  int
+	InstanceType    string // Note that caller must ensure it matches with AMI Architecture
+	KeyPairName     string
+	Tenancy         string
+	StorageSize     int
+	InstanceProfile string
 
 	// Optional
 	UserData string
@@ -29,6 +30,7 @@ func NewInstance(e aws.Environment, name string, args InstanceArgs, opts ...pulu
 	instance, err := ec2.NewInstance(e.Ctx, e.Namer.ResourceName(name), &ec2.InstanceArgs{
 		Ami:                     pulumi.StringPtr(args.AMI),
 		SubnetId:                e.RandomSubnets().Index(pulumi.Int(0)),
+		IamInstanceProfile:      pulumi.StringPtr(args.InstanceProfile),
 		InstanceType:            pulumi.StringPtr(args.InstanceType),
 		VpcSecurityGroupIds:     pulumi.ToStringArray(e.DefaultSecurityGroups()),
 		KeyName:                 pulumi.StringPtr(args.KeyPairName),

--- a/resources/aws/environment.go
+++ b/resources/aws/environment.go
@@ -15,18 +15,18 @@ const (
 	awsRegionParamName = "region"
 
 	// AWS Infra
-	DDInfraDefaultVPCIDParamName                 = "aws/defaultVPCID"
-	DDInfraDefaultSubnetsParamName               = "aws/defaultSubnets"
-	DDInfraDefaultSecurityGroupsParamName        = "aws/defaultSecurityGroups"
-	DDInfraDefaultInstanceTypeParamName          = "aws/defaultInstanceType"
-	DDInfraDefaultDockerInstanceProfileParamName = "aws/defaultInstanceProfile"
-	DDInfraDefaultARMInstanceTypeParamName       = "aws/defaultARMInstanceType"
-	DDInfraDefaultKeyPairParamName               = "aws/defaultKeyPairName"
-	DDinfraDefaultPublicKeyPath                  = "aws/defaultPublicKeyPath"
-	DDInfraDefaultPrivateKeyPath                 = "aws/defaultPrivateKeyPath"
-	DDInfraDefaultPrivateKeyPassword             = "aws/defaultPrivateKeyPassword"
-	DDInfraDefaultInstanceStorageSize            = "aws/defaultInstanceStorageSize"
-	DDInfraDefaultShutdownBehavior               = "aws/defaultShutdownBehavior"
+	DDInfraDefaultVPCIDParamName           = "aws/defaultVPCID"
+	DDInfraDefaultSubnetsParamName         = "aws/defaultSubnets"
+	DDInfraDefaultSecurityGroupsParamName  = "aws/defaultSecurityGroups"
+	DDInfraDefaultInstanceTypeParamName    = "aws/defaultInstanceType"
+	DDInfraDefaultInstanceProfileParamName = "aws/defaultInstanceProfile"
+	DDInfraDefaultARMInstanceTypeParamName = "aws/defaultARMInstanceType"
+	DDInfraDefaultKeyPairParamName         = "aws/defaultKeyPairName"
+	DDinfraDefaultPublicKeyPath            = "aws/defaultPublicKeyPath"
+	DDInfraDefaultPrivateKeyPath           = "aws/defaultPrivateKeyPath"
+	DDInfraDefaultPrivateKeyPassword       = "aws/defaultPrivateKeyPassword"
+	DDInfraDefaultInstanceStorageSize      = "aws/defaultInstanceStorageSize"
+	DDInfraDefaultShutdownBehavior         = "aws/defaultShutdownBehavior"
 
 	// AWS ECS
 	DDInfraEcsExecKMSKeyID                  = "aws/ecs/execKMSKeyID"
@@ -137,8 +137,8 @@ func (e *Environment) DefaultInstanceType() string {
 	return e.GetStringWithDefault(e.InfraConfig, DDInfraDefaultInstanceTypeParamName, e.envDefault.ddInfra.defaultInstanceType)
 }
 
-func (e *Environment) DefaultDockerInstanceProfile() string {
-	return e.GetStringWithDefault(e.InfraConfig, DDInfraDefaultDockerInstanceProfileParamName, e.envDefault.ddInfra.defaultDockerInstanceProfile)
+func (e *Environment) DefaultInstanceProfileName() string {
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraDefaultInstanceTypeParamName, e.envDefault.ddInfra.defaultInstanceProfileName)
 }
 
 func (e *Environment) DefaultARMInstanceType() string {

--- a/resources/aws/environment.go
+++ b/resources/aws/environment.go
@@ -15,17 +15,18 @@ const (
 	awsRegionParamName = "region"
 
 	// AWS Infra
-	DDInfraDefaultVPCIDParamName           = "aws/defaultVPCID"
-	DDInfraDefaultSubnetsParamName         = "aws/defaultSubnets"
-	DDInfraDefaultSecurityGroupsParamName  = "aws/defaultSecurityGroups"
-	DDInfraDefaultInstanceTypeParamName    = "aws/defaultInstanceType"
-	DDInfraDefaultARMInstanceTypeParamName = "aws/defaultARMInstanceType"
-	DDInfraDefaultKeyPairParamName         = "aws/defaultKeyPairName"
-	DDinfraDefaultPublicKeyPath            = "aws/defaultPublicKeyPath"
-	DDInfraDefaultPrivateKeyPath           = "aws/defaultPrivateKeyPath"
-	DDInfraDefaultPrivateKeyPassword       = "aws/defaultPrivateKeyPassword"
-	DDInfraDefaultInstanceStorageSize      = "aws/defaultInstanceStorageSize"
-	DDInfraDefaultShutdownBehavior         = "aws/defaultShutdownBehavior"
+	DDInfraDefaultVPCIDParamName                 = "aws/defaultVPCID"
+	DDInfraDefaultSubnetsParamName               = "aws/defaultSubnets"
+	DDInfraDefaultSecurityGroupsParamName        = "aws/defaultSecurityGroups"
+	DDInfraDefaultInstanceTypeParamName          = "aws/defaultInstanceType"
+	DDInfraDefaultDockerInstanceProfileParamName = "aws/defaultInstanceProfile"
+	DDInfraDefaultARMInstanceTypeParamName       = "aws/defaultARMInstanceType"
+	DDInfraDefaultKeyPairParamName               = "aws/defaultKeyPairName"
+	DDinfraDefaultPublicKeyPath                  = "aws/defaultPublicKeyPath"
+	DDInfraDefaultPrivateKeyPath                 = "aws/defaultPrivateKeyPath"
+	DDInfraDefaultPrivateKeyPassword             = "aws/defaultPrivateKeyPassword"
+	DDInfraDefaultInstanceStorageSize            = "aws/defaultInstanceStorageSize"
+	DDInfraDefaultShutdownBehavior               = "aws/defaultShutdownBehavior"
 
 	// AWS ECS
 	DDInfraEcsExecKMSKeyID                  = "aws/ecs/execKMSKeyID"
@@ -134,6 +135,10 @@ func (e *Environment) DefaultSecurityGroups() []string {
 
 func (e *Environment) DefaultInstanceType() string {
 	return e.GetStringWithDefault(e.InfraConfig, DDInfraDefaultInstanceTypeParamName, e.envDefault.ddInfra.defaultInstanceType)
+}
+
+func (e *Environment) DefaultDockerInstanceProfile() string {
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraDefaultDockerInstanceProfileParamName, e.envDefault.ddInfra.defaultDockerInstanceProfile)
 }
 
 func (e *Environment) DefaultARMInstanceType() string {

--- a/resources/aws/environmentDefaults.go
+++ b/resources/aws/environmentDefaults.go
@@ -20,14 +20,14 @@ type awsProvider struct {
 }
 
 type ddInfra struct {
-	defaultVPCID                 string
-	defaultSubnets               []string
-	defaultSecurityGroups        []string
-	defaultInstanceType          string
-	defaultARMInstanceType       string
-	defaultInstanceStorageSize   int
-	defaultShutdownBehavior      string
-	defaultDockerInstanceProfile string
+	defaultVPCID               string
+	defaultSubnets             []string
+	defaultSecurityGroups      []string
+	defaultInstanceType        string
+	defaultInstanceProfileName string
+	defaultARMInstanceType     string
+	defaultInstanceStorageSize int
+	defaultShutdownBehavior    string
 
 	ecs ddInfraECS
 	eks ddInfraEKS
@@ -76,14 +76,14 @@ func sandboxDefault() environmentDefault {
 			region: string(aws.RegionUSEast1),
 		},
 		ddInfra: ddInfra{
-			defaultVPCID:                 "vpc-d1aac1a8",
-			defaultSubnets:               []string{"subnet-b89e00e2", "subnet-8ee8b1c6", "subnet-3f5db45b"},
-			defaultSecurityGroups:        []string{"sg-46506837", "sg-7fedd80a", "sg-0e952e295ab41e748"},
-			defaultInstanceType:          "t3.medium",
-			defaultDockerInstanceProfile: "agent-ecr-read",
-			defaultARMInstanceType:       "t4g.medium",
-			defaultInstanceStorageSize:   200,
-			defaultShutdownBehavior:      "stop",
+			defaultVPCID:               "vpc-d1aac1a8",
+			defaultSubnets:             []string{"subnet-b89e00e2", "subnet-8ee8b1c6", "subnet-3f5db45b"},
+			defaultSecurityGroups:      []string{"sg-46506837", "sg-7fedd80a", "sg-0e952e295ab41e748"},
+			defaultInstanceType:        "t3.medium",
+			defaultInstanceProfileName: "ec2InstanceRole",
+			defaultARMInstanceType:     "t4g.medium",
+			defaultInstanceStorageSize: 200,
+			defaultShutdownBehavior:    "stop",
 
 			ecs: ddInfraECS{
 				execKMSKeyID:                "arn:aws:kms:us-east-1:601427279990:key/c84f93c2-a562-4a59-a326-918fbe7235c7",
@@ -116,14 +116,14 @@ func agentSandboxDefault() environmentDefault {
 			region: string(aws.RegionUSEast1),
 		},
 		ddInfra: ddInfra{
-			defaultVPCID:                 "vpc-029c0faf8f49dee8d",
-			defaultSubnets:               []string{"subnet-0a15f3482cd3f9820", "subnet-091570395d476e9ce", "subnet-003831c49a10df3dd"},
-			defaultSecurityGroups:        []string{"sg-038231b976eb13d44", "sg-05466e7ce253d21b1"},
-			defaultInstanceType:          "t3.medium",
-			defaultDockerInstanceProfile: "agent-ecr-read",
-			defaultARMInstanceType:       "t4g.medium",
-			defaultInstanceStorageSize:   200,
-			defaultShutdownBehavior:      "stop",
+			defaultVPCID:               "vpc-029c0faf8f49dee8d",
+			defaultSubnets:             []string{"subnet-0a15f3482cd3f9820", "subnet-091570395d476e9ce", "subnet-003831c49a10df3dd"},
+			defaultSecurityGroups:      []string{"sg-038231b976eb13d44", "sg-05466e7ce253d21b1"},
+			defaultInstanceType:        "t3.medium",
+			defaultInstanceProfileName: "ec2InstanceRole",
+			defaultARMInstanceType:     "t4g.medium",
+			defaultInstanceStorageSize: 200,
+			defaultShutdownBehavior:    "stop",
 
 			ecs: ddInfraECS{
 				execKMSKeyID:                "arn:aws:kms:us-east-1:376334461865:key/1d1fe533-a4f1-44ee-99ec-225b44fcb9ed",
@@ -156,14 +156,14 @@ func agentQADefault() environmentDefault {
 			region: string(aws.RegionUSEast1),
 		},
 		ddInfra: ddInfra{
-			defaultVPCID:                 "vpc-0097b9307ec2c8139",
-			defaultSubnets:               []string{"subnet-0f1ca3e929eb3fb8b", "subnet-03061a1647c63c3c3", "subnet-071213aedb0e1ae54"},
-			defaultSecurityGroups:        []string{"sg-05e9573fcc582f22c", "sg-0498c960a173dff1e"},
-			defaultInstanceType:          "t3.medium",
-			defaultDockerInstanceProfile: "agent-ecr-read",
-			defaultARMInstanceType:       "t4g.medium",
-			defaultInstanceStorageSize:   200,
-			defaultShutdownBehavior:      "stop",
+			defaultVPCID:               "vpc-0097b9307ec2c8139",
+			defaultSubnets:             []string{"subnet-0f1ca3e929eb3fb8b", "subnet-03061a1647c63c3c3", "subnet-071213aedb0e1ae54"},
+			defaultSecurityGroups:      []string{"sg-05e9573fcc582f22c", "sg-0498c960a173dff1e"},
+			defaultInstanceType:        "t3.medium",
+			defaultInstanceProfileName: "ec2InstanceRole",
+			defaultARMInstanceType:     "t4g.medium",
+			defaultInstanceStorageSize: 200,
+			defaultShutdownBehavior:    "stop",
 
 			ecs: ddInfraECS{
 				execKMSKeyID:                "arn:aws:kms:us-east-1:669783387624:key/384373bc-6d99-4d68-84b5-b76b756b0af3",

--- a/resources/aws/environmentDefaults.go
+++ b/resources/aws/environmentDefaults.go
@@ -20,13 +20,14 @@ type awsProvider struct {
 }
 
 type ddInfra struct {
-	defaultVPCID               string
-	defaultSubnets             []string
-	defaultSecurityGroups      []string
-	defaultInstanceType        string
-	defaultARMInstanceType     string
-	defaultInstanceStorageSize int
-	defaultShutdownBehavior    string
+	defaultVPCID                 string
+	defaultSubnets               []string
+	defaultSecurityGroups        []string
+	defaultInstanceType          string
+	defaultARMInstanceType       string
+	defaultInstanceStorageSize   int
+	defaultShutdownBehavior      string
+	defaultDockerInstanceProfile string
 
 	ecs ddInfraECS
 	eks ddInfraEKS
@@ -75,13 +76,14 @@ func sandboxDefault() environmentDefault {
 			region: string(aws.RegionUSEast1),
 		},
 		ddInfra: ddInfra{
-			defaultVPCID:               "vpc-d1aac1a8",
-			defaultSubnets:             []string{"subnet-b89e00e2", "subnet-8ee8b1c6", "subnet-3f5db45b"},
-			defaultSecurityGroups:      []string{"sg-46506837", "sg-7fedd80a", "sg-0e952e295ab41e748"},
-			defaultInstanceType:        "t3.medium",
-			defaultARMInstanceType:     "t4g.medium",
-			defaultInstanceStorageSize: 200,
-			defaultShutdownBehavior:    "stop",
+			defaultVPCID:                 "vpc-d1aac1a8",
+			defaultSubnets:               []string{"subnet-b89e00e2", "subnet-8ee8b1c6", "subnet-3f5db45b"},
+			defaultSecurityGroups:        []string{"sg-46506837", "sg-7fedd80a", "sg-0e952e295ab41e748"},
+			defaultInstanceType:          "t3.medium",
+			defaultDockerInstanceProfile: "agent-ecr-read",
+			defaultARMInstanceType:       "t4g.medium",
+			defaultInstanceStorageSize:   200,
+			defaultShutdownBehavior:      "stop",
 
 			ecs: ddInfraECS{
 				execKMSKeyID:                "arn:aws:kms:us-east-1:601427279990:key/c84f93c2-a562-4a59-a326-918fbe7235c7",
@@ -114,13 +116,14 @@ func agentSandboxDefault() environmentDefault {
 			region: string(aws.RegionUSEast1),
 		},
 		ddInfra: ddInfra{
-			defaultVPCID:               "vpc-029c0faf8f49dee8d",
-			defaultSubnets:             []string{"subnet-0a15f3482cd3f9820", "subnet-091570395d476e9ce", "subnet-003831c49a10df3dd"},
-			defaultSecurityGroups:      []string{"sg-038231b976eb13d44", "sg-05466e7ce253d21b1"},
-			defaultInstanceType:        "t3.medium",
-			defaultARMInstanceType:     "t4g.medium",
-			defaultInstanceStorageSize: 200,
-			defaultShutdownBehavior:    "stop",
+			defaultVPCID:                 "vpc-029c0faf8f49dee8d",
+			defaultSubnets:               []string{"subnet-0a15f3482cd3f9820", "subnet-091570395d476e9ce", "subnet-003831c49a10df3dd"},
+			defaultSecurityGroups:        []string{"sg-038231b976eb13d44", "sg-05466e7ce253d21b1"},
+			defaultInstanceType:          "t3.medium",
+			defaultDockerInstanceProfile: "agent-ecr-read",
+			defaultARMInstanceType:       "t4g.medium",
+			defaultInstanceStorageSize:   200,
+			defaultShutdownBehavior:      "stop",
 
 			ecs: ddInfraECS{
 				execKMSKeyID:                "arn:aws:kms:us-east-1:376334461865:key/1d1fe533-a4f1-44ee-99ec-225b44fcb9ed",
@@ -153,13 +156,14 @@ func agentQADefault() environmentDefault {
 			region: string(aws.RegionUSEast1),
 		},
 		ddInfra: ddInfra{
-			defaultVPCID:               "vpc-0097b9307ec2c8139",
-			defaultSubnets:             []string{"subnet-0f1ca3e929eb3fb8b", "subnet-03061a1647c63c3c3", "subnet-071213aedb0e1ae54"},
-			defaultSecurityGroups:      []string{"sg-05e9573fcc582f22c", "sg-0498c960a173dff1e"},
-			defaultInstanceType:        "t3.medium",
-			defaultARMInstanceType:     "t4g.medium",
-			defaultInstanceStorageSize: 200,
-			defaultShutdownBehavior:    "stop",
+			defaultVPCID:                 "vpc-0097b9307ec2c8139",
+			defaultSubnets:               []string{"subnet-0f1ca3e929eb3fb8b", "subnet-03061a1647c63c3c3", "subnet-071213aedb0e1ae54"},
+			defaultSecurityGroups:        []string{"sg-05e9573fcc582f22c", "sg-0498c960a173dff1e"},
+			defaultInstanceType:          "t3.medium",
+			defaultDockerInstanceProfile: "agent-ecr-read",
+			defaultARMInstanceType:       "t4g.medium",
+			defaultInstanceStorageSize:   200,
+			defaultShutdownBehavior:      "stop",
 
 			ecs: ddInfraECS{
 				execKMSKeyID:                "arn:aws:kms:us-east-1:669783387624:key/384373bc-6d99-4d68-84b5-b76b756b0af3",

--- a/scenarios/aws/ec2/vm.go
+++ b/scenarios/aws/ec2/vm.go
@@ -57,7 +57,7 @@ func NewVM(e aws.Environment, name string, params ...VMOption) (*remote.Host, er
 	})
 }
 
-func InstallEcrCredentialsHelper(e aws.Environment, vm *remote.Host) (*goremote.Command, error) {
+func InstallECRCredentialsHelper(e aws.Environment, vm *remote.Host) (*goremote.Command, error) {
 	ecrCredsHelperInstall, err := vm.OS.PackageManager().Ensure("amazon-ecr-credential-helper")
 	if err != nil {
 		return nil, err

--- a/scenarios/aws/ec2/vm.go
+++ b/scenarios/aws/ec2/vm.go
@@ -35,7 +35,7 @@ func NewVM(e aws.Environment, name string, params ...VMOption) (*remote.Host, er
 			AMI:             amiInfo.id,
 			InstanceType:    vmArgs.instanceType,
 			UserData:        vmArgs.userData,
-			InstanceProfile: vmArgs.iamInstanceProfile,
+			InstanceProfile: vmArgs.instanceProfile,
 		}
 
 		// Create the EC2 instance
@@ -57,6 +57,10 @@ func NewVM(e aws.Environment, name string, params ...VMOption) (*remote.Host, er
 func defaultVMArgs(e aws.Environment, vmArgs *vmArgs) error {
 	if vmArgs.osInfo == nil {
 		vmArgs.osInfo = &os.UbuntuDefault
+	}
+
+	if vmArgs.instanceProfile == "" {
+		vmArgs.instanceProfile = e.DefaultInstanceProfileName()
 	}
 
 	if vmArgs.instanceType == "" {

--- a/scenarios/aws/ec2/vm.go
+++ b/scenarios/aws/ec2/vm.go
@@ -57,7 +57,7 @@ func NewVM(e aws.Environment, name string, params ...VMOption) (*remote.Host, er
 	})
 }
 
-func InstallEcrCredentialHelper(e aws.Environment, vm *remote.Host) (*goremote.Command, error) {
+func InstallEcrCredentialsHelper(e aws.Environment, vm *remote.Host) (*goremote.Command, error) {
 	ecrCredsHelperInstall, err := vm.OS.PackageManager().Ensure("amazon-ecr-credential-helper")
 	if err != nil {
 		return nil, err

--- a/scenarios/aws/ec2/vm.go
+++ b/scenarios/aws/ec2/vm.go
@@ -75,6 +75,7 @@ func InstallEcrCredentialHelper(e aws.Environment, vm *remote.Host) (*goremote.C
 
 	return ecrConfigCommand, nil
 }
+
 func defaultVMArgs(e aws.Environment, vmArgs *vmArgs) error {
 	if vmArgs.osInfo == nil {
 		vmArgs.osInfo = &os.UbuntuDefault

--- a/scenarios/aws/ec2/vm.go
+++ b/scenarios/aws/ec2/vm.go
@@ -1,12 +1,15 @@
 package ec2
 
 import (
+	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/components"
+	"github.com/DataDog/test-infra-definitions/components/command"
 	"github.com/DataDog/test-infra-definitions/components/os"
 	"github.com/DataDog/test-infra-definitions/components/remote"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 	"github.com/DataDog/test-infra-definitions/resources/aws/ec2"
 
+	goremote "github.com/pulumi/pulumi-command/sdk/go/command/remote"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -54,6 +57,24 @@ func NewVM(e aws.Environment, name string, params ...VMOption) (*remote.Host, er
 	})
 }
 
+func InstallEcrCredentialHelper(e aws.Environment, vm *remote.Host) (*goremote.Command, error) {
+	ecrCredsHelperInstall, err := vm.OS.PackageManager().Ensure("amazon-ecr-credential-helper")
+	if err != nil {
+		return nil, err
+	}
+
+	ecrConfigCommand, err := vm.OS.Runner().Command(
+		e.CommonNamer.ResourceName("ecr-config"),
+		&command.Args{
+			Create: pulumi.Sprintf("mkdir -p ~/.docker && echo '{\"credsStore\": \"ecr-login\"}' > ~/.docker/config.json"),
+			Sudo:   false,
+		}, utils.PulumiDependsOn(ecrCredsHelperInstall))
+	if err != nil {
+		return nil, err
+	}
+
+	return ecrConfigCommand, nil
+}
 func defaultVMArgs(e aws.Environment, vmArgs *vmArgs) error {
 	if vmArgs.osInfo == nil {
 		vmArgs.osInfo = &os.UbuntuDefault

--- a/scenarios/aws/ec2/vm.go
+++ b/scenarios/aws/ec2/vm.go
@@ -32,9 +32,10 @@ func NewVM(e aws.Environment, name string, params ...VMOption) (*remote.Host, er
 	// Create the EC2 instance
 	return components.NewComponent(*e.CommonEnvironment, e.Namer.ResourceName(name), func(c *remote.Host) error {
 		instanceArgs := ec2.InstanceArgs{
-			AMI:          amiInfo.id,
-			InstanceType: vmArgs.instanceType,
-			UserData:     vmArgs.userData,
+			AMI:             amiInfo.id,
+			InstanceType:    vmArgs.instanceType,
+			UserData:        vmArgs.userData,
+			InstanceProfile: vmArgs.iamInstanceProfile,
 		}
 
 		// Create the EC2 instance

--- a/scenarios/aws/ec2/vm_run.go
+++ b/scenarios/aws/ec2/vm_run.go
@@ -83,8 +83,8 @@ func VMRunWithDocker(ctx *pulumi.Context) error {
 		return err
 	}
 
-	_, installDocker := osWithDockerProvided[vm.OS.Descriptor().Flavor]
-	manager, _, err := docker.NewManager(*env.CommonEnvironment, vm, installDocker)
+	_, isDockerInstalled := osWithDockerProvided[vm.OS.Descriptor().Flavor]
+	manager, _, err := docker.NewManager(*env.CommonEnvironment, vm, !isDockerInstalled)
 	if err != nil {
 		return err
 	}

--- a/scenarios/aws/ec2/vm_run.go
+++ b/scenarios/aws/ec2/vm_run.go
@@ -84,7 +84,7 @@ func VMRunWithDocker(ctx *pulumi.Context) error {
 		return err
 	}
 
-	installEcrCredsHelperCmd, err := InstallEcrCredentialHelper(env, vm)
+	installEcrCredsHelperCmd, err := InstallEcrCredentialsHelper(env, vm)
 	if err != nil {
 		return err
 	}

--- a/scenarios/aws/ec2/vm_run.go
+++ b/scenarios/aws/ec2/vm_run.go
@@ -84,7 +84,7 @@ func VMRunWithDocker(ctx *pulumi.Context) error {
 		return err
 	}
 
-	installEcrCredsHelperCmd, err := InstallEcrCredentialsHelper(env, vm)
+	installEcrCredsHelperCmd, err := InstallECRCredentialsHelper(env, vm)
 	if err != nil {
 		return err
 	}

--- a/scenarios/aws/ec2/vm_run.go
+++ b/scenarios/aws/ec2/vm_run.go
@@ -91,7 +91,6 @@ func VMRunWithDocker(ctx *pulumi.Context) error {
 		return err
 	}
 
-	vm.OS.PackageManager()
 	ecrCredsHelperInstall, err := vm.OS.PackageManager().Ensure("amazon-ecr-credential-helper", utils.PulumiDependsOn(setupDockerCmd))
 	if err != nil {
 		return err

--- a/scenarios/aws/ec2/vm_run.go
+++ b/scenarios/aws/ec2/vm_run.go
@@ -75,7 +75,7 @@ func VMRunWithDocker(ctx *pulumi.Context) error {
 
 	// If no OS is provided, we default to AmazonLinuxECS as it ships with Docker pre-installed
 	osDesc := os.DescriptorFromString(env.InfraOSDescriptor(), os.AmazonLinuxECS)
-	vm, err := NewVM(env, "vm", WithAMI(env.InfraOSImageID(), osDesc, osDesc.Architecture))
+	vm, err := NewVM(env, "vm", WithAMI(env.InfraOSImageID(), osDesc, osDesc.Architecture), WithInstanceProfile(env.DefaultDockerInstanceProfile()))
 	if err != nil {
 		return err
 	}

--- a/scenarios/aws/ec2/vmargs.go
+++ b/scenarios/aws/ec2/vmargs.go
@@ -20,10 +20,11 @@ import (
 // [Functional options pattern]: https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
 
 type vmArgs struct {
-	osInfo       *os.Descriptor
-	ami          string
-	userData     string
-	instanceType string
+	osInfo             *os.Descriptor
+	ami                string
+	userData           string
+	instanceType       string
+	iamInstanceProfile string
 }
 
 type VMOption = func(*vmArgs) error
@@ -70,6 +71,13 @@ func WithInstanceType(instanceType string) VMOption {
 func WithUserData(userData string) VMOption {
 	return func(p *vmArgs) error {
 		p.userData = userData
+		return nil
+	}
+}
+
+func WithInstanceProfile(instanceProfile string) VMOption {
+	return func(p *vmArgs) error {
+		p.iamInstanceProfile = instanceProfile
 		return nil
 	}
 }

--- a/scenarios/aws/ec2/vmargs.go
+++ b/scenarios/aws/ec2/vmargs.go
@@ -20,11 +20,11 @@ import (
 // [Functional options pattern]: https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
 
 type vmArgs struct {
-	osInfo             *os.Descriptor
-	ami                string
-	userData           string
-	instanceType       string
-	iamInstanceProfile string
+	osInfo          *os.Descriptor
+	ami             string
+	userData        string
+	instanceType    string
+	instanceProfile string
 }
 
 type VMOption = func(*vmArgs) error
@@ -77,7 +77,7 @@ func WithUserData(userData string) VMOption {
 
 func WithInstanceProfile(instanceProfile string) VMOption {
 	return func(p *vmArgs) error {
-		p.iamInstanceProfile = instanceProfile
+		p.instanceProfile = instanceProfile
 		return nil
 	}
 }


### PR DESCRIPTION
What does this PR do?
---------------------

Configure docker scenario to add an Instance Profile that allows pulling docker image from QA env ECR. Also configures the aws-ecr-credentials-helper

Related PR on `test-infra-cleaner`: https://github.com/DataDog/test-infra-cleaner/pull/16
Related PR on `datadog-agent`: https://github.com/DataDog/datadog-agent/pull/22373

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
