### PR TITLE
Use -Force when creating Windows folder to avoid ResourceExists error

### DIFF
--- a/components/command/windowsOSCommand.go
+++ b/components/command/windowsOSCommand.go
@@ -28,7 +28,7 @@ func (fs windowsOSCommand) CreateDirectory(
 	return createDirectory(
 		runner,
 		name,
-		fmt.Sprintf("New-Item -Path %v -ItemType Directory", remotePath),
+		fmt.Sprintf("New-Item -Force -Path %v -ItemType Directory", remotePath),
 		fmt.Sprintf("if (-not (Test-Path -Path %v/*)) { Remove-Item -Path %v -ErrorAction SilentlyContinue }", remotePath, remotePath),
 		useSudo,
 		opts...)


### PR DESCRIPTION
What does this PR do?
---------------------

Use `-Force` flag when creating a folder on Windows

Which scenarios this will impact?
-------------------

We have issues when we use `WithIntegration` for the same integration in different tests on Windows. For instance, a first test creates the folder, and when the second test creates the folder again it fails with a `ResourceExists` error.

Motivation
----------

Additional Notes
----------------
