### PR TITLE
[CONTINT-3783] Add tracegen app to eks and kind scenarios

### DIFF
--- a/components/datadog/apps/tracegen/k8s.go
+++ b/components/datadog/apps/tracegen/k8s.go
@@ -17,21 +17,7 @@ type K8sComponent struct {
 	pulumi.ResourceState
 }
 
-func nodeSelector(nodeGroups pulumi.StringArrayInput) pulumi.StringMapInput {
-	return nodeGroups.ToStringArrayOutput().ApplyT(
-		func(arr []string) pulumi.StringMapInput {
-			for _, ng := range arr {
-				if ng != "" {
-					return pulumi.StringMap{
-						"eks.amazonaws.com/nodegroup": pulumi.String(ng),
-					}
-				}
-			}
-			return nil
-		}).(pulumi.StringMapInput)
-}
-
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, traceAgentURL string, nodeGroups pulumi.StringArrayInput, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, traceAgentURL string, nodeGroup pulumi.StringInput, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &K8sComponent{}
@@ -76,7 +62,9 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 					},
 				},
 				Spec: &corev1.PodSpecArgs{
-					NodeSelector: nodeSel,
+					NodeSelector: pulumi.StringMap{
+						"eks.amazonaws.com/nodegroup": nodeGroup,
+					},
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("tracegen"),

--- a/components/datadog/apps/tracegen/k8s.go
+++ b/components/datadog/apps/tracegen/k8s.go
@@ -1,0 +1,197 @@
+package tracegen
+
+import (
+	"fmt"
+
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/common/utils"
+
+	"github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes"
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/apps/v1"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v3/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+type K8sComponent struct {
+	pulumi.ResourceState
+}
+
+func nodeGroupAffinity(nodeGroups pulumi.StringArray) corev1.AffinityPtrInput {
+	if len(nodeGroups) == 0 {
+		return nil
+	}
+	return &corev1.AffinityArgs{
+		NodeAffinity: &corev1.NodeAffinityArgs{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelectorArgs{
+				NodeSelectorTerms: corev1.NodeSelectorTermArray{
+					&corev1.NodeSelectorTermArgs{
+						MatchExpressions: corev1.NodeSelectorRequirementArray{
+							&corev1.NodeSelectorRequirementArgs{
+								Key:      pulumi.String("eks.amazonaws.com/nodegroup"),
+								Operator: pulumi.String("In"),
+								Values:   nodeGroups,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, traceAgentURL string, nodeGroups pulumi.StringArray, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
+	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
+
+	k8sComponent := &K8sComponent{}
+	if err := e.Ctx.RegisterComponentResource("dd:apps", fmt.Sprintf("%s/tracegen", namespace), k8sComponent, opts...); err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, pulumi.Parent(k8sComponent))
+
+	ns, err := corev1.NewNamespace(e.Ctx, namespace, &corev1.NamespaceArgs{
+		Metadata: metav1.ObjectMetaArgs{
+			Name: pulumi.String(namespace),
+		},
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	affinity := nodeGroupAffinity(nodeGroups)
+
+	opts = append(opts, utils.PulumiDependsOn(ns))
+
+	if _, err := appsv1.NewDeployment(e.Ctx, fmt.Sprintf("%s/tracegen-uds", namespace), &appsv1.DeploymentArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.String("tracegen-uds"),
+			Namespace: pulumi.String(namespace),
+			Labels: pulumi.StringMap{
+				"app": pulumi.String("tracegen-uds"),
+			},
+		},
+		Spec: &appsv1.DeploymentSpecArgs{
+			Replicas: pulumi.Int(1),
+			Selector: &metav1.LabelSelectorArgs{
+				MatchLabels: pulumi.StringMap{
+					"app": pulumi.String("tracegen-uds"),
+				},
+			},
+			Template: &corev1.PodTemplateSpecArgs{
+				Metadata: &metav1.ObjectMetaArgs{
+					Labels: pulumi.StringMap{
+						"app": pulumi.String("tracegen-uds"),
+					},
+				},
+				Spec: &corev1.PodSpecArgs{
+					Affinity: affinity,
+					Containers: corev1.ContainerArray{
+						&corev1.ContainerArgs{
+							Name:  pulumi.String("tracegen"),
+							Image: pulumi.String("ghcr.io/datadog/apps-tracegen:main"),
+							Env: &corev1.EnvVarArray{
+								&corev1.EnvVarArgs{
+									Name:  pulumi.String("DD_TRACE_AGENT_URL"),
+									Value: pulumi.String(traceAgentURL),
+								},
+							},
+							Resources: &corev1.ResourceRequirementsArgs{
+								Limits: pulumi.StringMap{
+									"cpu":    pulumi.String("100m"),
+									"memory": pulumi.String("32Mi"),
+								},
+								Requests: pulumi.StringMap{
+									"cpu":    pulumi.String("10m"),
+									"memory": pulumi.String("32Mi"),
+								},
+							},
+							VolumeMounts: &corev1.VolumeMountArray{
+								&corev1.VolumeMountArgs{
+									Name:      pulumi.String("apmsocketpath"),
+									MountPath: pulumi.String("/var/run/datadog"),
+								},
+							},
+						},
+					},
+					Volumes: corev1.VolumeArray{
+						&corev1.VolumeArgs{
+							Name: pulumi.String("apmsocketpath"),
+							HostPath: &corev1.HostPathVolumeSourceArgs{
+								Path: pulumi.String("/var/run/datadog"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}, opts...); err != nil {
+		return nil, err
+	}
+
+	if _, err := appsv1.NewDeployment(e.Ctx, fmt.Sprintf("%s/tracegen-udp", namespace), &appsv1.DeploymentArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.String("tracegen-udp"),
+			Namespace: pulumi.String(namespace),
+			Labels: pulumi.StringMap{
+				"app": pulumi.String("tracegen-udp"),
+			},
+		},
+		Spec: &appsv1.DeploymentSpecArgs{
+			Replicas: pulumi.Int(1),
+			Selector: &metav1.LabelSelectorArgs{
+				MatchLabels: pulumi.StringMap{
+					"app": pulumi.String("tracegen-udp"),
+				},
+			},
+			Template: &corev1.PodTemplateSpecArgs{
+				Metadata: &metav1.ObjectMetaArgs{
+					Labels: pulumi.StringMap{
+						"app": pulumi.String("tracegen-udp"),
+					},
+				},
+				Spec: &corev1.PodSpecArgs{
+					Affinity: affinity,
+					Containers: corev1.ContainerArray{
+						&corev1.ContainerArgs{
+							Name:  pulumi.String("tracegen-udp"),
+							Image: pulumi.String("ghcr.io/datadog/apps-tracegen:main"),
+							Env: &corev1.EnvVarArray{
+								&corev1.EnvVarArgs{
+									Name: pulumi.String("DD_AGENT_HOST"),
+									ValueFrom: &corev1.EnvVarSourceArgs{
+										FieldRef: &corev1.ObjectFieldSelectorArgs{
+											FieldPath: pulumi.String("status.hostIP"),
+										},
+									},
+								},
+								&corev1.EnvVarArgs{
+									Name: pulumi.String("DD_ENTITY_ID"),
+									ValueFrom: &corev1.EnvVarSourceArgs{
+										FieldRef: &corev1.ObjectFieldSelectorArgs{
+											FieldPath: pulumi.String("metadata.uid"),
+										},
+									},
+								},
+							},
+							Resources: &corev1.ResourceRequirementsArgs{
+								Limits: pulumi.StringMap{
+									"cpu":    pulumi.String("10m"),
+									"memory": pulumi.String("32Mi"),
+								},
+								Requests: pulumi.StringMap{
+									"cpu":    pulumi.String("2m"),
+									"memory": pulumi.String("32Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, opts...); err != nil {
+		return nil, err
+	}
+
+	return k8sComponent, nil
+}

--- a/components/datadog/apps/tracegen/k8s.go
+++ b/components/datadog/apps/tracegen/k8s.go
@@ -65,7 +65,7 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 					},
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
-							Name:  pulumi.String("tracegen"),
+							Name:  pulumi.String("tracegen-uds"),
 							Image: pulumi.String("ghcr.io/datadog/apps-tracegen:main"),
 							Env: &corev1.EnvVarArray{
 								&corev1.EnvVarArgs{
@@ -75,11 +75,11 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 							},
 							Resources: &corev1.ResourceRequirementsArgs{
 								Limits: pulumi.StringMap{
-									"cpu":    pulumi.String("100m"),
+									"cpu":    pulumi.String("10m"),
 									"memory": pulumi.String("32Mi"),
 								},
 								Requests: pulumi.StringMap{
-									"cpu":    pulumi.String("10m"),
+									"cpu":    pulumi.String("2m"),
 									"memory": pulumi.String("32Mi"),
 								},
 							},

--- a/components/datadog/apps/tracegen/k8s.go
+++ b/components/datadog/apps/tracegen/k8s.go
@@ -17,7 +17,7 @@ type K8sComponent struct {
 	pulumi.ResourceState
 }
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, traceAgentURL string, nodeGroup pulumi.StringInput, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, nodeGroup pulumi.StringInput, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &K8sComponent{}
@@ -70,7 +70,7 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 							Env: &corev1.EnvVarArray{
 								&corev1.EnvVarArgs{
 									Name:  pulumi.String("DD_TRACE_AGENT_URL"),
-									Value: pulumi.String(traceAgentURL),
+									Value: pulumi.String("/var/run/datadog/apm.socket"),
 								},
 							},
 							Resources: &corev1.ResourceRequirementsArgs{

--- a/components/datadog/apps/tracegen/k8s.go
+++ b/components/datadog/apps/tracegen/k8s.go
@@ -132,32 +132,32 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 		return nil, err
 	}
 
-	if _, err := appsv1.NewDeployment(e.Ctx, fmt.Sprintf("%s/tracegen-udp", namespace), &appsv1.DeploymentArgs{
+	if _, err := appsv1.NewDeployment(e.Ctx, fmt.Sprintf("%s/tracegen-tcp", namespace), &appsv1.DeploymentArgs{
 		Metadata: &metav1.ObjectMetaArgs{
-			Name:      pulumi.String("tracegen-udp"),
+			Name:      pulumi.String("tracegen-tcp"),
 			Namespace: pulumi.String(namespace),
 			Labels: pulumi.StringMap{
-				"app": pulumi.String("tracegen-udp"),
+				"app": pulumi.String("tracegen-tcp"),
 			},
 		},
 		Spec: &appsv1.DeploymentSpecArgs{
 			Replicas: pulumi.Int(1),
 			Selector: &metav1.LabelSelectorArgs{
 				MatchLabels: pulumi.StringMap{
-					"app": pulumi.String("tracegen-udp"),
+					"app": pulumi.String("tracegen-tcp"),
 				},
 			},
 			Template: &corev1.PodTemplateSpecArgs{
 				Metadata: &metav1.ObjectMetaArgs{
 					Labels: pulumi.StringMap{
-						"app": pulumi.String("tracegen-udp"),
+						"app": pulumi.String("tracegen-tcp"),
 					},
 				},
 				Spec: &corev1.PodSpecArgs{
 					Affinity: affinity,
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
-							Name:  pulumi.String("tracegen-udp"),
+							Name:  pulumi.String("tracegen-tcp"),
 							Image: pulumi.String("ghcr.io/datadog/apps-tracegen:main"),
 							Env: &corev1.EnvVarArray{
 								&corev1.EnvVarArgs{

--- a/components/datadog/apps/tracegen/k8s.go
+++ b/components/datadog/apps/tracegen/k8s.go
@@ -36,8 +36,6 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 		return nil, err
 	}
 
-	nodeSel := nodeSelector(nodeGroups)
-
 	opts = append(opts, utils.PulumiDependsOn(ns))
 
 	if _, err := appsv1.NewDeployment(e.Ctx, fmt.Sprintf("%s/tracegen-uds", namespace), &appsv1.DeploymentArgs{
@@ -130,7 +128,6 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 					},
 				},
 				Spec: &corev1.PodSpecArgs{
-					NodeSelector: nodeSel,
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("tracegen-tcp"),

--- a/components/datadog/apps/tracegen/k8s.go
+++ b/components/datadog/apps/tracegen/k8s.go
@@ -141,7 +141,6 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 										},
 									},
 								},
-								&corev1.EnvVarArgs{},
 							},
 							Resources: &corev1.ResourceRequirementsArgs{
 								Limits: pulumi.StringMap{

--- a/components/datadog/apps/tracegen/k8s.go
+++ b/components/datadog/apps/tracegen/k8s.go
@@ -168,14 +168,7 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 										},
 									},
 								},
-								&corev1.EnvVarArgs{
-									Name: pulumi.String("DD_ENTITY_ID"),
-									ValueFrom: &corev1.EnvVarSourceArgs{
-										FieldRef: &corev1.ObjectFieldSelectorArgs{
-											FieldPath: pulumi.String("metadata.uid"),
-										},
-									},
-								},
+								&corev1.EnvVarArgs{},
 							},
 							Resources: &corev1.ResourceRequirementsArgs{
 								Limits: pulumi.StringMap{

--- a/components/datadog/apps/tracegen/k8s.go
+++ b/components/datadog/apps/tracegen/k8s.go
@@ -128,6 +128,9 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 					},
 				},
 				Spec: &corev1.PodSpecArgs{
+					NodeSelector: pulumi.StringMap{
+						"eks.amazonaws.com/nodegroup": nodeGroup,
+					},
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("tracegen-tcp"),

--- a/components/datadog/apps/tracegen/k8s.go
+++ b/components/datadog/apps/tracegen/k8s.go
@@ -17,7 +17,7 @@ type K8sComponent struct {
 	pulumi.ResourceState
 }
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, nodeGroup pulumi.StringInput, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, nodeSelector pulumi.StringMapInput, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &K8sComponent{}
@@ -60,9 +60,7 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 					},
 				},
 				Spec: &corev1.PodSpecArgs{
-					NodeSelector: pulumi.StringMap{
-						"eks.amazonaws.com/nodegroup": nodeGroup,
-					},
+					NodeSelector: nodeSelector,
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("tracegen-uds"),
@@ -128,9 +126,7 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 					},
 				},
 				Spec: &corev1.PodSpecArgs{
-					NodeSelector: pulumi.StringMap{
-						"eks.amazonaws.com/nodegroup": nodeGroup,
-					},
+					NodeSelector: nodeSelector,
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("tracegen-tcp"),

--- a/resources/aws/eks/nodeGroups.go
+++ b/resources/aws/eks/nodeGroups.go
@@ -48,7 +48,7 @@ func newManagedNodeGroup(e aws.Environment, name string, cluster *eks.Cluster, n
 		NodeGroupNamePrefix: e.CommonNamer.DisplayName(37, pulumi.String(name), pulumi.String("ng")),
 		ScalingConfig: awsEks.NodeGroupScalingConfigArgs{
 			DesiredSize: pulumi.Int(1),
-			MaxSize:     pulumi.Int(1),
+			MaxSize:     pulumi.Int(2),
 			MinSize:     pulumi.Int(0),
 		},
 		NodeRole: nodeRole,

--- a/resources/aws/eks/nodeGroups.go
+++ b/resources/aws/eks/nodeGroups.go
@@ -48,7 +48,7 @@ func newManagedNodeGroup(e aws.Environment, name string, cluster *eks.Cluster, n
 		NodeGroupNamePrefix: e.CommonNamer.DisplayName(37, pulumi.String(name), pulumi.String("ng")),
 		ScalingConfig: awsEks.NodeGroupScalingConfigArgs{
 			DesiredSize: pulumi.Int(1),
-			MaxSize:     pulumi.Int(2),
+			MaxSize:     pulumi.Int(1),
 			MinSize:     pulumi.Int(0),
 		},
 		NodeRole: nodeRole,

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -274,16 +274,12 @@ func Run(ctx *pulumi.Context) error {
 				return err
 			}
 
-			if cgroupV1Ng != nil {
-				if _, err := tracegen.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-tracegen-cgroupv1", "/var/run/datadog/apm.socket", cgroupV1Ng); err != nil {
-					return err
-				}
+			if _, err := tracegen.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-tracegen-cgroupv1", "/var/run/datadog/apm.socket", cgroupV1Ng); err != nil {
+				return err
 			}
 
-			if cgroupV2Ng != nil {
-				if _, err := tracegen.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-tracegen-cgroupv2", "/var/run/datadog/apm.socket", cgroupV2Ng); err != nil {
-					return err
-				}
+			if _, err := tracegen.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-tracegen-cgroupv2", "/var/run/datadog/apm.socket", cgroupV2Ng); err != nil {
+				return err
 			}
 
 			if _, err := prometheus.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-prometheus"); err != nil {

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -274,11 +274,11 @@ func Run(ctx *pulumi.Context) error {
 				return err
 			}
 
-			if _, err := tracegen.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-tracegen-cgroupv1", "/var/run/datadog/apm.socket", cgroupV1Ng); err != nil {
+			if _, err := tracegen.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-tracegen-cgroupv1", cgroupV1Ng); err != nil {
 				return err
 			}
 
-			if _, err := tracegen.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-tracegen-cgroupv2", "/var/run/datadog/apm.socket", cgroupV2Ng); err != nil {
+			if _, err := tracegen.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-tracegen-cgroupv2", cgroupV2Ng); err != nil {
 				return err
 			}
 

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -29,6 +29,9 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
+// eksNodeSelector is the label used to select the node group for tracegen
+const eksNodeSelector = "eks.amazonaws.com/nodegroup"
+
 func Run(ctx *pulumi.Context) error {
 	awsEnv, err := resourcesAws.NewEnvironment(ctx)
 	if err != nil {
@@ -274,11 +277,11 @@ func Run(ctx *pulumi.Context) error {
 				return err
 			}
 
-			if _, err := tracegen.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-tracegen-cgroupv1", cgroupV1Ng); err != nil {
+			if _, err := tracegen.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-tracegen-cgroupv1", pulumi.StringMap{eksNodeSelector: cgroupV1Ng}); err != nil {
 				return err
 			}
 
-			if _, err := tracegen.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-tracegen-cgroupv2", cgroupV2Ng); err != nil {
+			if _, err := tracegen.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-tracegen-cgroupv2", pulumi.StringMap{eksNodeSelector: cgroupV2Ng}); err != nil {
 				return err
 			}
 

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/nginx"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/prometheus"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/redis"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/tracegen"
 	dogstatsdstandalone "github.com/DataDog/test-infra-definitions/components/datadog/dogstatsd-standalone"
 	fakeintakeComp "github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	localKubernetes "github.com/DataDog/test-infra-definitions/components/kubernetes"
@@ -132,6 +133,11 @@ agents:
 
 		// dogstatsd clients that report to the dogstatsd standalone deployment
 		if _, err := dogstatsd.K8sAppDefinition(*awsEnv.CommonEnvironment, kindKubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket); err != nil {
+			return err
+		}
+
+		// for tracegen we can't find the cgroup version as it depends on the underlying version of the kernel
+		if _, err := tracegen.K8sAppDefinition(*awsEnv.CommonEnvironment, kindKubeProvider, "workload-tracegen", nil); err != nil {
 			return err
 		}
 

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -11,7 +11,6 @@ import (
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/nginx"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/prometheus"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/redis"
-	"github.com/DataDog/test-infra-definitions/components/datadog/apps/tracegen"
 	dogstatsdstandalone "github.com/DataDog/test-infra-definitions/components/datadog/dogstatsd-standalone"
 	fakeintakeComp "github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	localKubernetes "github.com/DataDog/test-infra-definitions/components/kubernetes"
@@ -133,10 +132,6 @@ agents:
 
 		// dogstatsd clients that report to the dogstatsd standalone deployment
 		if _, err := dogstatsd.K8sAppDefinition(*awsEnv.CommonEnvironment, kindKubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket); err != nil {
-			return err
-		}
-
-		if _, err := tracegen.K8sAppDefinition(*awsEnv.CommonEnvironment, kindKubeProvider, "workload-tracegen", "/var/run/datadog/apm.socket", nil); err != nil {
 			return err
 		}
 

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/nginx"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/prometheus"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/redis"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/tracegen"
 	dogstatsdstandalone "github.com/DataDog/test-infra-definitions/components/datadog/dogstatsd-standalone"
 	fakeintakeComp "github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	localKubernetes "github.com/DataDog/test-infra-definitions/components/kubernetes"
@@ -132,6 +133,10 @@ agents:
 
 		// dogstatsd clients that report to the dogstatsd standalone deployment
 		if _, err := dogstatsd.K8sAppDefinition(*awsEnv.CommonEnvironment, kindKubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket); err != nil {
+			return err
+		}
+
+		if _, err := tracegen.K8sAppDefinition(*awsEnv.CommonEnvironment, kindKubeProvider, "workload-tracegen", "/var/run/datadog/apm.socket", nil); err != nil {
 			return err
 		}
 

--- a/tasks/eks.py
+++ b/tasks/eks.py
@@ -40,7 +40,7 @@ def create_eks(
     agent_version: Optional[str] = None,
     linux_node_group: bool = True,
     linux_arm_node_group: bool = False,
-    bottlerocket_node_group: bool = False,
+    bottlerocket_node_group: bool = True,
     windows_node_group: bool = False,
     instance_type: Optional[str] = None,
 ):


### PR DESCRIPTION
What does this PR do?
---------------------
This PR adds a workload sending traces from both cgroupv1 and cgroupv2 nodes in the aws/eks scenario

Which scenarios this will impact?
-------------------
aws/eks, aws/kind

Motivation
----------
We would like to add e2e tests to make sure container id is retrieved for apm traces on both cgroupv1 and cgroupv2. 

Additional Notes
----------------
Example: https://dddev.datadoghq.com/apm/traces?query=%40_top_level%3A1%20kube_cluster_name%3Aali-benabdallah-aws-eks%20kube_namespace%3Aworkload-tracegen-cgroupv2%20kube_deployment%3Atracegen-udp&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&historicalData=true&messageDisplay=inline&query_translation_version=v0&sort=desc&spanType=service-entry&traceQuery=&view=spans&start=1707755328234&end=1707928128234&paused=false