### PR TITLE
Add checks for encrypted keys and pulumi creds to setup.debug

### DIFF
--- a/tasks/config.py
+++ b/tasks/config.py
@@ -16,6 +16,7 @@ class Config(BaseModel, extra=Extra.forbid):
             keyPairName: Optional[str]
             publicKeyPath: Optional[str]
             privateKeyPath: Optional[str] = None
+            privateKeyPassword: Optional[str] = None
             account: Optional[str]
             teamTag: Optional[str]
 

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -44,9 +44,12 @@ def setup(
             if is_windows():
                 # Add common pulumi install locations to PATH
                 paths = [
-                    Path().home().joinpath(".pulumi", "bin"),
-                    Path().home().joinpath("AppData", "Local", "pulumi", "bin"),
-                    'C:\\Program Files (x86)\\Pulumi\\bin',
+                    str(x)
+                    for x in [
+                        Path().home().joinpath(".pulumi", "bin"),
+                        Path().home().joinpath("AppData", "Local", "pulumi", "bin"),
+                        'C:\\Program Files (x86)\\Pulumi\\bin',
+                    ]
                 ]
                 os.environ["PATH"] = ';'.join([os.environ["PATH"]] + paths)
             else:

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -53,7 +53,7 @@ def setup(
 
         config.save_to_local_config(config_path)
 
-    _check_config(ctx, config)
+    _check_config(config)
 
     if debug:
         debug_env(ctx, config_path=config_path)
@@ -95,7 +95,7 @@ def _install_pulumi(ctx: Context):
             os.environ["PATH"] = f"{os.environ['PATH']}:{path}"
 
 
-def _check_config(ctx: Context, config: Config):
+def _check_config(config: Config):
     aws = config.get_aws()
     if aws.privateKeyPassword:
         warn("WARNING: privateKeyPassword is set. Please ensure privateKeyPath is used ONLY for E2E tests.")

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -479,6 +479,14 @@ def debug_env(ctx, config_path: Optional[str] = None):
         raise Exit(code=1)
     info(f"Pulumi version: {out.stdout.strip()}")
 
+    # Check pulumi credentials
+    try:
+        out = ctx.run("pulumi whoami", hide=True)
+    except UnexpectedExit:
+        error("No pulumi credentials found")
+        info("Please login, e.g. pulumi login --local")
+        raise Exit(code=1)
+
     # check awscli version
     out = ctx.run("aws --version", hide=True)
     if not out.stdout.startswith("aws-cli/2"):

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -321,8 +321,10 @@ def find_matching_ec2_keypair(ctx: Context, keypairs: dict, path: Path) -> Tuple
 
 
 def get_ssh_keys():
+    ignore = ["known_hosts", "authorized_keys", "config"]
     root = Path.home().joinpath(".ssh")
-    return list(map(root.joinpath, os.listdir(root)))
+    filenames = filter(lambda x: x.is_file() and x not in ignore, root.iterdir())
+    return list(map(root.joinpath, filenames))
 
 
 def _check_key(ctx: Context, keyinfo: KeyInfo, keypair: dict, configuredKeyPairName: str):

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -31,16 +31,16 @@ def setup(
     else:
         info("🤖 Install Pulumi")
         if is_windows():
-            os.system("winget install pulumi")
+            ctx.run("winget install pulumi")
         elif is_linux():
-            os.system("curl -fsSL https://get.pulumi.com | sh")
+            ctx.run("curl -fsSL https://get.pulumi.com | sh")
         else:
-            os.system("brew install pulumi/tap/pulumi")
+            ctx.run("brew install pulumi/tap/pulumi")
 
     # install plugins
-    os.system("pulumi --non-interactive plugin install")
+    ctx.run("pulumi --non-interactive plugin install")
     # login to local stack storage
-    os.system("pulumi login --local")
+    ctx.run("pulumi login --local")
 
     try:
         config = get_local_config(config_path)

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -3,6 +3,7 @@ import getpass
 import json
 import os
 import os.path
+import shutil
 from pathlib import Path
 from typing import NamedTuple, Optional, Tuple
 
@@ -36,6 +37,21 @@ def setup(
             ctx.run("curl -fsSL https://get.pulumi.com | sh")
         else:
             ctx.run("brew install pulumi/tap/pulumi")
+        if shutil.which("pulumi") is None:
+            print()
+            warn("Pulumi is not in the PATH, please add pulumi to PATH before running tests")
+            # Pulumi is not in the PATH, add it to the process env so rest of setup can continue
+            if is_windows():
+                # Add common pulumi install locations to PATH
+                paths = [
+                    Path().home().joinpath(".pulumi", "bin"),
+                    Path().home().joinpath("AppData", "Local", "pulumi", "bin"),
+                    'C:\\Program Files (x86)\\Pulumi\\bin',
+                ]
+                os.environ["PATH"] = ';'.join([os.environ["PATH"]] + paths)
+            else:
+                path = Path().home().joinpath(".pulumi", "bin")
+                os.environ["PATH"] = f"{os.environ['PATH']}:{path}"
 
     # install plugins
     ctx.run("pulumi --non-interactive plugin install")

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -90,7 +90,7 @@ def _install_pulumi(ctx: Context):
                 ]
             ]
             os.environ["PATH"] = ';'.join([os.environ["PATH"]] + paths)
-        else:
+        elif is_linux():
             path = Path().home().joinpath(".pulumi", "bin")
             os.environ["PATH"] = f"{os.environ['PATH']}:{path}"
 


### PR DESCRIPTION
What does this PR do?
---------------------
Add more checks to `inv setup.debug`
- Ensures pulumi is logged in
- if `privateKeyPath` is configured, ensures it is not encrypted or a proper `privateKeyPassword` is provided

Fail `inv.setup` if `pulumi` cannot be executed, e.g. not on PATH

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
