### PR TITLE
Add standalone uploader to upload tests at the end of test run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,9 @@ RUN apt-get update -y && \
   # xsltproc is required by libvirt-sdk used in the micro-vms scenario
   xsltproc \
   jq && \
+  # Install the datadog-ci-uploader
+  curl --retry 10 -fsSL https://github.com/DataDog/datadog-ci/releases/latest/download/datadog-ci_linux-x64 --output "/usr/local/bin/datadog-ci" && \
+  chmod +x /usr/local/bin/datadog-ci && \
   # Clean up the lists work
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
What does this PR do?
---------------------

Add the standalone ci-uploader to the test-infra-
definitions image

Which scenarios this will impact?
-------------------
ec2

Motivation
----------
This is to remove dedicated upload jobs on datadog-agent repo, and upload tests alongside test execution

Additional Notes
----------------
