### PR TITLE
[CONTINT-3557] Disable origin detection dogstatsd udp

### DIFF
--- a/components/datadog/apps/dogstatsd/k8s.go
+++ b/components/datadog/apps/dogstatsd/k8s.go
@@ -151,6 +151,13 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 										},
 									},
 								},
+								&corev1.EnvVarArgs{
+									// This test should only make sure that when DD_ENTITY_ID is set, pod tags are retrieved
+									// A change in agent 7.53 will make this test fail as it will be able to retrieve container tags.
+									// https://github.com/DataDog/datadog-go/blob/208eafd4be2b9752131e66446497244328956b4d/statsd/statsd.go#L104C28-L104C55
+									Name:  pulumi.String("DD_ORIGIN_DETECTION_ENABLED"),
+									Value: pulumi.String("false"),
+								},
 							},
 							Resources: &corev1.ResourceRequirementsArgs{
 								Limits: pulumi.StringMap{


### PR DESCRIPTION
What does this PR do?
---------------------
Disable origin detection for the dogstatsd-udp app as it will break when we change the default behavior of origin detection to use container-tags first.

Another PR will add a workload with dogstatsd udp + origin detection

Which scenarios this will impact?
-------------------
all k8s scenarios

Motivation
----------

Additional Notes
----------------
