### PR TITLE
Use separate network bridge for each VM set.

### DIFF
--- a/scenarios/aws/microVMs/microvms/libvirt.go
+++ b/scenarios/aws/microVMs/microvms/libvirt.go
@@ -81,7 +81,8 @@ type VMCollection struct {
 	vmsets   []vmconfig.VMSet
 	pools    map[vmconfig.PoolType]LibvirtPool
 	fs       map[vmconfig.VMSetID]*LibvirtFilesystem
-	domains  []*Domain
+	domains  map[vmconfig.VMSetID][]*Domain
+	subnets  map[vmconfig.VMSetID]string
 	LibvirtProvider
 }
 
@@ -177,39 +178,59 @@ func (vm *VMCollection) SetupCollectionDomainConfigurations(depends []pulumi.Res
 			}
 		}
 
-		vm.domains = append(vm.domains, domains...)
+		if _, ok := vm.domains[set.ID]; ok {
+			vm.domains[set.ID] = append(vm.domains[set.ID], domains...)
+		} else {
+			vm.domains[set.ID] = domains
+		}
 	}
 
 	return waitFor, nil
 }
 
 func (vm *VMCollection) SetupCollectionNetwork(depends []pulumi.Resource) error {
-	var dhcpEntries []interface{}
-	var err error
-
-	for _, d := range vm.domains {
-		dhcpEntries = append(dhcpEntries, d.dhcpEntry)
-
-	}
-
-	network, err := generateNetworkResource(vm.instance.e.Ctx, vm.libvirtProviderFn, depends, vm.instance.instanceNamer, dhcpEntries)
-	if err != nil {
-		return err
-	}
-
-	for _, domain := range vm.domains {
-		domain.domainArgs.NetworkInterfaces = libvirt.DomainNetworkInterfaceArray{
-			libvirt.DomainNetworkInterfaceArgs{
-				NetworkId:    network.ID(),
-				WaitForLease: pulumi.Bool(false),
-			},
+	dhcpEntries := make(map[vmconfig.VMSetID][]interface{})
+	for setID, dls := range vm.domains {
+		for _, domain := range dls {
+			if _, ok := dhcpEntries[setID]; ok {
+				dhcpEntries[setID] = append(dhcpEntries[setID], domain.dhcpEntry)
+			} else {
+				dhcpEntries[setID] = []interface{}{domain.dhcpEntry}
+			}
 		}
 	}
 
-	// set iptable rules for allowing ports to access NFS server
-	_, err = allowNFSPortsForBridge(vm.instance.e.Ctx, vm.instance.Arch == LocalVMSet, network.Bridge, vm.instance.runner, vm.instance.instanceNamer)
-	if err != nil {
-		return err
+	for setID, domains := range vm.domains {
+		network, err := generateNetworkResource(
+			vm.instance.e.Ctx,
+			vm.libvirtProviderFn,
+			depends,
+			vm.instance.instanceNamer,
+			dhcpEntries[setID],
+			vm.subnets[setID],
+			setID,
+		)
+		if err != nil {
+			return err
+		}
+
+		for _, domain := range domains {
+			if domain.vmset.ID != setID {
+				continue
+			}
+			domain.domainArgs.NetworkInterfaces = libvirt.DomainNetworkInterfaceArray{
+				libvirt.DomainNetworkInterfaceArgs{
+					NetworkId:    network.ID(),
+					WaitForLease: pulumi.Bool(false),
+				},
+			}
+		}
+
+		// set iptable rules for allowing ports to access NFS server
+		_, err = allowNFSPortsForBridge(vm.instance.e.Ctx, vm.instance.Arch == LocalVMSet, network.Bridge, vm.instance.runner, vm.instance.instanceNamer, vm.subnets[setID])
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -273,6 +294,9 @@ func BuildVMCollections(instances map[string]*Instance, vmsets []vmconfig.VMSet,
 			instance: instance,
 		}
 
+		collection.subnets = make(map[vmconfig.VMSetID]string)
+		collection.domains = make(map[vmconfig.VMSetID][]*Domain)
+
 		// We want to lazily initialize the libvirt provider.
 		// If there is too long a time between the provider being initialized,
 		// which essentially creates a connection with the libvirt daemon, and the provider
@@ -309,17 +333,19 @@ func BuildVMCollections(instances map[string]*Instance, vmsets []vmconfig.VMSet,
 		}
 		waitFor = append(waitFor, wait...)
 		// setup console logs
-		for _, domain := range collection.domains {
-			if domain.ConsoleType == "file" {
-				createConsoleLogFile, err := createDomainConsoleLog(collection.instance.runner,
-					domain.DomainName,
-					domain.domainNamer.ResourceName("create-console-log", domain.domainID),
-					depends,
-				)
-				if err != nil {
-					return vmCollections, waitFor, err
+		for _, dls := range collection.domains {
+			for _, domain := range dls {
+				if domain.ConsoleType == "file" {
+					createConsoleLogFile, err := createDomainConsoleLog(collection.instance.runner,
+						domain.DomainName,
+						domain.domainNamer.ResourceName("create-console-log", domain.domainID),
+						depends,
+					)
+					if err != nil {
+						return vmCollections, waitFor, err
+					}
+					waitFor = append(waitFor, createConsoleLogFile)
 				}
-				waitFor = append(waitFor, createConsoleLogFile)
 			}
 		}
 	}
@@ -327,7 +353,11 @@ func BuildVMCollections(instances map[string]*Instance, vmsets []vmconfig.VMSet,
 	// map domains to ips
 	var domains []*Domain
 	for _, collection := range vmCollections {
-		domains = append(domains, collection.domains...)
+		for _, dls := range collection.domains {
+			for _, domain := range dls {
+				domains = append(domains, domain)
+			}
+		}
 	}
 	// Sort the domains so the ips are mapped deterministically across updates
 	// Otherwise an update could compute the mapping to be different even if nothing
@@ -342,27 +372,41 @@ func BuildVMCollections(instances map[string]*Instance, vmsets []vmconfig.VMSet,
 	// Discover subnet to use for the network.
 	// This is done dynamically so we can have concurrent micro-vm groups
 	// active, without the network conflicting.
-	var err error
-	initMicroVMGroupSubnet.Do(func() {
-		microVMGroupSubnet, err = getMicroVMGroupSubnet()
-	})
-	if err != nil {
-		return vmCollections, waitFor, fmt.Errorf("generateNetworkResource: unable to find any free subnet")
-	}
-	ip, _, _ := net.ParseCIDR(microVMGroupSubnet)
-	// The first ip address is derived from the microvm subnet.
-	// The gateway ip address is xxx.yyy.zzz.1. So the first VM should have address xxx.yyy.zzz.2
-	// Therefore we call getNextVMIP consecutively to move start from xxx.yyy.zzz.2
-	ip = getNextVMIP(&ip)
-	for _, d := range domains {
-		ip = getNextVMIP(&ip)
-		d.ip = fmt.Sprintf("%s", ip)
-		d.dhcpEntry = generateDHCPEntry(d.mac, d.ip, d.domainID)
+	//
+	// Moreover, each vmset has its own subnet, so we need to dynamically
+	// determine free ranges.
+	for _, collection := range vmCollections {
+		var taken []string
+		for _, set := range collection.vmsets {
+			for _, subnet := range collection.subnets {
+				taken = append(taken, subnet)
+			}
+			microVMGroupSubnet, err := getMicroVMGroupSubnet(taken)
+			if err != nil {
+				return vmCollections, waitFor, fmt.Errorf("generateNetworkResource: unable to find any free subnet")
+			}
+			fmt.Printf("subnet: %s\n", microVMGroupSubnet)
+			collection.subnets[set.ID] = microVMGroupSubnet
+
+			ip, _, _ := net.ParseCIDR(microVMGroupSubnet)
+			// The first ip address is derived from the microvm subnet.
+			// The gateway ip address is xxx.yyy.zzz.1. So the first VM should have address xxx.yyy.zzz.2
+			// Therefore we call getNextVMIP consecutively to move start from xxx.yyy.zzz.2
+			ip = getNextVMIP(&ip)
+			for _, d := range domains {
+				if d.vmset.ID != set.ID {
+					continue
+				}
+				ip = getNextVMIP(&ip)
+				d.ip = fmt.Sprintf("%s", ip)
+				d.dhcpEntry = generateDHCPEntry(d.mac, d.ip, d.domainID)
+			}
+		}
 	}
 
+	// setup the network for each collection
 	// Network setup has to be done after the dhcp entries have been generated for each domain
 	for _, collection := range vmCollections {
-		// setup the network for each collection
 		if err := collection.SetupCollectionNetwork(waitFor); err != nil {
 			return vmCollections, waitFor, err
 		}
@@ -380,23 +424,25 @@ func LaunchVMCollections(vmCollections []*VMCollection, depends []pulumi.Resourc
 		if err != nil {
 			return libvirtDomains, err
 		}
-		for _, domain := range collection.domains {
-			d, err := libvirt.NewDomain(collection.instance.e.Ctx,
-				domain.domainNamer.ResourceName(domain.domainID),
-				domain.domainArgs,
-				pulumi.Provider(provider),
-				pulumi.ReplaceOnChanges([]string{"*"}),
-				pulumi.DeleteBeforeReplace(true),
-				pulumi.DependsOn(depends),
-				// Pulumi incorrectly detects these as changing everytime.
-				pulumi.IgnoreChanges([]string{"filesystems", "firmware", "nvram"}),
-			)
-			if err != nil {
-				return libvirtDomains, err
-			}
-			domain.lvDomain = d
+		for _, dls := range collection.domains {
+			for _, domain := range dls {
+				d, err := libvirt.NewDomain(collection.instance.e.Ctx,
+					domain.domainNamer.ResourceName(domain.domainID),
+					domain.domainArgs,
+					pulumi.Provider(provider),
+					pulumi.ReplaceOnChanges([]string{"*"}),
+					pulumi.DeleteBeforeReplace(true),
+					pulumi.DependsOn(depends),
+					// Pulumi incorrectly detects these as changing everytime.
+					pulumi.IgnoreChanges([]string{"filesystems", "firmware", "nvram"}),
+				)
+				if err != nil {
+					return libvirtDomains, err
+				}
+				domain.lvDomain = d
 
-			libvirtDomains = append(libvirtDomains, d)
+				libvirtDomains = append(libvirtDomains, d)
+			}
 		}
 	}
 

--- a/scenarios/aws/microVMs/microvms/libvirt.go
+++ b/scenarios/aws/microVMs/microvms/libvirt.go
@@ -178,11 +178,7 @@ func (vm *VMCollection) SetupCollectionDomainConfigurations(depends []pulumi.Res
 			}
 		}
 
-		if _, ok := vm.domains[set.ID]; ok {
-			vm.domains[set.ID] = append(vm.domains[set.ID], domains...)
-		} else {
-			vm.domains[set.ID] = domains
-		}
+		vm.domains[set.ID] = append(vm.domains[set.ID], domains...)
 	}
 
 	return waitFor, nil

--- a/scenarios/aws/microVMs/microvms/libvirt.go
+++ b/scenarios/aws/microVMs/microvms/libvirt.go
@@ -188,11 +188,7 @@ func (vm *VMCollection) SetupCollectionNetwork(depends []pulumi.Resource) error 
 	dhcpEntries := make(map[vmconfig.VMSetID][]interface{})
 	for setID, dls := range vm.domains {
 		for _, domain := range dls {
-			if _, ok := dhcpEntries[setID]; ok {
-				dhcpEntries[setID] = append(dhcpEntries[setID], domain.dhcpEntry)
-			} else {
-				dhcpEntries[setID] = []interface{}{domain.dhcpEntry}
-			}
+			dhcpEntries[setID] = append(dhcpEntries[setID], domain.dhcpEntry)
 		}
 	}
 

--- a/scenarios/aws/microVMs/microvms/network.go
+++ b/scenarios/aws/microVMs/microvms/network.go
@@ -158,6 +158,8 @@ func generateNetworkResource(
 	network, err := libvirt.NewNetwork(ctx, resourceNamer.ResourceName("network", setID.String()), &libvirt.NetworkArgs{
 		Addresses: pulumi.StringArray{pulumi.String(microVMGroupSubnet)},
 		Mode:      pulumi.String("nat"),
+		// enable jumbo frames for the underlying interface. This is an optimization for NFS.
+		Mtu: pulumi.Int(9000),
 		Xml: libvirt.NetworkXmlArgs{
 			Xslt: netXML,
 		},

--- a/scenarios/aws/microVMs/microvms/network.go
+++ b/scenarios/aws/microVMs/microvms/network.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/common/namer"
 	"github.com/DataDog/test-infra-definitions/components/command"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/microVMs/microvms/resources"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/microVMs/vmconfig"
 )
 
 // The microvm subnet changed from /16 to /24 because the underlying libvirt sdk would identify
@@ -31,7 +32,6 @@ const iptablesTCPRule = "iptables %s INPUT -p tcp -i %s -s %s -m multiport --dpo
 const iptablesUDPRule = "iptables %s INPUT -p udp -i %s -s %s -m multiport --dports $(%s) -j ACCEPT"
 
 var initMicroVMGroupSubnet sync.Once
-var microVMGroupSubnet string
 
 func freeSubnet(subnet string) (bool, error) {
 	startIP, _, err := net.ParseCIDR(subnet)
@@ -69,9 +69,22 @@ func getMicroVMGroupSubnetPattern(subnet string) string {
 	return fmt.Sprintf("%d.%d.%d.*", ipv4[0], ipv4[1], ipv4[2])
 }
 
-func getMicroVMGroupSubnet() (string, error) {
+func subnetIsTaken(taken []string, subnet string) bool {
+	for _, t := range taken {
+		if t == subnet {
+			return true
+		}
+	}
+
+	return false
+}
+
+func getMicroVMGroupSubnet(taken []string) (string, error) {
 	for i := 1; i < 254; i++ {
 		subnet := fmt.Sprintf(microVMGroupSubnetTemplate, i)
+		if subnetIsTaken(taken, subnet) {
+			continue
+		}
 		if free, err := freeSubnet(subnet); err == nil && free {
 			return subnet, nil
 		}
@@ -80,7 +93,7 @@ func getMicroVMGroupSubnet() (string, error) {
 	return "", fmt.Errorf("getMicroVMGroupSubnet: could not find subnet")
 }
 
-func allowNFSPortsForBridge(ctx *pulumi.Context, isLocal bool, bridge pulumi.StringOutput, runner *Runner, resourceNamer namer.Namer) ([]pulumi.Resource, error) {
+func allowNFSPortsForBridge(ctx *pulumi.Context, isLocal bool, bridge pulumi.StringOutput, runner *Runner, resourceNamer namer.Namer, microVMGroupSubnet string) ([]pulumi.Resource, error) {
 	sudoPassword := GetSudoPassword(ctx, isLocal)
 	iptablesAllowTCPArgs := command.Args{
 		Create:                   pulumi.Sprintf(iptablesTCPRule, iptablesAddRuleFlag, bridge, microVMGroupSubnet, tcpRPCInfoPorts),
@@ -89,7 +102,7 @@ func allowNFSPortsForBridge(ctx *pulumi.Context, isLocal bool, bridge pulumi.Str
 		RequirePasswordFromStdin: true,
 		Stdin:                    sudoPassword,
 	}
-	iptablesAllowTCPDone, err := runner.Command(resourceNamer.ResourceName("allow-nfs-ports-tcp"), &iptablesAllowTCPArgs)
+	iptablesAllowTCPDone, err := runner.Command(resourceNamer.ResourceName("allow-nfs-ports-tcp", microVMGroupSubnet), &iptablesAllowTCPArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -101,7 +114,7 @@ func allowNFSPortsForBridge(ctx *pulumi.Context, isLocal bool, bridge pulumi.Str
 		RequirePasswordFromStdin: true,
 		Stdin:                    sudoPassword,
 	}
-	iptablesAllowUDPDone, err := runner.Command(resourceNamer.ResourceName("allow-nfs-ports-udp"), &iptablesAllowUDPArgs)
+	iptablesAllowUDPDone, err := runner.Command(resourceNamer.ResourceName("allow-nfs-ports-udp", microVMGroupSubnet), &iptablesAllowUDPArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +122,15 @@ func allowNFSPortsForBridge(ctx *pulumi.Context, isLocal bool, bridge pulumi.Str
 	return []pulumi.Resource{iptablesAllowTCPDone, iptablesAllowUDPDone}, nil
 }
 
-func generateNetworkResource(ctx *pulumi.Context, providerFn LibvirtProviderFn, depends []pulumi.Resource, resourceNamer namer.Namer, dhcpEntries []interface{}) (*libvirt.Network, error) {
+func generateNetworkResource(
+	ctx *pulumi.Context,
+	providerFn LibvirtProviderFn,
+	depends []pulumi.Resource,
+	resourceNamer namer.Namer,
+	dhcpEntries []interface{},
+	microVMGroupSubnet string,
+	setID vmconfig.VMSetID,
+) (*libvirt.Network, error) {
 	// Collect all DHCP entries in a single string to be
 	// formatted in network XML.
 	dhcpEntriesJoined := pulumi.All(dhcpEntries...).ApplyT(
@@ -134,7 +155,7 @@ func generateNetworkResource(ctx *pulumi.Context, providerFn LibvirtProviderFn, 
 			resources.DHCPEntries: dhcpEntriesJoined,
 		},
 	)
-	network, err := libvirt.NewNetwork(ctx, resourceNamer.ResourceName("network"), &libvirt.NetworkArgs{
+	network, err := libvirt.NewNetwork(ctx, resourceNamer.ResourceName("network", setID.String()), &libvirt.NetworkArgs{
 		Addresses: pulumi.StringArray{pulumi.String(microVMGroupSubnet)},
 		Mode:      pulumi.String("nat"),
 		Xml: libvirt.NetworkXmlArgs{

--- a/scenarios/aws/microVMs/microvms/provision.go
+++ b/scenarios/aws/microVMs/microvms/provision.go
@@ -40,7 +40,7 @@ func setupMicroVMSSHConfig(instance *Instance, subnets map[vmconfig.VMSetID]stri
 	createSSHDirArgs := command.Args{
 		Create: pulumi.Sprintf("mkdir -p /home/ubuntu/.ssh && chmod 700 /home/ubuntu/.ssh"),
 	}
-	createDirDone, err := instance.runner.Command(instance.instanceNamer.ResourceName("add-microvm-ssh-dir", microVMIPSubnet), &createSSHDirArgs, pulumi.DependsOn(depends))
+	createDirDone, err := instance.runner.Command(instance.instanceNamer.ResourceName("add-microvm-ssh-dir"), &createSSHDirArgs, pulumi.DependsOn(depends))
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func setupMicroVMSSHConfig(instance *Instance, subnets map[vmconfig.VMSetID]stri
 	args := command.Args{
 		Create: pulumi.Sprintf(`echo -e "%s" | tee /home/ubuntu/.ssh/config && chmod 600 /home/ubuntu/.ssh/config`, config.String()),
 	}
-	done, err := instance.runner.Command(instance.instanceNamer.ResourceName("add-microvm-ssh-config", microVMIPSubnet), &args, pulumi.DependsOn([]pulumi.Resource{createDirDone}))
+	done, err := instance.runner.Command(instance.instanceNamer.ResourceName("add-microvm-ssh-config"), &args, pulumi.DependsOn([]pulumi.Resource{createDirDone}))
 	if err != nil {
 		return nil, err
 	}

--- a/scenarios/aws/microVMs/microvms/provision.go
+++ b/scenarios/aws/microVMs/microvms/provision.go
@@ -1,7 +1,9 @@
 package microvms
 
 import (
+	"fmt"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -11,6 +13,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/components/command"
 	remoteComp "github.com/DataDog/test-infra-definitions/components/remote"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/microVMs/microvms/resources"
+	"github.com/DataDog/test-infra-definitions/scenarios/aws/microVMs/vmconfig"
 )
 
 const DockerMountpoint = "/mnt/docker"
@@ -33,7 +36,7 @@ func GetSudoPassword(ctx *pulumi.Context, isLocal bool) pulumi.StringOutput {
 	return SudoPasswordRemote
 }
 
-func setupMicroVMSSHConfig(instance *Instance, microVMIPSubnet string, depends []pulumi.Resource) ([]pulumi.Resource, error) {
+func setupMicroVMSSHConfig(instance *Instance, subnets map[vmconfig.VMSetID]string, depends []pulumi.Resource) ([]pulumi.Resource, error) {
 	createSSHDirArgs := command.Args{
 		Create: pulumi.Sprintf("mkdir -p /home/ubuntu/.ssh && chmod 700 /home/ubuntu/.ssh"),
 	}
@@ -42,9 +45,13 @@ func setupMicroVMSSHConfig(instance *Instance, microVMIPSubnet string, depends [
 		return nil, err
 	}
 
-	pattern := getMicroVMGroupSubnetPattern(microVMIPSubnet)
+	var config strings.Builder
+	for _, subnet := range subnets {
+		pattern := getMicroVMGroupSubnetPattern(subnet)
+		fmt.Fprintf(&config, "Host %s\nIdentityFile %s\nUser root\nStrictHostKeyChecking no\n", pattern, filepath.Join(GetWorkingDirectory(), "ddvm_rsa"))
+	}
 	args := command.Args{
-		Create: pulumi.Sprintf(`echo -e "Host %s\nIdentityFile %s\nUser root\nStrictHostKeyChecking no\n" | tee /home/ubuntu/.ssh/config && chmod 600 /home/ubuntu/.ssh/config`, pattern, filepath.Join(GetWorkingDirectory(), "ddvm_rsa")),
+		Create: pulumi.Sprintf(`echo -e "%s" | tee /home/ubuntu/.ssh/config && chmod 600 /home/ubuntu/.ssh/config`, config.String()),
 	}
 	done, err := instance.runner.Command(instance.instanceNamer.ResourceName("add-microvm-ssh-config", microVMIPSubnet), &args, pulumi.DependsOn([]pulumi.Resource{createDirDone}))
 	if err != nil {
@@ -185,13 +192,9 @@ func provisionRemoteMicroVMs(vmCollections []*VMCollection, instanceEnv *Instanc
 	var waitFor []pulumi.Resource
 
 	for _, collection := range vmCollections {
-		var sshConfigDone []pulumi.Resource
-		for _, subnet := range collection.subnets {
-			done, err := setupMicroVMSSHConfig(collection.instance, subnet, waitFor)
-			if err != nil {
-				return nil, err
-			}
-			sshConfigDone = append(sshConfigDone, done...)
+		sshConfigDone, err := setupMicroVMSSHConfig(collection.instance, collection.subnets, waitFor)
+		if err != nil {
+			return nil, err
 		}
 
 		microVMSSHKey, readKeyDone, err := readMicroVMSSHKey(collection.instance, sshConfigDone)

--- a/scenarios/aws/microVMs/microvms/provision.go
+++ b/scenarios/aws/microVMs/microvms/provision.go
@@ -187,7 +187,7 @@ func provisionRemoteMicroVMs(vmCollections []*VMCollection, instanceEnv *Instanc
 	for _, collection := range vmCollections {
 		var sshConfigDone []pulumi.Resource
 		for _, subnet := range collection.subnets {
-			done, err := setupMicroVMSSHConfig(collection.instance, collection.subnets[setID], waitFor)
+			done, err := setupMicroVMSSHConfig(collection.instance, subnet, waitFor)
 			if err != nil {
 				return nil, err
 			}
@@ -199,7 +199,7 @@ func provisionRemoteMicroVMs(vmCollections []*VMCollection, instanceEnv *Instanc
 			return nil, err
 		}
 
-		for setID, domains := range collection.domains {
+		for _, domains := range collection.domains {
 			if collection.instance.Arch == LocalVMSet {
 				continue
 			}

--- a/scenarios/aws/microVMs/microvms/provision.go
+++ b/scenarios/aws/microVMs/microvms/provision.go
@@ -185,9 +185,13 @@ func provisionRemoteMicroVMs(vmCollections []*VMCollection, instanceEnv *Instanc
 	var waitFor []pulumi.Resource
 
 	for _, collection := range vmCollections {
-		sshConfigDone, err := setupMicroVMSSHConfig(collection.instance, collection.subnets[setID], waitFor)
-		if err != nil {
-			return nil, err
+		var sshConfigDone []pulumi.Resource
+		for _, subnet := range collection.subnets {
+			done, err := setupMicroVMSSHConfig(collection.instance, collection.subnets[setID], waitFor)
+			if err != nil {
+				return nil, err
+			}
+			sshConfigDone = append(sshConfigDone, done...)
 		}
 
 		microVMSSHKey, readKeyDone, err := readMicroVMSSHKey(collection.instance, sshConfigDone)

--- a/scenarios/aws/microVMs/microvms/provision.go
+++ b/scenarios/aws/microVMs/microvms/provision.go
@@ -192,6 +192,10 @@ func provisionRemoteMicroVMs(vmCollections []*VMCollection, instanceEnv *Instanc
 	var waitFor []pulumi.Resource
 
 	for _, collection := range vmCollections {
+		if collection.instance.Arch == LocalVMSet {
+			continue
+		}
+
 		sshConfigDone, err := setupMicroVMSSHConfig(collection.instance, collection.subnets, waitFor)
 		if err != nil {
 			return nil, err
@@ -203,10 +207,6 @@ func provisionRemoteMicroVMs(vmCollections []*VMCollection, instanceEnv *Instanc
 		}
 
 		for _, domains := range collection.domains {
-			if collection.instance.Arch == LocalVMSet {
-				continue
-			}
-
 			for _, domain := range domains {
 				if domain.lvDomain == nil {
 					continue

--- a/scenarios/aws/microVMs/microvms/provision.go
+++ b/scenarios/aws/microVMs/microvms/provision.go
@@ -185,19 +185,19 @@ func provisionRemoteMicroVMs(vmCollections []*VMCollection, instanceEnv *Instanc
 	var waitFor []pulumi.Resource
 
 	for _, collection := range vmCollections {
+		sshConfigDone, err := setupMicroVMSSHConfig(collection.instance, collection.subnets[setID], waitFor)
+		if err != nil {
+			return nil, err
+		}
+
+		microVMSSHKey, readKeyDone, err := readMicroVMSSHKey(collection.instance, sshConfigDone)
+		if err != nil {
+			return nil, err
+		}
+
 		for setID, domains := range collection.domains {
 			if collection.instance.Arch == LocalVMSet {
 				continue
-			}
-
-			sshConfigDone, err := setupMicroVMSSHConfig(collection.instance, collection.subnets[setID], waitFor)
-			if err != nil {
-				return nil, err
-			}
-
-			microVMSSHKey, readKeyDone, err := readMicroVMSSHKey(collection.instance, sshConfigDone)
-			if err != nil {
-				return nil, err
 			}
 
 			for _, domain := range domains {

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -256,18 +256,20 @@ func exportVMInformation(ctx *pulumi.Context, instances map[string]*Instance, vm
 			if collection.instance.Arch != arch {
 				continue
 			}
-			for _, domain := range collection.domains {
-				var tags []pulumi.Output
-				for _, tag := range domain.vmset.Tags {
-					tags = append(tags, pulumi.ToOutput(tag))
+			for _, dls := range collection.domains {
+				for _, domain := range dls {
+					var tags []pulumi.Output
+					for _, tag := range domain.vmset.Tags {
+						tags = append(tags, pulumi.ToOutput(tag))
+					}
+					vms = append(vms, pulumi.ToMapOutput(map[string]pulumi.Output{
+						"id":           pulumi.ToOutput(domain.domainID),
+						"ip":           pulumi.ToOutput(domain.ip),
+						"tag":          pulumi.ToOutput(domain.tag),
+						"vmset-tags":   pulumi.ToArrayOutput(tags),
+						"ssh-key-path": pulumi.ToOutput(filepath.Join(GetWorkingDirectory(), "ddvm_rsa")),
+					}))
 				}
-				vms = append(vms, pulumi.ToMapOutput(map[string]pulumi.Output{
-					"id":           pulumi.ToOutput(domain.domainID),
-					"ip":           pulumi.ToOutput(domain.ip),
-					"tag":          pulumi.ToOutput(domain.tag),
-					"vmset-tags":   pulumi.ToArrayOutput(tags),
-					"ssh-key-path": pulumi.ToOutput(filepath.Join(GetWorkingDirectory(), "ddvm_rsa")),
-				}))
 			}
 		}
 

--- a/scenarios/aws/microVMs/vmconfig/config.go
+++ b/scenarios/aws/microVMs/vmconfig/config.go
@@ -4,6 +4,10 @@ type PoolType string
 
 type VMSetID string
 
+func (id VMSetID) String() string {
+	return string(id)
+}
+
 const (
 	RecipeCustomAMD64 = "custom-x86_64"
 	RecipeCustomARM64 = "custom-arm64"


### PR DESCRIPTION
What does this PR do?
---------------------
This PR uses a separate network bridge for each VM set.
It also set the MTU size of the network bridge to 9000.
[This PR](https://github.com/DataDog/ami-builder/pull/157) in ami-builder sets the corresponding MTUs of the VM interfaces to match this.

Which scenarios this will impact?
-------------------
`aws/microvms` only

Motivation
----------
We noticed the network read path to the NFS server experiencing latency causing problem with tests in KMT.
One possible culprit in this path is the shared network bridge between all the VMs and the host. This PR tries to alleviate pressure on the bridge by a assigning each vmset a different one.

Additional Notes
----------------
