### PR TITLE
APL-2848 Handle pipeline id and commit sha to set docker image

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -34,6 +34,7 @@ const (
 	DDAgentDeployParamName               = "deploy"
 	DDAgentVersionParamName              = "version"
 	DDAgentPipelineID                    = "pipeline_id"
+	DDAgentCommitSHA                     = "commit_sha"
 	DDAgentFullImagePathParamName        = "fullImagePath"
 	DDClusterAgentVersionParamName       = "clusterAgentVersion"
 	DDClusterAgentFullImagePathParamName = "clusterAgentFullImagePath"
@@ -169,6 +170,10 @@ func (e *CommonEnvironment) PipelineID() string {
 	return e.AgentConfig.Get(DDAgentPipelineID)
 }
 
+func (e *CommonEnvironment) CommitSHA() string {
+	return e.AgentConfig.Get(DDAgentCommitSHA)
+}
+
 func (e *CommonEnvironment) ClusterAgentVersion() string {
 	return e.AgentConfig.Get(DDClusterAgentVersionParamName)
 }
@@ -216,7 +221,7 @@ func (e *CommonEnvironment) DogstatsdDeploy() bool {
 }
 
 func (e *CommonEnvironment) DogstatsdFullImagePath() string {
-	return e.GetStringWithDefault(e.DogstatsdConfig, DDDogstatsdFullImagePathParamName, "gcr.io/datadoghq/dogstatsd")
+	return e.AgentConfig.Get(DDDogstatsdFullImagePathParamName)
 }
 
 // Updater namespace

--- a/components/datadog/agent/docker.go
+++ b/components/datadog/agent/docker.go
@@ -38,7 +38,7 @@ func (h *DockerAgent) Export(ctx *pulumi.Context, out *DockerAgentOutput) error 
 
 func NewDockerAgent(e config.CommonEnvironment, vm *remoteComp.Host, manager *docker.Manager, options ...dockeragentparams.Option) (*DockerAgent, error) {
 	return components.NewComponent(e, vm.Name(), func(comp *DockerAgent) error {
-		params, err := dockeragentparams.NewParams(options...)
+		params, err := dockeragentparams.NewParams(&e, options...)
 		if err != nil {
 			return err
 		}

--- a/components/datadog/agent/docker_image.go
+++ b/components/datadog/agent/docker_image.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"fmt"
+
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
 
@@ -19,6 +21,11 @@ func dockerAgentFullImagePath(e *config.CommonEnvironment, repositoryPath, image
 		return e.AgentFullImagePath()
 	}
 
+	// if agent pipeline id and commit sha are defined, use the image from the pipeline pushed on agent QA registry
+	if e.PipelineID() != "" && e.CommitSHA() != "" {
+		return utils.BuildDockerImagePath("669783387624.dkr.ecr.us-east-1.amazonaws.com/agent", fmt.Sprintf("%s-%s", e.PipelineID(), e.CommitSHA()))
+	}
+
 	if repositoryPath == "" {
 		repositoryPath = defaultAgentImageRepo
 	}
@@ -33,6 +40,11 @@ func dockerClusterAgentFullImagePath(e *config.CommonEnvironment, repositoryPath
 	// return cluster agent image path if defined
 	if e.ClusterAgentFullImagePath() != "" {
 		return e.ClusterAgentFullImagePath()
+	}
+
+	// if agent pipeline id and commit sha are defined, use the image from the pipeline pushed on agent QA registry
+	if e.PipelineID() != "" && e.CommitSHA() != "" {
+		return utils.BuildDockerImagePath("669783387624.dkr.ecr.us-east-1.amazonaws.com/cluster-agent", fmt.Sprintf("%s-%s", e.PipelineID(), e.CommitSHA()))
 	}
 
 	if repositoryPath == "" {

--- a/components/datadog/agent/docker_image.go
+++ b/components/datadog/agent/docker_image.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/resources/aws"
 
 	"github.com/Masterminds/semver"
 )
@@ -23,7 +24,7 @@ func dockerAgentFullImagePath(e *config.CommonEnvironment, repositoryPath, image
 
 	// if agent pipeline id and commit sha are defined, use the image from the pipeline pushed on agent QA registry
 	if e.PipelineID() != "" && e.CommitSHA() != "" {
-		return utils.BuildDockerImagePath("669783387624.dkr.ecr.us-east-1.amazonaws.com/agent", fmt.Sprintf("%s-%s", e.PipelineID(), e.CommitSHA()))
+		return utils.BuildDockerImagePath(fmt.Sprintf("%s/agent", aws.AgentQAECR), fmt.Sprintf("%s-%s", e.PipelineID(), e.CommitSHA()))
 	}
 
 	if repositoryPath == "" {
@@ -44,7 +45,7 @@ func dockerClusterAgentFullImagePath(e *config.CommonEnvironment, repositoryPath
 
 	// if agent pipeline id and commit sha are defined, use the image from the pipeline pushed on agent QA registry
 	if e.PipelineID() != "" && e.CommitSHA() != "" {
-		return utils.BuildDockerImagePath("669783387624.dkr.ecr.us-east-1.amazonaws.com/cluster-agent", fmt.Sprintf("%s-%s", e.PipelineID(), e.CommitSHA()))
+		return utils.BuildDockerImagePath(fmt.Sprintf("%s/cluster-agent", aws.AgentQAECR), fmt.Sprintf("%s-%s", e.PipelineID(), e.CommitSHA()))
 	}
 
 	if repositoryPath == "" {

--- a/components/datadog/dockeragentparams/params.go
+++ b/components/datadog/dockeragentparams/params.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/DataDog/test-infra-definitions/common"
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	"github.com/DataDog/test-infra-definitions/components/docker"
 
@@ -49,11 +51,16 @@ type Params struct {
 
 type Option = func(*Params) error
 
-func NewParams(options ...Option) (*Params, error) {
+func NewParams(e *config.CommonEnvironment, options ...Option) (*Params, error) {
 	version := &Params{
 		AgentServiceEnvironment: pulumi.Map{},
 		EnvironmentVariables:    pulumi.StringMap{},
 	}
+
+	if e.PipelineID() != "" && e.CommitSHA() != "" {
+		options = append(options, WithFullImagePath(utils.BuildDockerImagePath("669783387624.dkr.ecr.us-east-1.amazonaws.com/agent", fmt.Sprintf("%s-%s", e.PipelineID(), e.CommitSHA()))))
+	}
+
 	return common.ApplyOption(version, options)
 }
 

--- a/components/datadog/dogstatsd-standalone/docker_image.go
+++ b/components/datadog/dogstatsd-standalone/docker_image.go
@@ -20,7 +20,7 @@ func dockerDogstatsdFullImagePath(e *config.CommonEnvironment, repositoryPath st
 
 	// if agent pipeline id and commit sha are defined, use the image from the pipeline pushed on agent QA registry
 	if e.PipelineID() != "" && e.CommitSHA() != "" {
-		return utils.BuildDockerImagePath("669783387624.dkr.ecr.us-east-1.amazonaws.com/cluster-agent", fmt.Sprintf("%s-%s", e.PipelineID(), e.CommitSHA()))
+		return utils.BuildDockerImagePath("669783387624.dkr.ecr.us-east-1.amazonaws.com/dogstatsd", fmt.Sprintf("%s-%s", e.PipelineID(), e.CommitSHA()))
 	}
 
 	if repositoryPath == "" {

--- a/components/datadog/dogstatsd-standalone/docker_image.go
+++ b/components/datadog/dogstatsd-standalone/docker_image.go
@@ -1,0 +1,31 @@
+package dogstatsdstandalone
+
+import (
+	"fmt"
+
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/common/utils"
+)
+
+const (
+	defaultDogstatsdImageRepo = "gcr.io/datadoghq/dogstatsd"
+	defaultDogstatsdImageTag  = "latest"
+)
+
+func dockerDogstatsdFullImagePath(e *config.CommonEnvironment, repositoryPath string) string {
+	// return dogstatsd image path if defined
+	if e.DogstatsdFullImagePath() != "" {
+		return e.DogstatsdFullImagePath()
+	}
+
+	// if agent pipeline id and commit sha are defined, use the image from the pipeline pushed on agent QA registry
+	if e.PipelineID() != "" && e.CommitSHA() != "" {
+		return utils.BuildDockerImagePath("669783387624.dkr.ecr.us-east-1.amazonaws.com/cluster-agent", fmt.Sprintf("%s-%s", e.PipelineID(), e.CommitSHA()))
+	}
+
+	if repositoryPath == "" {
+		repositoryPath = defaultDogstatsdImageRepo
+	}
+
+	return utils.BuildDockerImagePath(repositoryPath, defaultDogstatsdImageTag)
+}

--- a/components/datadog/dogstatsd-standalone/docker_image.go
+++ b/components/datadog/dogstatsd-standalone/docker_image.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/resources/aws"
 )
 
 const (
@@ -20,7 +21,7 @@ func dockerDogstatsdFullImagePath(e *config.CommonEnvironment, repositoryPath st
 
 	// if agent pipeline id and commit sha are defined, use the image from the pipeline pushed on agent QA registry
 	if e.PipelineID() != "" && e.CommitSHA() != "" {
-		return utils.BuildDockerImagePath("669783387624.dkr.ecr.us-east-1.amazonaws.com/dogstatsd", fmt.Sprintf("%s-%s", e.PipelineID(), e.CommitSHA()))
+		return utils.BuildDockerImagePath(fmt.Sprintf("%s/dogstatsd", aws.AgentQAECR), fmt.Sprintf("%s-%s", e.PipelineID(), e.CommitSHA()))
 	}
 
 	if repositoryPath == "" {

--- a/components/datadog/dogstatsd-standalone/k8s.go
+++ b/components/datadog/dogstatsd-standalone/k8s.go
@@ -152,7 +152,7 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("dogstatsd-standalone"),
-							Image: pulumi.String(e.DogstatsdFullImagePath()),
+							Image: pulumi.String(dockerDogstatsdFullImagePath(&e, "gcr.io/datadoghq/dogstatsd")),
 							Ports: corev1.ContainerPortArray{
 								&corev1.ContainerPortArgs{
 									ContainerPort: pulumi.Int(8125),

--- a/resources/aws/const.go
+++ b/resources/aws/const.go
@@ -5,4 +5,5 @@ import "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 var (
 	EnabledString  = pulumi.String("ENABLED")
 	DisabledString = pulumi.String("DISABLED")
+	AgentQAECR     = "669783387624.dkr.ecr.us-east-1.amazonaws.com"
 )


### PR DESCRIPTION
What does this PR do?
---------------------

Automatically uses the image built in the pipeline if PipelineID and CommitSHA are defined

Linked with: https://github.com/DataDog/datadog-agent/pull/22636

Which scenarios this will impact?
-------------------

docker,ecs,kubernetes

Motivation
----------

Additional Notes
----------------
