### PR TITLE
export fakeintake when created within dockervm

### DIFF
--- a/scenarios/aws/ec2/vm_run.go
+++ b/scenarios/aws/ec2/vm_run.go
@@ -114,6 +114,14 @@ func VMRunWithDocker(ctx *pulumi.Context) error {
 			if err != nil {
 				return err
 			}
+
+			if err := fakeintake.Export(env.Ctx, nil); err != nil {
+				return err
+			}
+			if err != nil {
+				return err
+			}
+
 			agentOptions = append(agentOptions, dockeragentparams.WithFakeintake(fakeintake))
 		}
 


### PR DESCRIPTION
What does this PR do?
---------------------

This PR exports the fakeintake when created in the docker vm.


Which scenarios this will impact?
-------------------
- `aws/dockervm`

Motivation
----------
Currently, when a fakeintake is created within a dockervm scenario, it is not exported in the outputs of the stack. Exporting it is required because we need the fakeintake endpoint to initialize the fakeintake client in the e2e tests.
Additional Notes

----------------
