### PR TITLE
Sanitize username + add some debug prints

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -86,8 +86,10 @@ func NewCommonEnvironment(ctx *pulumi.Context) (CommonEnvironment, error) {
 	if err != nil {
 		return env, err
 	}
-	env.username = user.Username
+	env.username = strings.ReplaceAll(user.Username, "\\", "/")
 
+	ctx.Log.Debug(fmt.Sprintf("user name: %s", env.username), nil)
+	ctx.Log.Debug(fmt.Sprintf("resource tags: %v", env.DefaultResourceTags()), nil)
 	ctx.Log.Debug(fmt.Sprintf("agent version: %s", env.AgentVersion()), nil)
 	ctx.Log.Debug(fmt.Sprintf("pipeline id: %s", env.PipelineID()), nil)
 	ctx.Log.Debug(fmt.Sprintf("deploy: %v", env.AgentDeploy()), nil)


### PR DESCRIPTION
What does this PR do?
---------------------
This PR sanitizes the username as read by `user.Current()` to remove the "\" and replace it with "/".

This was evidenced by the error message
```
ValidationException: 1 validation error detected: Value 'DESKTOP-V03BB2P\Julien Lebot' at 'tags.3.member.value' failed to satisfy constraint: Member must satisfy regular expression pattern: ^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$
```

According to an online regex tool, it's the "\" in the username that's causing the issue
![image](https://github.com/DataDog/test-infra-definitions/assets/63521/27ffb61f-0074-4b46-9cf6-aca8a42cf67f)


Which scenarios this will impact?
-------------------
Windows scenarios.

Motivation
----------
Working e2e on Windows.

Additional Notes
----------------
Added some debug logs.
