### PR TITLE
Download VM images with curl

### DIFF
--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -272,7 +272,7 @@ func downloadRootfs(fs *LibvirtFilesystem, runner *Runner, depends []pulumi.Reso
 			waitFor = append(waitFor, resources...)
 		} else {
 			webDownload = true
-			parallelDownloadMax += 1
+			parallelDownloadMax++
 			fmt.Fprintf(&curlDownload, "%s -o %s ", fsImage.imageSource, fsImage.imagePath)
 		}
 	}

--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -281,7 +281,7 @@ func downloadRootfs(fs *LibvirtFilesystem, runner *Runner, depends []pulumi.Reso
 		downloadWithCurlArgs := command.Args{
 			Create: pulumi.Sprintf("curl -s -Z --parallel-max %d %s", parallelDownloadMax, curlDownload.String()),
 		}
-		downloadWithCurlDone, err := runner.Command(fs.fsNamer.ResourceName("download-with-curl", filepath.Base(fsImage.imagePath)), &downloadWithCurlArgs)
+		downloadWithCurlDone, err := runner.Command(fs.fsNamer.ResourceName("download-with-curl"), &downloadWithCurlArgs)
 		if err != nil {
 			return waitFor, err
 		}

--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -273,7 +273,7 @@ func downloadRootfs(fs *LibvirtFilesystem, runner *Runner, depends []pulumi.Reso
 		} else {
 			webDownload = true
 			parallelDownloadMax += 1
-			fmt.Fprintf(&curlDownload, "%s -o %s ", fsImage.imagePath, fsImage.imageSource)
+			fmt.Fprintf(&curlDownload, "%s -o %s ", fsImage.imageSource, fsImage.imagePath)
 		}
 	}
 


### PR DESCRIPTION
What does this PR do?
---------------------
This PR uses curl to download VM images instead of aria2c.

Which scenarios this will impact?
-------------------

Motivation
----------
Aria2c has an [issue](https://github.com/aria2/aria2/issues/1344) when servers return range headers in a particular way, which is effecting us causing jobs in the agent CI to fail intermittently.

Additional Notes
----------------
