### PR TITLE
Implement fakeintake single LB for agent-sandbox|qa

### DIFF
--- a/components/datadog/fakeintake/component.go
+++ b/components/datadog/fakeintake/component.go
@@ -19,7 +19,8 @@ type Fakeintake struct {
 	// It's cleaner to export the full URL, but the Agent requires only host in some cases.
 	// Keeping those internal to Pulumi program.
 	Host   pulumi.StringOutput
-	Scheme pulumi.StringOutput
+	Scheme string // Scheme is a string as it's known in code and is useful to check HTTP/HTTPS
+	Port   uint32 // Same for Port
 
 	URL pulumi.StringOutput `pulumi:"url"`
 }

--- a/resources/aws/environment.go
+++ b/resources/aws/environment.go
@@ -32,6 +32,8 @@ const (
 	// AWS ECS
 	DDInfraEcsExecKMSKeyID                  = "aws/ecs/execKMSKeyID"
 	DDInfraEcsFargateFakeintakeClusterArn   = "aws/ecs/fargateFakeintakeClusterArn"
+	DDInfraEcsFakeintakeLBListenerArn       = "aws/ecs/fakeintakeLBListenerArn"
+	DDInfraEcsFakeintakeLBBaseHost          = "aws/ecs/fakeintakeLBBaseHost"
 	DDInfraEcsTaskExecutionRole             = "aws/ecs/taskExecutionRole"
 	DDInfraEcsTaskRole                      = "aws/ecs/taskRole"
 	DDInfraEcsInstanceProfile               = "aws/ecs/instanceProfile"
@@ -188,6 +190,14 @@ func (e *Environment) ECSExecKMSKeyID() string {
 
 func (e *Environment) ECSFargateFakeintakeClusterArn() string {
 	return e.GetStringWithDefault(e.InfraConfig, DDInfraEcsFargateFakeintakeClusterArn, e.envDefault.ddInfra.ecs.fargateFakeintakeClusterArn)
+}
+
+func (e *Environment) ECSFakeintakeLBListenerArn() string {
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraEcsFakeintakeLBListenerArn, e.envDefault.ddInfra.ecs.fakeintakeLBListenerArn)
+}
+
+func (e *Environment) ECSFakeintakeLBBaseHost() string {
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraEcsFakeintakeLBBaseHost, e.envDefault.ddInfra.ecs.fakeintakeLBBaseHostHeader)
 }
 
 func (e *Environment) ECSTaskExecutionRole() string {

--- a/resources/aws/environmentDefaults.go
+++ b/resources/aws/environmentDefaults.go
@@ -38,6 +38,8 @@ type ddInfra struct {
 type ddInfraECS struct {
 	execKMSKeyID                  string
 	fargateFakeintakeClusterArn   string
+	fakeintakeLBListenerArn       string
+	fakeintakeLBBaseHostHeader    string
 	taskExecutionRole             string
 	taskRole                      string
 	instanceProfile               string
@@ -134,6 +136,8 @@ func agentSandboxDefault() environmentDefault {
 			ecs: ddInfraECS{
 				execKMSKeyID:                "arn:aws:kms:us-east-1:376334461865:key/1d1fe533-a4f1-44ee-99ec-225b44fcb9ed",
 				fargateFakeintakeClusterArn: "arn:aws:ecs:us-east-1:376334461865:cluster/fakeintake-ecs",
+				fakeintakeLBListenerArn:     "arn:aws:elasticloadbalancing:us-east-1:376334461865:listener/app/fakeintake/3bbebae6506eb8cb/eea87c947a30f106",
+				fakeintakeLBBaseHostHeader:  ".lb1.fi.sandbox.dda-testing.com",
 				taskExecutionRole:           "arn:aws:iam::376334461865:role/ecsTaskExecutionRole",
 				taskRole:                    "arn:aws:iam::376334461865:role/ecsTaskRole",
 				instanceProfile:             "arn:aws:iam::376334461865:instance-profile/ecsInstanceRole",
@@ -175,6 +179,8 @@ func agentQADefault() environmentDefault {
 			ecs: ddInfraECS{
 				execKMSKeyID:                "arn:aws:kms:us-east-1:669783387624:key/384373bc-6d99-4d68-84b5-b76b756b0af3",
 				fargateFakeintakeClusterArn: "arn:aws:ecs:us-east-1:669783387624:cluster/fakeintake-ecs",
+				fakeintakeLBListenerArn:     "arn:aws:elasticloadbalancing:us-east-1:669783387624:listener/app/fakeintake/de7956e70776e471/ddfa738893c2dc0e",
+				fakeintakeLBBaseHostHeader:  ".lb1.fi.qa.dda-testing.com",
 				taskExecutionRole:           "arn:aws:iam::669783387624:role/ecsTaskExecutionRole",
 				taskRole:                    "arn:aws:iam::669783387624:role/ecsTaskRole",
 				instanceProfile:             "arn:aws:iam::669783387624:instance-profile/ecsInstanceRole",

--- a/scenarios/aws/fakeintake/fakeintake.go
+++ b/scenarios/aws/fakeintake/fakeintake.go
@@ -16,14 +16,10 @@ import (
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 	"github.com/DataDog/test-infra-definitions/resources/aws/ecs"
 
-	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/acm"
-	calb "github.com/pulumi/pulumi-aws/sdk/v5/go/aws/alb"
 	classicECS "github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ecs"
 	clb "github.com/pulumi/pulumi-aws/sdk/v5/go/aws/lb"
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ssm"
 	awsxEcs "github.com/pulumi/pulumi-awsx/sdk/go/awsx/ecs"
-	"github.com/pulumi/pulumi-awsx/sdk/go/awsx/lb"
-	"github.com/pulumi/pulumi-tls/sdk/v4/go/tls"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 
 	"github.com/cenkalti/backoff/v4"
@@ -33,8 +29,8 @@ const (
 	sleepInterval = 1 * time.Second
 	maxRetries    = 120
 	containerName = "fakeintake"
-	port          = 80
-	sslPort       = 443
+	httpPort      = 80
+	httpsPort     = 443
 )
 
 func NewECSFargateInstance(e aws.Environment, name string, option ...Option) (*fakeintake.Fakeintake, error) {
@@ -70,7 +66,16 @@ func NewECSFargateInstance(e aws.Environment, name string, option ...Option) (*f
 			return err
 		}
 
+		useLoadBalancer := false
 		if params.LoadBalancerEnabled {
+			if e.ECSFakeintakeLBListenerArn() != "" {
+				useLoadBalancer = true
+			} else {
+				e.Ctx.Log.Warn("Load balancer is enabled but no listener is defined, will not use LB", nil)
+			}
+		}
+
+		if useLoadBalancer {
 			err = fargateSvcLB(e, namer, taskDef, fi, opts...)
 		} else {
 			err = fargateSvcNoLB(e, namer, taskDef, fi, opts...)
@@ -115,7 +120,7 @@ func fargateSvcNoLB(e aws.Environment, namer namer.Namer, taskDef *awsxEcs.Farga
 
 		// fail the deployment if the fakeintake is not healthy
 		e.Ctx.Log.Info(fmt.Sprintf("Waiting for fakeintake at %s to be healthy", ipAddress), nil)
-		healthURL := buildFakeIntakeURL("http", ipAddress, "/fakeintake/health", port)
+		healthURL := buildFakeIntakeURL("http", ipAddress, "/fakeintake/health", httpPort)
 		err = backoff.Retry(func() error {
 			e.Ctx.Log.Debug(fmt.Sprintf("getting fakeintake health at %s", healthURL), nil)
 			resp, err := http.Get(healthURL)
@@ -133,94 +138,59 @@ func fargateSvcNoLB(e aws.Environment, namer namer.Namer, taskDef *awsxEcs.Farga
 			return nil, err
 		}
 
-		return []string{ipAddress, buildFakeIntakeURL("http", ipAddress, "", port)}, nil
+		return []string{ipAddress, buildFakeIntakeURL("http", ipAddress, "", httpPort)}, nil
 	}).(pulumi.StringArrayOutput)
 
+	fi.Scheme = "http"
+	fi.Port = httpPort
 	fi.Host = output.Index(pulumi.Int(0))
 	fi.URL = output.Index(pulumi.Int(1))
-	fi.Scheme = pulumi.String("http").ToStringOutput()
 
 	return err
 }
 
 func fargateSvcLB(e aws.Environment, namer namer.Namer, taskDef *awsxEcs.FargateTaskDefinition, fi *fakeintake.Fakeintake, opts ...pulumi.ResourceOption) error {
-	alb, err := lb.NewApplicationLoadBalancer(e.Ctx, namer.ResourceName("lb"), &lb.ApplicationLoadBalancerArgs{
-		Name:           e.CommonNamer.DisplayName(32, pulumi.String(fi.Name())),
-		SubnetIds:      e.RandomSubnets(),
-		Internal:       pulumi.BoolPtr(!e.ECSServicePublicIP()),
-		SecurityGroups: pulumi.ToStringArray(e.DefaultSecurityGroups()),
-		DefaultTargetGroup: &lb.TargetGroupArgs{
-			HealthCheck: &clb.TargetGroupHealthCheckArgs{
-				Path: pulumi.StringPtr("/fakeintake/health"),
-			},
-			Name:       e.CommonNamer.DisplayName(32, pulumi.String("name")),
-			Port:       pulumi.IntPtr(port),
-			Protocol:   pulumi.StringPtr("HTTP"),
-			TargetType: pulumi.StringPtr("ip"),
-			VpcId:      pulumi.StringPtr(e.DefaultVPCID()),
-		},
-		Listener: &lb.ListenerArgs{
-			Port:     pulumi.IntPtr(port),
-			Protocol: pulumi.StringPtr("HTTP"),
-		},
-	}, utils.MergeOptions(opts, e.WithProviders(config.ProviderAWS, config.ProviderAWSX))...)
-	if err != nil {
-		return err
-	}
-
-	key, err := tls.NewPrivateKey(e.Ctx, namer.ResourceName("key"), &tls.PrivateKeyArgs{
-		Algorithm: pulumi.String("RSA"),
-		RsaBits:   pulumi.IntPtr(4096),
-	}, utils.MergeOptions(opts, e.WithProviders(config.ProviderTLS))...)
-	if err != nil {
-		return err
-	}
-
-	selfcert, err := tls.NewSelfSignedCert(e.Ctx, namer.ResourceName("cert"), &tls.SelfSignedCertArgs{
-		AllowedUses: pulumi.StringArray{
-			pulumi.String("server_auth"),
-		},
-		DnsNames: pulumi.StringArray{
-			alb.LoadBalancer.DnsName(),
-		},
-		PrivateKeyPem: key.PrivateKeyPem,
-		Subject: &tls.SelfSignedCertSubjectArgs{
-			CommonName: alb.LoadBalancer.DnsName(),
-		},
-		ValidityPeriodHours: pulumi.Int(24),
-	}, utils.MergeOptions(opts, e.WithProviders(config.ProviderTLS))...)
-	if err != nil {
-		return err
-	}
-
-	cert, err := acm.NewCertificate(e.Ctx, namer.ResourceName("cert"), &acm.CertificateArgs{
-		CertificateBody: selfcert.CertPem,
-		PrivateKey:      key.PrivateKeyPem,
+	targetGroup, err := clb.NewTargetGroup(e.Ctx, namer.ResourceName("target-group"), &clb.TargetGroupArgs{
+		Port:          pulumi.Int(80),
+		Protocol:      pulumi.String("HTTP"),
+		TargetType:    pulumi.String("ip"),
+		IpAddressType: pulumi.String("ipv4"),
+		VpcId:         pulumi.StringPtr(e.DefaultVPCID()),
+		Name:          e.CommonNamer.DisplayName(32, pulumi.String("fakeintake")),
 	}, utils.MergeOptions(opts, e.WithProviders(config.ProviderAWS))...)
 	if err != nil {
 		return err
 	}
 
-	if _, err = calb.NewListener(e.Ctx, namer.ResourceName("lb-https"), &calb.ListenerArgs{
-		LoadBalancerArn: alb.LoadBalancer.Arn(),
-		Port:            pulumi.IntPtr(sslPort),
-		Protocol:        pulumi.StringPtr("HTTPS"),
-		CertificateArn:  cert.Arn,
-		DefaultActions: calb.ListenerDefaultActionArray{
-			calb.ListenerDefaultActionArgs{
-				Type:           pulumi.String("forward"),
-				TargetGroupArn: alb.DefaultTargetGroup.Arn(),
+	// Hashing fakeintake resource name as prefix for Host header
+	hostPrefix := utils.StrHash(namer.ResourceName(e.Ctx.Stack()))
+	host := hostPrefix + e.ECSFakeintakeLBBaseHost()
+
+	_, err = clb.NewListenerRule(e.Ctx, namer.ResourceName(hostPrefix), &clb.ListenerRuleArgs{
+		ListenerArn: pulumi.String(e.ECSFakeintakeLBListenerArn()),
+		Conditions: clb.ListenerRuleConditionArray{
+			clb.ListenerRuleConditionArgs{
+				HostHeader: clb.ListenerRuleConditionHostHeaderArgs{
+					Values: pulumi.ToStringArray([]string{host}),
+				},
 			},
 		},
-	}, utils.MergeOptions(opts, e.WithProviders(config.ProviderAWS))...); err != nil {
+		Actions: clb.ListenerRuleActionArray{
+			clb.ListenerRuleActionArgs{
+				Type:           pulumi.String("forward"),
+				TargetGroupArn: targetGroup.Arn,
+			},
+		},
+	}, utils.MergeOptions(opts, e.WithProviders(config.ProviderAWS))...)
+	if err != nil {
 		return err
 	}
-	ipAdress := alb.LoadBalancer.DnsName()
+
 	balancerArray := classicECS.ServiceLoadBalancerArray{
 		&classicECS.ServiceLoadBalancerArgs{
 			ContainerName:  pulumi.String(containerName),
-			ContainerPort:  pulumi.Int(port),
-			TargetGroupArn: alb.DefaultTargetGroup.Arn(),
+			ContainerPort:  pulumi.Int(httpPort),
+			TargetGroupArn: targetGroup.Arn,
 		},
 	}
 
@@ -229,12 +199,10 @@ func fargateSvcLB(e aws.Environment, namer namer.Namer, taskDef *awsxEcs.Fargate
 		return err
 	}
 
-	fi.Host = ipAdress
-	fi.Scheme = pulumi.String("http").ToStringOutput()
-	fi.URL = ipAdress.ApplyT(func(ip string) string {
-		return buildFakeIntakeURL("http", ip, "", port)
-	}).(pulumi.StringOutput)
-
+	fi.Scheme = "https"
+	fi.Port = httpsPort
+	fi.Host = pulumi.String(host).ToStringOutput()
+	fi.URL = pulumi.String(fi.Scheme + "://" + host).ToStringOutput()
 	return nil
 }
 
@@ -252,8 +220,8 @@ func fargateLinuxContainerDefinition(imageURL string, apiKeySSMParamName pulumi.
 		},
 		PortMappings: awsxEcs.TaskDefinitionPortMappingArray{
 			awsxEcs.TaskDefinitionPortMappingArgs{
-				ContainerPort: pulumi.Int(port),
-				HostPort:      pulumi.Int(port),
+				ContainerPort: pulumi.Int(httpPort),
+				HostPort:      pulumi.Int(httpPort),
 				Protocol:      pulumi.StringPtr("tcp"),
 			},
 		},


### PR DESCRIPTION
What does this PR do?
---------------------

Use a permanent LB for FI in `agent-sandbox` and `agent-qa`, reducing IP usage, speeding up creation.

Agent routing is based on `Host` header in ALB: `<hash>.lbX.fi.<sandbox|qa>.dda-testing.com`.
A wildcard CNAME entry in Route53 allows to route `*.fi.<env>.dda-testing.com` to the LB. If we add more in the future we'll need records for `*.lbX.fi` instead.
The ALB does TLS termination and has a signed SSL cert as we have a public DNS.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
