### PR TITLE
fix docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,11 +13,13 @@ on:
     tags:
       - v*.*.*
     paths:
+      - .github/workflows/docker-publish.yml
       - components/datadog/apps/*/images/**
   pull_request:
     branches:
       - main
     paths:
+      - .github/workflows/docker-publish.yml
       - components/datadog/apps/*/images/**
 
 env:
@@ -28,7 +30,7 @@ env:
 
 
 jobs:
-  docker-build:
+  build:
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,7 @@ env:
 
 
 jobs:
-  build:
+  docker-build:
 
     runs-on: ubuntu-latest
     permissions:

--- a/components/datadog/apps/npm-tools/images/go-httpbin/Dockerfile
+++ b/components/datadog/apps/npm-tools/images/go-httpbin/Dockerfile
@@ -1,2 +1,1 @@
 FROM mccutchen/go-httpbin
-

--- a/components/datadog/apps/npm-tools/images/go-httpbin/Dockerfile
+++ b/components/datadog/apps/npm-tools/images/go-httpbin/Dockerfile
@@ -1,1 +1,2 @@
 FROM mccutchen/go-httpbin
+


### PR DESCRIPTION
What does this PR do?
---------------------

fix docker publish workflow
seems dd-merge-queue doesn't care about the main name of the workflow and build job conflict with the main job and didn't publish previous images from [PR](https://github.com/DataDog/test-infra-definitions/pull/612)

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
