### PR TITLE
[host] increase agent installer curl retry

### DIFF
--- a/components/datadog/agent/host_linuxos.go
+++ b/components/datadog/agent/host_linuxos.go
@@ -51,7 +51,7 @@ func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersio
 	}
 
 	return fmt.Sprintf(
-		`curl -L https://s3.amazonaws.com/dd-agent/scripts/%v --retry 3 -o install-script.sh && for i in 1 2 3; do DD_API_KEY=%%s %v DD_INSTALL_ONLY=true bash install-script.sh  && break || sleep 2; done`,
+		`curl -L https://s3.amazonaws.com/dd-agent/scripts/%v --retry 10 -o install-script.sh && for i in 1 2 3; do DD_API_KEY=%%s %v DD_INSTALL_ONLY=true bash install-script.sh  && break || sleep 2; done`,
 		fmt.Sprintf("install_script_agent%s.sh", version.Major),
 		commandLine), nil
 }


### PR DESCRIPTION
What does this PR do?
---------------------

Increase `curl` retries to fetch the installer script from 3 to 10 

Which scenarios this will impact?
-------------------

Linux Host

Motivation
----------

We are seeing flakiness doe to an `SSL_ERROR_ZERO_RETURN` on curl on tests using this resource

Additional Notes
----------------
