### PR TITLE
[CONTINT-3558 ] Add tracegen to the ECS scenario

### DIFF
--- a/components/datadog/agent/ecs.go
+++ b/components/datadog/agent/ecs.go
@@ -87,6 +87,14 @@ func ecsLinuxAgentSingleContainerDefinition(e config.CommonEnvironment, apiKeySS
 		},
 		Environment: append(append(ecs.TaskDefinitionKeyValuePairArray{
 			ecs.TaskDefinitionKeyValuePairArgs{
+				Name:  pulumi.StringPtr("DD_APM_ENABLED"),
+				Value: pulumi.StringPtr("true"),
+			},
+			ecs.TaskDefinitionKeyValuePairArgs{
+				Name:  pulumi.StringPtr("DD_APM_NON_LOCAL_TRAFFIC"),
+				Value: pulumi.StringPtr("true"),
+			},
+			ecs.TaskDefinitionKeyValuePairArgs{
 				Name:  pulumi.StringPtr("DD_CHECKS_TAG_CARDINALITY"),
 				Value: pulumi.StringPtr("high"),
 			},

--- a/components/datadog/apps/tracegen/ecs.go
+++ b/components/datadog/apps/tracegen/ecs.go
@@ -1,0 +1,115 @@
+package tracegen
+
+import (
+	"fmt"
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/resources/aws"
+	classicECS "github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ecs"
+	"github.com/pulumi/pulumi-awsx/sdk/go/awsx/awsx"
+	"github.com/pulumi/pulumi-awsx/sdk/go/awsx/ecs"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+//classicECS.ServicePlacementConstraintArray{
+//classicECS.ServicePlacementConstraintArgs{
+//Type:       pulumi.String("memberOf"),
+//Expression: pulumi.StringPtr("attribute:ecs.os-type == linux"),
+//},
+//},
+
+type EcsComponent struct {
+	pulumi.ResourceState
+}
+
+func EcsAppDefinition(e aws.Environment, workloadName string, clusterArn pulumi.StringInput, opts ...pulumi.ResourceOption) (*EcsComponent, error) {
+	namer := e.Namer.WithPrefix(fmt.Sprintf("%s/tracegen", workloadName))
+	opts = append(opts, e.WithProviders(config.ProviderAWS, config.ProviderAWSX))
+
+	ecsComponent := &EcsComponent{}
+	if err := e.Ctx.RegisterComponentResource("dd:apps", namer.ResourceName("grp"), ecsComponent, opts...); err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, pulumi.Parent(ecsComponent))
+
+	if _, err := ecs.NewEC2Service(e.Ctx, namer.ResourceName("uds"), &ecs.EC2ServiceArgs{
+		Name:                 e.CommonNamer.DisplayName(255, pulumi.String("tracegen-uds")),
+		Cluster:              clusterArn,
+		DesiredCount:         pulumi.IntPtr(1),
+		EnableExecuteCommand: pulumi.BoolPtr(true),
+		TaskDefinitionArgs: &ecs.EC2ServiceTaskDefinitionArgs{
+			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
+				"tracegen": {
+					Name:  pulumi.String("tracegen"),
+					Image: pulumi.String("ghcr.io/datadog/apps-tracegen:main"),
+					Environment: ecs.TaskDefinitionKeyValuePairArray{
+						ecs.TaskDefinitionKeyValuePairArgs{
+							Name:  pulumi.StringPtr("DD_TRACE_AGENT_URL"),
+							Value: pulumi.StringPtr("unix:///var/run/datadog/apm.socket"),
+						},
+					},
+					Cpu:    pulumi.IntPtr(10),
+					Memory: pulumi.IntPtr(32),
+					MountPoints: ecs.TaskDefinitionMountPointArray{
+						ecs.TaskDefinitionMountPointArgs{
+							SourceVolume:  pulumi.StringPtr("apmsocketpath"),
+							ContainerPath: pulumi.StringPtr("/var/run/datadog"),
+							ReadOnly:      pulumi.BoolPtr(true),
+						},
+					},
+				},
+			},
+			ExecutionRole: &awsx.DefaultRoleWithPolicyArgs{
+				RoleArn: pulumi.StringPtr(e.ECSTaskExecutionRole()),
+			},
+			TaskRole: &awsx.DefaultRoleWithPolicyArgs{
+				RoleArn: pulumi.StringPtr(e.ECSTaskRole()),
+			},
+			NetworkMode: pulumi.StringPtr("none"),
+			Family:      e.Namer.DisplayName(255, pulumi.String("tracegen-uds-ec2")),
+			Volumes: classicECS.TaskDefinitionVolumeArray{
+				classicECS.TaskDefinitionVolumeArgs{
+					Name:     pulumi.String("apmsocketpath"),
+					HostPath: pulumi.StringPtr("/var/run/datadog"),
+				},
+			},
+		},
+	}, opts...); err != nil {
+		return nil, err
+	}
+
+	if _, err := ecs.NewEC2Service(e.Ctx, namer.ResourceName("tcp"), &ecs.EC2ServiceArgs{
+		Name:                 e.CommonNamer.DisplayName(255, pulumi.String("tracegen-tcp")),
+		Cluster:              clusterArn,
+		DesiredCount:         pulumi.IntPtr(1),
+		EnableExecuteCommand: pulumi.BoolPtr(true),
+		TaskDefinitionArgs: &ecs.EC2ServiceTaskDefinitionArgs{
+			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
+				"tracegen": {
+					Name:  pulumi.String("tracegen"),
+					Image: pulumi.String("ghcr.io/datadog/apps-tracegen:main"),
+					Environment: ecs.TaskDefinitionKeyValuePairArray{
+						ecs.TaskDefinitionKeyValuePairArgs{
+							Name:  pulumi.StringPtr("ECS_AGENT_HOST"),
+							Value: pulumi.StringPtr("true"),
+						},
+					},
+					Cpu:    pulumi.IntPtr(10),
+					Memory: pulumi.IntPtr(32),
+				},
+			},
+			ExecutionRole: &awsx.DefaultRoleWithPolicyArgs{
+				RoleArn: pulumi.StringPtr(e.ECSTaskExecutionRole()),
+			},
+			TaskRole: &awsx.DefaultRoleWithPolicyArgs{
+				RoleArn: pulumi.StringPtr(e.ECSTaskRole()),
+			},
+			NetworkMode: pulumi.StringPtr("none"),
+			Family:      e.Namer.DisplayName(255, pulumi.String("tracegen-tcp-ec2")),
+		},
+	}, opts...); err != nil {
+		return nil, err
+	}
+
+	return ecsComponent, nil
+}

--- a/components/datadog/apps/tracegen/ecs.go
+++ b/components/datadog/apps/tracegen/ecs.go
@@ -96,7 +96,7 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...
 			TaskRole: &awsx.DefaultRoleWithPolicyArgs{
 				RoleArn: pulumi.StringPtr(e.ECSTaskRole()),
 			},
-			NetworkMode: pulumi.StringPtr("none"),
+			NetworkMode: pulumi.StringPtr("bridge"),
 			Family:      e.CommonNamer.DisplayName(255, pulumi.String("tracegen-tcp-ec2")),
 		},
 	}, opts...); err != nil {

--- a/components/datadog/apps/tracegen/ecs.go
+++ b/components/datadog/apps/tracegen/ecs.go
@@ -1,7 +1,6 @@
 package tracegen
 
 import (
-	"fmt"
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 	classicECS "github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ecs"
@@ -10,19 +9,12 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-//classicECS.ServicePlacementConstraintArray{
-//classicECS.ServicePlacementConstraintArgs{
-//Type:       pulumi.String("memberOf"),
-//Expression: pulumi.StringPtr("attribute:ecs.os-type == linux"),
-//},
-//},
-
 type EcsComponent struct {
 	pulumi.ResourceState
 }
 
-func EcsAppDefinition(e aws.Environment, workloadName string, clusterArn pulumi.StringInput, opts ...pulumi.ResourceOption) (*EcsComponent, error) {
-	namer := e.Namer.WithPrefix(fmt.Sprintf("%s/tracegen", workloadName))
+func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...pulumi.ResourceOption) (*EcsComponent, error) {
+	namer := e.Namer.WithPrefix("tracegen")
 	opts = append(opts, e.WithProviders(config.ProviderAWS, config.ProviderAWSX))
 
 	ecsComponent := &EcsComponent{}
@@ -66,7 +58,7 @@ func EcsAppDefinition(e aws.Environment, workloadName string, clusterArn pulumi.
 				RoleArn: pulumi.StringPtr(e.ECSTaskRole()),
 			},
 			NetworkMode: pulumi.StringPtr("none"),
-			Family:      e.Namer.DisplayName(255, pulumi.String("tracegen-uds-ec2")),
+			Family:      e.CommonNamer.DisplayName(255, pulumi.String("tracegen-uds-ec2")),
 			Volumes: classicECS.TaskDefinitionVolumeArray{
 				classicECS.TaskDefinitionVolumeArgs{
 					Name:     pulumi.String("apmsocketpath"),
@@ -105,7 +97,7 @@ func EcsAppDefinition(e aws.Environment, workloadName string, clusterArn pulumi.
 				RoleArn: pulumi.StringPtr(e.ECSTaskRole()),
 			},
 			NetworkMode: pulumi.StringPtr("none"),
-			Family:      e.Namer.DisplayName(255, pulumi.String("tracegen-tcp-ec2")),
+			Family:      e.CommonNamer.DisplayName(255, pulumi.String("tracegen-tcp-ec2")),
 		},
 	}, opts...); err != nil {
 		return nil, err

--- a/scenarios/aws/ecs/run.go
+++ b/scenarios/aws/ecs/run.go
@@ -8,10 +8,12 @@ import (
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/nginx"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/prometheus"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/redis"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/tracegen"
 	fakeintakeComp "github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	resourcesAws "github.com/DataDog/test-infra-definitions/resources/aws"
 	"github.com/DataDog/test-infra-definitions/resources/aws/ecs"
 	"github.com/DataDog/test-infra-definitions/scenarios/aws/fakeintake"
+
 	"github.com/pulumi/pulumi-aws/sdk/v5/go/aws/ssm"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -143,6 +145,10 @@ func Run(ctx *pulumi.Context) error {
 		}
 
 		if _, err := prometheus.EcsAppDefinition(awsEnv, ecsCluster.Arn); err != nil {
+			return err
+		}
+
+		if _, err := tracegen.EcsAppDefinition(awsEnv, ecsCluster.Arn); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
What does this PR do?
---------------------
This PR adds a tracegen to the AWS/ECS scenario. The task has placement constraints to get scheduled on either bottlerocket (cgroupv1) or linux (cgroupv2) nodegroups.

Which scenarios this will impact?
-------------------
aws/ecs

Motivation
----------
We would like to test that traces and origin detection are working on ECS.

Additional Notes
----------------
