### PR TITLE
Add pulumi time resource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,11 +91,15 @@ RUN curl --retry 10 -fsSL https://get.pulumi.com/ | bash -s -- --version $PULUMI
   mv ~/.pulumi/bin/* /usr/bin
 
 # Install Pulumi plugins
+# The time resource is installed explicitly here instead in go.mod
+# because it's not used directly by this repository, thus go mod tidy
+# would remove it...
 COPY . /tmp/test-infra
 RUN cd /tmp/test-infra && \
   go mod download && \
   export PULUMI_CONFIG_PASSPHRASE=dummy && \
   pulumi --non-interactive plugin install && \
+  pulumi --non-interactive plugin install resource time v0.0.16 && \
   pulumi --non-interactive plugin ls && \
   cd / && \
   rm -rf /tmp/test-infra


### PR DESCRIPTION
What does this PR do?
---------------------
This PR adds the [Pulumi time resource](https://www.pulumi.com/registry/packages/time/installation-configuration/), necessary for Windows Domain Controllers creation.

Which scenarios this will impact?
-------------------
Windows Domain Controllers.

Motivation
----------
Working Windows Domain Controllers scenarios.

Additional Notes
----------------
Since this is not directly used by this repository, I added it as a `pulumi plugin install` command instead of an entry in the `go.mod` file, to prevent it from being removed by `go mod tidy`.
