### PR TITLE
Overwrite API key if it already exists

### DIFF
--- a/scenarios/aws/ecs/run.go
+++ b/scenarios/aws/ecs/run.go
@@ -102,9 +102,10 @@ func Run(ctx *pulumi.Context) error {
 			}
 		}
 		apiKeyParam, err = ssm.NewParameter(ctx, awsEnv.Namer.ResourceName("agent-apikey"), &ssm.ParameterArgs{
-			Name:  awsEnv.CommonNamer.DisplayName(1011, pulumi.String("agent-apikey")),
-			Type:  ssm.ParameterTypeSecureString,
-			Value: awsEnv.AgentAPIKey(),
+			Name:      awsEnv.CommonNamer.DisplayName(1011, pulumi.String("agent-apikey")),
+			Type:      ssm.ParameterTypeSecureString,
+			Overwrite: pulumi.Bool(true),
+			Value:     awsEnv.AgentAPIKey(),
 		}, awsEnv.WithProviders(config.ProviderAWS))
 		if err != nil {
 			return err

--- a/scenarios/aws/fakeintake/fakeintake.go
+++ b/scenarios/aws/fakeintake/fakeintake.go
@@ -48,9 +48,10 @@ func NewECSFargateInstance(e aws.Environment, name string, option ...Option) (*f
 		opts := []pulumi.ResourceOption{pulumi.Parent(fi)}
 
 		apiKeyParam, err := ssm.NewParameter(e.Ctx, namer.ResourceName("agent", "apikey"), &ssm.ParameterArgs{
-			Name:  e.CommonNamer.DisplayName(1011, pulumi.String(name), pulumi.String("apikey")),
-			Type:  ssm.ParameterTypeSecureString,
-			Value: e.AgentAPIKey(),
+			Name:      e.CommonNamer.DisplayName(1011, pulumi.String(name), pulumi.String("apikey")),
+			Type:      ssm.ParameterTypeSecureString,
+			Value:     e.AgentAPIKey(),
+			Overwrite: pulumi.Bool(true),
 		}, utils.MergeOptions(opts, e.WithProviders(config.ProviderAWS))...)
 		if err != nil {
 			return err


### PR DESCRIPTION
What does this PR do?
---------------------

We expect the API key to be created by Pulumi. In some cases if the deletion failed we will get an error saying the parameter already exists. We prevent this error from happening by allowing pulumi to overwrite the parameter.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
