### PR TITLE
Collect agent telemetry

### DIFF
--- a/components/datadog/agent/ecs.go
+++ b/components/datadog/agent/ecs.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 
@@ -172,6 +173,24 @@ func ecsLinuxAgentSingleContainerDefinition(e config.CommonEnvironment, apiKeySS
 				HostPort:      pulumi.IntPtr(8126),
 				Protocol:      pulumi.StringPtr("tcp"),
 			},
+		},
+		DockerLabels: pulumi.StringMap{
+			"com.datadoghq.ad.checks": pulumi.String(utils.JSONMustMarshal(
+				map[string]interface{}{
+					"openmetrics": map[string]interface{}{
+						"init_configs": []map[string]interface{}{},
+						"instances": []map[string]interface{}{
+							{
+								"openmetrics_endpoint": "http://localhost:5000/telemetry",
+								"namespace":            "datadog.agent",
+								"metrics": []string{
+									".*",
+								},
+							},
+						},
+					},
+				},
+			)),
 		},
 	}
 }

--- a/components/datadog/agent/ecsFargate.go
+++ b/components/datadog/agent/ecsFargate.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 
 	"github.com/pulumi/pulumi-awsx/sdk/go/awsx/ecs"
@@ -54,5 +55,23 @@ func ECSFargateLinuxContainerDefinition(e config.CommonEnvironment, image string
 		LogConfiguration: logConfig,
 		PortMappings:     ecs.TaskDefinitionPortMappingArray{},
 		VolumesFrom:      ecs.TaskDefinitionVolumeFromArray{},
+		DockerLabels: pulumi.StringMap{
+			"com.datadoghq.ad.checks": pulumi.String(utils.JSONMustMarshal(
+				map[string]interface{}{
+					"openmetrics": map[string]interface{}{
+						"init_configs": []map[string]interface{}{},
+						"instances": []map[string]interface{}{
+							{
+								"openmetrics_endpoint": "http://localhost:5000/telemetry",
+								"namespace":            "datadog.agent",
+								"metrics": []string{
+									".*",
+								},
+							},
+						},
+					},
+				},
+			)),
+		},
 	}
 }

--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -233,6 +233,24 @@ func buildLinuxHelmValues(installName, agentImagePath, agentImageTag, clusterAge
 				"tag":           pulumi.String(agentImageTag),
 				"doNotCheckTag": pulumi.Bool(true),
 			},
+			"podAnnotations": pulumi.StringMap{
+				"ad.datadoghq.com/agent.checks": pulumi.String(utils.JSONMustMarshal(
+					map[string]interface{}{
+						"openmetrics": map[string]interface{}{
+							"init_configs": []map[string]interface{}{},
+							"instances": []map[string]interface{}{
+								{
+									"openmetrics_endpoint": "http://localhost:6000/telemetry",
+									"namespace":            "datadog.agent",
+									"metrics": []string{
+										".*",
+									},
+								},
+							},
+						},
+					}),
+				),
+			},
 		},
 		"clusterAgent": pulumi.Map{
 			"enabled": pulumi.Bool(true),


### PR DESCRIPTION
What does this PR do?
---------------------

Collect the agent telemetry data during the e2e tests.

Which scenarios this will impact?
-------------------

`aws/ecs`
`aws/eks`
`aws/kind`

Motivation
----------

Telemetry data can help better understanding why a flaky test failed.

Additional Notes
----------------
