### PR TITLE
docker agent compose up running in privileged, required by system-probe

### DIFF
--- a/components/datadog/agent/docker.go
+++ b/components/datadog/agent/docker.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"strings"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"gopkg.in/yaml.v3"
 
@@ -58,6 +60,14 @@ func NewDockerAgent(e config.CommonEnvironment, vm *remoteComp.Host, manager *do
 }
 
 func dockerAgentComposeManifest(agentImagePath string, apiKey pulumi.StringInput, envVars pulumi.Map) docker.ComposeInlineManifest {
+	runInPrivileged := false
+	for k := range envVars {
+		if strings.HasPrefix(k, "DD_SYSTEM_PROBE_") {
+			runInPrivileged = true
+			break
+		}
+	}
+
 	agentManifestContent := pulumi.All(apiKey, envVars).ApplyT(func(args []interface{}) (string, error) {
 		apiKeyResolved := args[0].(string)
 		envVarsResolved := args[1].(map[string]any)
@@ -65,7 +75,7 @@ func dockerAgentComposeManifest(agentImagePath string, apiKey pulumi.StringInput
 			Version: "3.9",
 			Services: map[string]docker.ComposeManifestService{
 				"agent": {
-					Privileged:    true,
+					Privileged:    runInPrivileged,
 					Image:         agentImagePath,
 					ContainerName: agentContainerName,
 					Volumes: []string{

--- a/components/datadog/agent/docker.go
+++ b/components/datadog/agent/docker.go
@@ -65,6 +65,7 @@ func dockerAgentComposeManifest(agentImagePath string, apiKey pulumi.StringInput
 			Version: "3.9",
 			Services: map[string]docker.ComposeManifestService{
 				"agent": {
+					Privileged:    true,
 					Image:         agentImagePath,
 					ContainerName: agentContainerName,
 					Volumes: []string{
@@ -72,6 +73,7 @@ func dockerAgentComposeManifest(agentImagePath string, apiKey pulumi.StringInput
 						"/proc/:/host/proc",
 						"/sys/fs/cgroup/:/host/sys/fs/cgroup",
 						"/var/run/datadog:/var/run/datadog",
+						"/sys/kernel/tracing:/sys/kernel/tracing",
 					},
 					Environment: map[string]any{
 						"DD_API_KEY":               apiKeyResolved,

--- a/components/docker/compose.go
+++ b/components/docker/compose.go
@@ -14,6 +14,7 @@ type ComposeManifest struct {
 
 type ComposeManifestService struct {
 	Pid           string         `yaml:"pid,omitempty"`
+	Privileged    bool           `yaml:"privileged,omitempty"`
 	Ports         []string       `yaml:"ports,omitempty"`
 	Image         string         `yaml:"image"`
 	ContainerName string         `yaml:"container_name"`


### PR DESCRIPTION
What does this PR do?
---------------------

Run docker agent in privileged mode, it's required to run system-probe properly
mount /sys/kernel/tracing from the host to the container as well

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
