### PR TITLE
Set remote_configuration.no_tls_validation to true

### DIFF
--- a/components/datadog/agent/ecs.go
+++ b/components/datadog/agent/ecs.go
@@ -205,6 +205,10 @@ func ecsFakeintakeAdditionalEndpointsEnv(fakeintake *fakeintake.Fakeintake) []ec
 			Value: pulumi.StringPtr("true"),
 		},
 		ecs.TaskDefinitionKeyValuePairArgs{
+			Name:  pulumi.StringPtr("DD_REMOTE_CONFIGURATION_NO_TLS_VALIDATION"),
+			Value: pulumi.StringPtr("true"),
+		},
+		ecs.TaskDefinitionKeyValuePairArgs{
 			Name:  pulumi.StringPtr("DD_ADDITIONAL_ENDPOINTS"),
 			Value: pulumi.Sprintf(`{"https://%s": ["FAKEAPIKEY"]}`, fakeintake.Host),
 		},

--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -352,6 +352,10 @@ func (values HelmValues) configureFakeintake(fakeintake *fakeintake.Fakeintake) 
 			"value": pulumi.String("true"),
 		},
 		pulumi.Map{
+			"name":  pulumi.String("DD_REMOTE_CONFIGURATION_NO_TLS_VALIDATION"),
+			"value": pulumi.String("true"),
+		},
+		pulumi.Map{
 			"name":  pulumi.String("DD_ADDITIONAL_ENDPOINTS"),
 			"value": pulumi.Sprintf(`{"%s": ["FAKEAPIKEY"]}`, fakeintake.URL),
 		},

--- a/components/datadog/dockeragentparams/params.go
+++ b/components/datadog/dockeragentparams/params.go
@@ -123,13 +123,14 @@ func withIntakeHostname(hostname pulumi.StringInput, shouldSkipSSLCertificateVal
 	}).(pulumi.BoolOutput)
 	return func(p *Params) error {
 		envVars := pulumi.Map{
-			"DD_DD_URL":                        pulumi.Sprintf("http://%s:80", hostname),
-			"DD_LOGS_CONFIG_DD_URL":            pulumi.Sprintf("%s:80", hostname),
-			"DD_PROCESS_CONFIG_PROCESS_DD_URL": pulumi.Sprintf("http://%s:80", hostname),
-			"DD_APM_DD_URL":                    pulumi.Sprintf("http://%s:80", hostname),
-			"DD_SKIP_SSL_VALIDATION":           pulumi.Bool(shouldSkipSSLCertificateValidation),
-			"DD_LOGS_CONFIG_LOGS_NO_SSL":       pulumi.Bool(shouldSkipSSLCertificateValidation),
-			"DD_LOGS_CONFIG_FORCE_USE_HTTP":    shouldEnforceHTTPInput,
+			"DD_DD_URL":                                 pulumi.Sprintf("http://%s:80", hostname),
+			"DD_LOGS_CONFIG_DD_URL":                     pulumi.Sprintf("%s:80", hostname),
+			"DD_PROCESS_CONFIG_PROCESS_DD_URL":          pulumi.Sprintf("http://%s:80", hostname),
+			"DD_APM_DD_URL":                             pulumi.Sprintf("http://%s:80", hostname),
+			"DD_SKIP_SSL_VALIDATION":                    pulumi.Bool(shouldSkipSSLCertificateValidation),
+			"DD_REMOTE_CONFIGURATION_NO_TLS_VALIDATION": pulumi.Bool(shouldSkipSSLCertificateValidation),
+			"DD_LOGS_CONFIG_LOGS_NO_SSL":                pulumi.Bool(shouldSkipSSLCertificateValidation),
+			"DD_LOGS_CONFIG_FORCE_USE_HTTP":             shouldEnforceHTTPInput,
 		}
 		for key, value := range envVars {
 			if err := WithAgentServiceEnvVariable(key, value)(p); err != nil {
@@ -170,11 +171,12 @@ func WithAdditionalFakeintake(fakeintake *fakeintake.Fakeintake) func(*Params) e
 	}).(pulumi.BoolOutput)
 	return func(p *Params) error {
 		logsEnvVars := pulumi.Map{
-			"DD_ADDITIONAL_ENDPOINTS":             additionalEndpointsContentInput,
-			"DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS": additionalLogsEndpointsContentInput,
-			"DD_SKIP_SSL_VALIDATION":              pulumi.Bool(true),
-			"DD_LOGS_CONFIG_LOGS_NO_SSL":          pulumi.Bool(true),
-			"DD_LOGS_CONFIG_FORCE_USE_HTTP":       shouldEnforceHTTPInput,
+			"DD_ADDITIONAL_ENDPOINTS":                   additionalEndpointsContentInput,
+			"DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS":       additionalLogsEndpointsContentInput,
+			"DD_SKIP_SSL_VALIDATION":                    pulumi.Bool(true),
+			"DD_REMOTE_CONFIGURATION_NO_TLS_VALIDATION": pulumi.Bool(true),
+			"DD_LOGS_CONFIG_LOGS_NO_SSL":                pulumi.Bool(true),
+			"DD_LOGS_CONFIG_FORCE_USE_HTTP":             shouldEnforceHTTPInput,
 		}
 		for key, value := range logsEnvVars {
 			if err := WithAgentServiceEnvVariable(key, value)(p); err != nil {


### PR DESCRIPTION
What does this PR do?
---------------------

Set `remote_configuration.no_tls_validation` to `true` when `skip_ssl_validation` is also set to `true`.

Which scenarios this will impact?
-------------------

* `aws/ecs`
* `aws/eks`
* `aws/kind`

Motivation
----------

Fix the agent in `CrashLoopBackOff` in e2e tests because of this error:
```
Error: unable to create remote-config service: remote Configuration does not allow skipping TLS validation by default (currently skipped because `skip_ssl_validation` is set to true). While it is not advised, the `remote_configuration.no_tls_validation` config option can be set to `true` to disable this protection
```

Additional Notes
----------------

`skip_ssl_validation: true` is needed to have the agent able to send payloads to the fake intake, which doesn’t have a valid certificate signed by a well known CA.