### PR TITLE
Fix create-docker invoke task

### DIFF
--- a/scenarios/aws/ec2/vm_run.go
+++ b/scenarios/aws/ec2/vm_run.go
@@ -111,14 +111,12 @@ func VMRunWithDocker(ctx *pulumi.Context) error {
 			agentOptions = append(agentOptions, dockeragentparams.WithFakeintake(fakeintake))
 		}
 
-		_, err = agent.NewDockerAgent(*env.CommonEnvironment, vm, manager, agentOptions...)
-		if err != nil {
-			return err
+		if env.TestingWorkloadDeploy() {
+			agentOptions = append(agentOptions, dockeragentparams.WithExtraComposeManifest(dogstatsd.DockerComposeManifest.Name, dogstatsd.DockerComposeManifest.Content))
+			agentOptions = append(agentOptions, dockeragentparams.WithEnvironmentVariables(pulumi.StringMap{"HOST_IP": vm.Address}))
 		}
-	}
 
-	if env.TestingWorkloadDeploy() {
-		_, err := manager.ComposeStrUp("dogstatsd-apps", []docker.ComposeInlineManifest{dogstatsd.DockerComposeManifest}, pulumi.StringMap{"HOST_IP": vm.Address})
+		_, err = agent.NewDockerAgent(*env.CommonEnvironment, vm, manager, agentOptions...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
What does this PR do?
---------------------

Fix invoke create-docker task

It was broken because the way it was rewritten assume the dogstatsd manifest can be applied alone, however the dogstatsd manifest must be applied together with the agent manifest to work and override some variables

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
