### PR TITLE
[CONTINT-3858] Remove nodeselectors from tracegen

### DIFF
--- a/components/datadog/apps/tracegen/k8s.go
+++ b/components/datadog/apps/tracegen/k8s.go
@@ -17,11 +17,11 @@ type K8sComponent struct {
 	pulumi.ResourceState
 }
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, nodeSelector pulumi.StringMapInput, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &K8sComponent{}
-	if err := e.Ctx.RegisterComponentResource("dd:apps", fmt.Sprintf("%s/tracegen", namespace), k8sComponent, opts...); err != nil {
+	if err := e.Ctx.RegisterComponentResource("dd:apps", fmt.Sprintf("%s-tracegen", namespace), k8sComponent, opts...); err != nil {
 		return nil, err
 	}
 
@@ -60,7 +60,6 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 					},
 				},
 				Spec: &corev1.PodSpecArgs{
-					NodeSelector: nodeSelector,
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("tracegen-uds"),
@@ -126,7 +125,6 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 					},
 				},
 				Spec: &corev1.PodSpecArgs{
-					NodeSelector: nodeSelector,
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("tracegen-tcp"),

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -29,9 +29,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-// eksNodeSelector is the label used to select the node group for tracegen
-const eksNodeSelector = "eks.amazonaws.com/nodegroup"
-
 func Run(ctx *pulumi.Context) error {
 	awsEnv, err := resourcesAws.NewEnvironment(ctx)
 	if err != nil {
@@ -136,8 +133,6 @@ func Run(ctx *pulumi.Context) error {
 		comp.KubeConfig = cluster.KubeconfigJson
 
 		nodeGroups := make([]pulumi.Resource, 0)
-		var cgroupV1Ng pulumi.StringOutput
-		var cgroupV2Ng pulumi.StringOutput
 		// Create managed node groups
 		if awsEnv.EKSLinuxNodeGroup() {
 			ng, err := localEks.NewLinuxNodeGroup(awsEnv, cluster, linuxNodeRole)
@@ -145,8 +140,6 @@ func Run(ctx *pulumi.Context) error {
 				return err
 			}
 			nodeGroups = append(nodeGroups, ng)
-			// The default AMI used for Amazon Linux 2 is using cgroupv1
-			cgroupV1Ng = ng.NodeGroup.NodeGroupName()
 		}
 
 		if awsEnv.EKSLinuxARMNodeGroup() {
@@ -155,7 +148,6 @@ func Run(ctx *pulumi.Context) error {
 				return err
 			}
 			nodeGroups = append(nodeGroups, ng)
-			cgroupV1Ng = ng.NodeGroup.NodeGroupName()
 		}
 
 		if awsEnv.EKSBottlerocketNodeGroup() {
@@ -164,8 +156,6 @@ func Run(ctx *pulumi.Context) error {
 				return err
 			}
 			nodeGroups = append(nodeGroups, ng)
-			// Bottlerocket uses cgroupv2
-			cgroupV2Ng = ng.NodeGroup.NodeGroupName()
 		}
 
 		// Create unmanaged node groups
@@ -277,11 +267,7 @@ func Run(ctx *pulumi.Context) error {
 				return err
 			}
 
-			if _, err := tracegen.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-tracegen-cgroupv1", pulumi.StringMap{eksNodeSelector: cgroupV1Ng}); err != nil {
-				return err
-			}
-
-			if _, err := tracegen.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-tracegen-cgroupv2", pulumi.StringMap{eksNodeSelector: cgroupV2Ng}); err != nil {
+			if _, err := tracegen.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-tracegen"); err != nil {
 				return err
 			}
 

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -137,7 +137,7 @@ agents:
 		}
 
 		// for tracegen we can't find the cgroup version as it depends on the underlying version of the kernel
-		if _, err := tracegen.K8sAppDefinition(*awsEnv.CommonEnvironment, kindKubeProvider, "workload-tracegen", nil); err != nil {
+		if _, err := tracegen.K8sAppDefinition(*awsEnv.CommonEnvironment, kindKubeProvider, "workload-tracegen"); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
What does this PR do?
---------------------
This PR removes nodeselectors from tracegen. They are not necessary to schedule the pods. Originally we introduced them to schedule the workloads on identified cgroupv1 / cgroupv2 nodes but now we prefer to run all the tests on kind with either cgroupv1 or cgroupv2 AMI.

Which scenarios this will impact?
-------------------
aws/eks, aws/kind

Motivation
----------
Simplify the e2e tests

Additional Notes
----------------
