### PR TITLE
[gitlab] store private key in memory

### DIFF
--- a/.github/jwt.sh
+++ b/.github/jwt.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Source: docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app
 
 set -o pipefail
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,7 @@ build-runner-image:
     - export GITHUB_APP_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.github_app_id --with-decryption --query "Parameter.Value" --out text)
     - export GITHUB_INSTALLATION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.github_installation_id --with-decryption --query "Parameter.Value" --out text)
     - export GITHUB_PRIVATE_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.github_private_key --with-decryption --query "Parameter.Value" --out text)
-    - export JWT=$(.github/jwt.sh $GITHUB_APP_ID <(echo $GITHUB_PRIVATE_KEY))
+    - export JWT=$(.github/jwt.sh "$GITHUB_APP_ID" <(echo "$GITHUB_PRIVATE_KEY"))
     - |
       export GITHUB_TOKEN=`curl -s --fail --retry 10 -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $JWT" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/app/installations/$GITHUB_INSTALLATION_ID/access_tokens | jq -r '.token'`
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,14 +17,13 @@ build-runner-image:
   tags: ["arch:amd64"]
   variables:
     RELEASE_IMAGE: "false"
-    GITHUB_PRIVATE_KEY_PATH: /tmp/github.pem
   rules:
     - when: on_success
   before_script:
     - export GITHUB_APP_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.github_app_id --with-decryption --query "Parameter.Value" --out text)
     - export GITHUB_INSTALLATION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.github_installation_id --with-decryption --query "Parameter.Value" --out text)
-    - aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.github_private_key --with-decryption --query "Parameter.Value" --out text > $GITHUB_PRIVATE_KEY_PATH
-    - export JWT=$(.github/jwt.sh $GITHUB_APP_ID $GITHUB_PRIVATE_KEY_PATH)
+    - export GITHUB_PRIVATE_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.github_private_key --with-decryption --query "Parameter.Value" --out text)
+    - export JWT=$(.github/jwt.sh $GITHUB_APP_ID <(echo $GITHUB_PRIVATE_KEY))
     - |
       export GITHUB_TOKEN=`curl -s --fail --retry 10 -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $JWT" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/app/installations/$GITHUB_INSTALLATION_ID/access_tokens | jq -r '.token'`
   script:


### PR DESCRIPTION
What does this PR do?
---------------------

Remove private key after we're done using it

Which scenarios this will impact?
-------------------

None

Motivation
----------

Limit life of private key on the CI

Additional Notes
----------------

Could not find a way to generate the digest from the key content in memory, rather than stored in a file. Open to suggestions!
