### PR TITLE
Add pre-commit hooks corresponding to GitHub workflows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,16 +3,22 @@ repos:
     rev: v1.52.2
     hooks:
     - id: golangci-lint
-  - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.350
+  - repo: local
     hooks:
     - id: pyright
+      name: pyright
+      entry: pyright
+      language: system  # Use local install for pyright, else we cannot import the requirements and we get errors on external libraries
+      'types_or': [python, pyi]
+      require_serial: true
+      additional_dependencies: []
+      minimum_pre_commit_version: '2.9.2'
   - repo: https://github.com/pycqa/flake8
     rev: "7.0.0"
     hooks:
     - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: "5.11.2"
+    rev: "5.12.0"
     hooks:
       - id: isort
   - repo: https://github.com/psf/black-pre-commit-mirror

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,28 @@ repos:
     rev: v1.52.2
     hooks:
     - id: golangci-lint
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.350
+    hooks:
+    - id: pyright
+  - repo: https://github.com/pycqa/flake8
+    rev: "7.0.0"
+    hooks:
+    - id: flake8
+  - repo: https://github.com/pycqa/isort
+    rev: "5.11.2"
+    hooks:
+      - id: isort
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.2.0
+    hooks:
+      - id: black
+  - repo: https://github.com/jendrikseipp/vulture
+    rev: 'v2.3'
+    hooks:
+      - id: vulture
+        args:
+          - --ignore-decorators
+          - "@task"
+          - --ignore-names
+          - 'test_*,Test*'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,4 @@ repos:
           - "@task"
           - --ignore-names
           - 'test_*,Test*'
+          - tasks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@
 
 [tool.black]
 line-length = 120
-py36 = false
 skip-string-normalization = true
 
 [tool.isort]


### PR DESCRIPTION
What does this PR do?
---------------------

Adds pre-commit config matching the linters found in workflows

Which scenarios this will impact?
-------------------

None, only tooling

Motivation
----------

Detect linter failures before without requiring CI runs.

Additional Notes
----------------

Due to how pre-commit works, we cannot install the modules from `requirements.txt` in the virtualenv, which means that `pyright` does not detect them and therefore fails (see https://github.com/pre-commit/pre-commit/issues/730 for a discussion on this problem). The solution is to revert to using the pyright program installed in the system, without the internal virtualenv that pre-commit creates.