### PR TITLE
Use public.ecr.aws redis image to avoid rate limit

### DIFF
--- a/components/datadog/apps/redis/ecs.go
+++ b/components/datadog/apps/redis/ecs.go
@@ -55,7 +55,7 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...
 			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
 				"redis": {
 					Name:  pulumi.String("redis"),
-					Image: pulumi.String("redis:latest"),
+					Image: pulumi.String("public.ecr.aws/docker/library/redis:latest"),
 					DockerLabels: pulumi.StringMap{
 						"com.datadoghq.ad.tags": pulumi.String("[\"ecs_launch_type:ec2\"]"),
 					},

--- a/components/datadog/apps/redis/ecsFargate.go
+++ b/components/datadog/apps/redis/ecsFargate.go
@@ -49,7 +49,7 @@ func FargateAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, apiK
 
 	serverContainer := &ecs.TaskDefinitionContainerDefinitionArgs{
 		Name:  pulumi.String("redis"),
-		Image: pulumi.String("redis:latest"),
+		Image: pulumi.String("public.ecr.aws/docker/library/redis:latest"),
 		DockerLabels: pulumi.StringMap{
 			"com.datadoghq.ad.tags": pulumi.String("[\"ecs_launch_type:fargate\"]"),
 		},

--- a/components/datadog/apps/redis/k8s.go
+++ b/components/datadog/apps/redis/k8s.go
@@ -73,7 +73,7 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("redis"),
-							Image: pulumi.String("redis:latest"),
+							Image: pulumi.String("public.ecr.aws/docker/library/redis:latest"),
 							Args: pulumi.StringArray{
 								pulumi.String("--loglevel"),
 								pulumi.String("verbose"),


### PR DESCRIPTION
What does this PR do?
---------------------

Update the redis container image from dockerhub `redis:latest` to `public.ecr.aws/docker/library/redis:latest`

Which scenarios this will impact?
-------------------

tests that use the redis container images.
on the datadog-agent repo I found 1 test `TestRedisECS` that will fail after merging this PR. We will need to update the expected tags here:
* https://github.com/DataDog/datadog-agent/blob/d3c07fce4a0dc7eea2a79b9dd168c73c718f4cba/test/new-e2e/tests/containers/ecs_test.go#L252
* https://github.com/DataDog/datadog-agent/blob/d3c07fce4a0dc7eea2a79b9dd168c73c718f4cba/test/new-e2e/tests/containers/ecs_test.go#L281

Motivation
----------

avoid getting image pull backoff during end2end test. We recently seen several rate limit occurences in the datadog-agent CI e2e tests job

Additional Notes
----------------
