### PR TITLE
[CONTINT-3706] Increase the fake intake memory

### DIFF
--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -197,7 +197,10 @@ func Run(ctx *pulumi.Context) error {
 
 		var fakeIntake *fakeintakeComp.Fakeintake
 		if awsEnv.GetCommonEnvironment().AgentUseFakeintake() {
-			fakeIntakeOptions := []fakeintake.Option{}
+			fakeIntakeOptions := []fakeintake.Option{
+				fakeintake.WithCPU(1024),
+				fakeintake.WithMemory(6144),
+			}
 			if awsEnv.GetCommonEnvironment().InfraShouldDeployFakeintakeWithLB() {
 				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithLoadBalancer())
 			}

--- a/scenarios/aws/fakeintake/fakeintake.go
+++ b/scenarios/aws/fakeintake/fakeintake.go
@@ -59,8 +59,8 @@ func NewECSFargateInstance(e aws.Environment, name string, option ...Option) (*f
 		taskDef, err := ecs.FargateTaskDefinitionWithAgent(e,
 			namer.ResourceName("taskdef"),
 			pulumi.String("fakeintake-ecs"),
-			1024, 6144,
-			map[string]awsxEcs.TaskDefinitionContainerDefinitionArgs{"fakeintake": *fargateLinuxContainerDefinition(params.ImageURL, apiKeyParam.Name)},
+			params.CPU, params.Memory,
+			map[string]awsxEcs.TaskDefinitionContainerDefinitionArgs{"fakeintake": *fargateLinuxContainerDefinition(params.ImageURL, apiKeyParam.Name, params.Memory-600)},
 			apiKeyParam.Name,
 			nil,
 			opts...,
@@ -237,7 +237,7 @@ func fargateSvcLB(e aws.Environment, namer namer.Namer, taskDef *awsxEcs.Fargate
 	return nil
 }
 
-func fargateLinuxContainerDefinition(imageURL string, apiKeySSMParamName pulumi.StringInput) *awsxEcs.TaskDefinitionContainerDefinitionArgs {
+func fargateLinuxContainerDefinition(imageURL string, apiKeySSMParamName pulumi.StringInput, GoMemLimitMiB int) *awsxEcs.TaskDefinitionContainerDefinitionArgs {
 	return &awsxEcs.TaskDefinitionContainerDefinitionArgs{
 		Name:        pulumi.String(containerName),
 		Image:       pulumi.String(imageURL),
@@ -246,7 +246,7 @@ func fargateLinuxContainerDefinition(imageURL string, apiKeySSMParamName pulumi.
 		Environment: awsxEcs.TaskDefinitionKeyValuePairArray{
 			awsxEcs.TaskDefinitionKeyValuePairArgs{
 				Name:  pulumi.StringPtr("GOMEMLIMIT"),
-				Value: pulumi.StringPtr("5120MiB"),
+				Value: pulumi.StringPtr(fmt.Sprintf("%dMiB", GoMemLimitMiB)),
 			},
 		},
 		PortMappings: awsxEcs.TaskDefinitionPortMappingArray{

--- a/scenarios/aws/fakeintake/fakeintake.go
+++ b/scenarios/aws/fakeintake/fakeintake.go
@@ -59,7 +59,7 @@ func NewECSFargateInstance(e aws.Environment, name string, option ...Option) (*f
 		taskDef, err := ecs.FargateTaskDefinitionWithAgent(e,
 			namer.ResourceName("taskdef"),
 			pulumi.String("fakeintake-ecs"),
-			1024, 4096,
+			1024, 6144,
 			map[string]awsxEcs.TaskDefinitionContainerDefinitionArgs{"fakeintake": *fargateLinuxContainerDefinition(params.ImageURL, apiKeyParam.Name)},
 			apiKeyParam.Name,
 			nil,
@@ -246,7 +246,7 @@ func fargateLinuxContainerDefinition(imageURL string, apiKeySSMParamName pulumi.
 		Environment: awsxEcs.TaskDefinitionKeyValuePairArray{
 			awsxEcs.TaskDefinitionKeyValuePairArgs{
 				Name:  pulumi.StringPtr("GOMEMLIMIT"),
-				Value: pulumi.StringPtr("3072MiB"),
+				Value: pulumi.StringPtr("5120MiB"),
 			},
 		},
 		PortMappings: awsxEcs.TaskDefinitionPortMappingArray{

--- a/scenarios/aws/fakeintake/params.go
+++ b/scenarios/aws/fakeintake/params.go
@@ -5,6 +5,8 @@ import "github.com/DataDog/test-infra-definitions/common"
 type Params struct {
 	LoadBalancerEnabled bool
 	ImageURL            string
+	CPU                 int
+	Memory              int
 }
 
 type Option = func(*Params) error
@@ -14,6 +16,8 @@ func NewParams(options ...Option) (*Params, error) {
 	params := &Params{
 		LoadBalancerEnabled: false,
 		ImageURL:            "public.ecr.aws/datadog/fakeintake:latest",
+		CPU:                 512,
+		Memory:              1024,
 	}
 	return common.ApplyOption(params, options)
 }
@@ -30,6 +34,22 @@ func WithLoadBalancer() Option {
 func WithImageURL(imageURL string) Option {
 	return func(p *Params) error {
 		p.ImageURL = imageURL
+		return nil
+	}
+}
+
+// WithCPU sets the number of CPU units to allocate to the fakeintake
+func WithCPU(cpu int) Option {
+	return func(p *Params) error {
+		p.CPU = cpu
+		return nil
+	}
+}
+
+// WithMemory sets the amount (in MiB) of memory to allocate to the fakeintake
+func WithMemory(memory int) Option {
+	return func(p *Params) error {
+		p.Memory = memory
 		return nil
 	}
 }

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -59,7 +59,10 @@ func Run(ctx *pulumi.Context) error {
 
 	var fakeIntake *fakeintakeComp.Fakeintake
 	if awsEnv.GetCommonEnvironment().AgentUseFakeintake() {
-		fakeIntakeOptions := []fakeintake.Option{}
+		fakeIntakeOptions := []fakeintake.Option{
+			fakeintake.WithCPU(1024),
+			fakeintake.WithMemory(6144),
+		}
 		if awsEnv.GetCommonEnvironment().InfraShouldDeployFakeintakeWithLB() {
 			fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithLoadBalancer())
 		}


### PR DESCRIPTION
What does this PR do?
---------------------

Bump the memory of the fake intake to avoid OOM kill on the EKS and Kind scenarios.
Reduce the memory of the fake intake to save money on other scenarios.

Which scenarios this will impact?
-------------------

* all

Motivation
----------

I was looking at some flaky e2e tests and some of the failures are pointing towards the fake intake.

Ex.:

* [fake intake returns 504 error](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22%20%40test.status%3Afail&citest_explorer_sort=time%2Cdesc&currentTab=overview&eventStack=AgAAAY1P4T3aaWxAuwAAAAAAAAAYAAAAAEFZMVA0VDNhQUFCSXVaSXFhQ0xkTmNfTQAAACQAAAAAMDE4ZDRmZTMtMTFjMy00YzNjLTlmODItZTQxNjhhMmZmODg0&index=citest&mode=sliding&saved-view-id=2236559&testId=AgAAAY1P4T3aaWxAuwAAAAAAAAAYAAAAAEFZMVA0VDNhQUFCSXVaSXFhQ0xkTmNfTQAAACQAAAAAMDE4ZDRmZTMtMTFjMy00YzNjLTlmODItZTQxNjhhMmZmODg0&trace=AgAAAY1P4T3aaWxAuwAAAAAAAAAYAAAAAEFZMVA0VDNhQUFCSXVaSXFhQ0xkTmNfTQAAACQAAAAAMDE4ZDRmZTMtMTFjMy00YzNjLTlmODItZTQxNjhhMmZmODg0&start=1705919011102&end=1706523811102&paused=false):
  ```
        	Error:      	Received unexpected error:
        	            	Expected 200 got 504
        	Messages:   	Failed to query fake intake
  ```
* [fake intake returns 502 error](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22%20%40test.status%3Afail&citest_explorer_sort=time%2Cdesc&currentTab=overview&eventStack=AgAAAY1PzvYqHbuP1wAAAAAAAAAYAAAAAEFZMVB6dllxQUFDWGFZeld0TUhwYUp1NgAAACQAAAAAMDE4ZDRmZDUtNWViZC00MzcyLTlhYjctNjRmNzBjMDliMjk4&index=citest&mode=sliding&saved-view-id=2236559&testId=AgAAAY1PzvYqHbuP1wAAAAAAAAAYAAAAAEFZMVB6dllxQUFDWGFZeld0TUhwYUp1NgAAACQAAAAAMDE4ZDRmZDUtNWViZC00MzcyLTlhYjctNjRmNzBjMDliMjk4&trace=AgAAAY1PzvYqHbuP1wAAAAAAAAAYAAAAAEFZMVB6dllxQUFDWGFZeld0TUhwYUp1NgAAACQAAAAAMDE4ZDRmZDUtNWViZC00MzcyLTlhYjctNjRmNzBjMDliMjk4&start=1705919131102&end=1706523931102&paused=false)
  ```
        	Error:      	Received unexpected error:
        	            	Expected 200 got 502
        	Messages:   	Failed to query fake intake
  ```
* [fake intake misses data](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22%20%40test.status%3Afail&citest_explorer_sort=time%2Cdesc&currentTab=overview&eventStack=AgAAAY1P0MMaTZdOTwAAAAAAAAAYAAAAAEFZMVAwTU1hQUFEdWlCUkVQNk1BeG5GcwAAACQAAAAAMDE4ZDRmZDUtNWViZC00MzcyLTlhYjctNjRmNzBjMDliMjk4&index=citest&mode=sliding&saved-view-id=2236559&testId=AgAAAY1P0MMaTZdOTwAAAAAAAAAYAAAAAEFZMVAwTU1hQUFEdWlCUkVQNk1BeG5GcwAAACQAAAAAMDE4ZDRmZDUtNWViZC00MzcyLTlhYjctNjRmNzBjMDliMjk4&trace=AgAAAY1P0MMaTZdOTwAAAAAAAAAYAAAAAEFZMVAwTU1hQUFEdWlCUkVQNk1BeG5GcwAAACQAAAAAMDE4ZDRmZDUtNWViZC00MzcyLTlhYjctNjRmNzBjMDliMjk4&start=1705919191102&end=1706523991102&paused=false):
  ```
        	Error:      	Should NOT be empty, but was 
        	Messages:   	No SBOM for ghcr.io/datadog/apps-nginx-server yet
  ```

The data are showing a fake intake memory starvation followed by a restart:

* [First case](https://dddev.datadoghq.com/dashboard/qcp-brm-ysc/e2e-tests-containers-k8s?refresh_mode=paused&tpl_var_fake_intake_task_family%5B0%5D=ci-27290983-4670-kind-cluster-fakeintake-ecs&tpl_var_kube_cluster_name%5B0%5D=ci-27290983-4670-kind-cluster&view=spans&from_ts=1706441346106&to_ts=1706443060420&live=false):
  
![image](https://github.com/DataDog/test-infra-definitions/assets/1437785/bb79b551-c96f-445a-826f-737bd1fece9e)
* [Seconde case](https://dddev.datadoghq.com/dashboard/qcp-brm-ysc/e2e-tests-containers-k8s?refresh_mode=paused&tpl_var_fake_intake_task_family%5B0%5D=ci-27290998-4670-kind-cluster-fakeintake-ecs&tpl_var_kube_cluster_name%5B0%5D=ci-27290998-4670-kind-cluster&view=spans&from_ts=1706440152971&to_ts=1706441824091&live=false):
  
![image](https://github.com/DataDog/test-infra-definitions/assets/1437785/3956ce8a-c390-4cbf-ab1c-b146bb540021)

In both cases, we can see exactly the same symptoms.
* The memory consumption starts to plateau (because of `GOMEMLIMIT`) before the “Number of payloads collected” starts to plateau. This means that the garbage collector is asked to do cleanup before the fake intake starts to cleanup its payloads.
* This results in pressure that is visible on the CPU graph: the garbage collector consumes more and more CPU to try to keep the memory consumption below `GOMEMLIMIT`. Up to 1 core (the limit of the Fargate task).
* As all the CPU available to the Fargate task is consumed by the garbage collector, the fake intake response time degrades. It climbs up to more than 1 second.
* And the fake intake is eventually killed and restarted.

Additional Notes
----------------

The default CPU and memory limits used for the non-Kubernetes scenarios have been chosen based on the measures collected in [this notebook](https://dddev.datadoghq.com/notebook/7384273/fake-intake-memory-consumption).