### PR TITLE
[os] descriptor from string defaults to default descriptor

### DIFF
--- a/components/os/descriptor.go
+++ b/components/os/descriptor.go
@@ -29,24 +29,24 @@ func NewDescriptorWithArch(f Flavor, version string, arch Architecture) Descript
 }
 
 // String format is <flavor>:<version>(:<arch>)
-func DescriptorFromString(descStr string, defaultFlavor Flavor) Descriptor {
+func DescriptorFromString(descStr string, defaultDescriptor Descriptor) Descriptor {
+	if descStr == "" {
+		return defaultDescriptor
+	}
+
 	parts := strings.Split(descStr, osDescriptorSep)
 	if len(parts) < 2 || len(parts) > 3 {
 		panic(fmt.Sprintf("invalid OS descriptor string, was: %s", descStr))
 	}
 
-	var flavor Flavor
-	if parts[0] == "" {
-		flavor = defaultFlavor
-	} else {
-		flavor = FlavorFromString(parts[0])
-	}
+	flavor := FlavorFromString(parts[0])
+	version := parts[1]
 
 	if len(parts) == 3 {
-		return NewDescriptorWithArch(flavor, parts[1], ArchitectureFromString(parts[2]))
+		return NewDescriptorWithArch(flavor, version, ArchitectureFromString(parts[2]))
 	}
 
-	return NewDescriptor(flavor, parts[1])
+	return NewDescriptor(flavor, version)
 }
 
 func (d Descriptor) Family() Family {

--- a/scenarios/aws/ec2/vm_run.go
+++ b/scenarios/aws/ec2/vm_run.go
@@ -23,7 +23,7 @@ func VMRun(ctx *pulumi.Context) error {
 		return err
 	}
 
-	osDesc := os.DescriptorFromString(env.InfraOSDescriptor(), os.Ubuntu)
+	osDesc := os.DescriptorFromString(env.InfraOSDescriptor(), os.AmazonLinuxECSDefault)
 	vm, err := NewVM(env, "vm", WithAMI(env.InfraOSImageID(), osDesc, osDesc.Architecture))
 	if err != nil {
 		return err
@@ -75,7 +75,7 @@ func VMRunWithDocker(ctx *pulumi.Context) error {
 	}
 
 	// If no OS is provided, we default to AmazonLinuxECS as it ships with Docker pre-installed
-	osDesc := os.DescriptorFromString(env.InfraOSDescriptor(), os.AmazonLinuxECS)
+	osDesc := os.DescriptorFromString(env.InfraOSDescriptor(), os.AmazonLinuxECSDefault)
 	vm, err := NewVM(env, "vm", WithAMI(env.InfraOSImageID(), osDesc, osDesc.Architecture))
 	if err != nil {
 		return err

--- a/scenarios/azure/compute/vm_run.go
+++ b/scenarios/azure/compute/vm_run.go
@@ -14,7 +14,7 @@ func VMRun(ctx *pulumi.Context) error {
 		return err
 	}
 
-	osDesc := os.DescriptorFromString(env.InfraOSDescriptor(), os.Ubuntu)
+	osDesc := os.DescriptorFromString(env.InfraOSDescriptor(), os.UbuntuDefault)
 	vm, err := NewVM(env, "vm", WithImageURN(env.InfraOSImageID(), osDesc, osDesc.Architecture))
 	if err != nil {
 		return err


### PR DESCRIPTION
What does this PR do?
---------------------

Default descriptor to a valid descriptor instead of to an os flavor

Which scenarios this will impact?
-------------------

docker and vm

Motivation
----------

The docker run function is currently broken, as it panics if a valid os descriptor is not defined on the config map

Additional Notes
----------------
