### PR TITLE
ECS nginx/redis without LBs

### DIFF
--- a/components/datadog/apps/nginx/ecs.go
+++ b/components/datadog/apps/nginx/ecs.go
@@ -8,7 +8,6 @@ import (
 	classicECS "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ecs"
 	"github.com/pulumi/pulumi-awsx/sdk/v2/go/awsx/awsx"
 	"github.com/pulumi/pulumi-awsx/sdk/v2/go/awsx/ecs"
-	"github.com/pulumi/pulumi-awsx/sdk/v2/go/awsx/lb"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -26,27 +25,6 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...
 	}
 
 	opts = append(opts, pulumi.Parent(ecsComponent))
-
-	alb, err := lb.NewApplicationLoadBalancer(e.Ctx, namer.ResourceName("lb"), &lb.ApplicationLoadBalancerArgs{
-		Name:           e.CommonNamer.DisplayName(32, pulumi.String("nginx"), pulumi.String("ec2")),
-		SubnetIds:      e.RandomSubnets(),
-		Internal:       pulumi.BoolPtr(true),
-		SecurityGroups: pulumi.ToStringArray(e.DefaultSecurityGroups()),
-		DefaultTargetGroup: &lb.TargetGroupArgs{
-			Name:       e.CommonNamer.DisplayName(32, pulumi.String("nginx"), pulumi.String("ec2")),
-			Port:       pulumi.IntPtr(80),
-			Protocol:   pulumi.StringPtr("HTTP"),
-			TargetType: pulumi.StringPtr("instance"),
-			VpcId:      pulumi.StringPtr(e.DefaultVPCID()),
-		},
-		Listener: &lb.ListenerArgs{
-			Port:     pulumi.IntPtr(80),
-			Protocol: pulumi.StringPtr("HTTP"),
-		},
-	}, opts...)
-	if err != nil {
-		return nil, err
-	}
 
 	if _, err := ecs.NewEC2Service(e.Ctx, namer.ResourceName("server"), &ecs.EC2ServiceArgs{
 		Name:                 e.CommonNamer.DisplayName(255, pulumi.String("nginx"), pulumi.String("ec2")),
@@ -102,6 +80,17 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...
 						Timeout:  pulumi.Int(5),
 					},
 				},
+				"query": {
+					Name:  pulumi.String("query"),
+					Image: pulumi.String("ghcr.io/datadog/apps-http-client:main"),
+					Command: pulumi.StringArray{
+						pulumi.String("-url"),
+						pulumi.String("http://nginx"),
+					},
+					Cpu:    pulumi.IntPtr(50),
+					Memory: pulumi.IntPtr(32),
+					Links:  pulumi.ToStringArray([]string{"nginx:nginx"}),
+				},
 			},
 			ExecutionRole: &awsx.DefaultRoleWithPolicyArgs{
 				RoleArn: pulumi.StringPtr(e.ECSTaskExecutionRole()),
@@ -125,44 +114,6 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...
 					},
 				},
 			},
-		},
-		LoadBalancers: classicECS.ServiceLoadBalancerArray{
-			&classicECS.ServiceLoadBalancerArgs{
-				ContainerName:  pulumi.String("nginx"),
-				ContainerPort:  pulumi.Int(80),
-				TargetGroupArn: alb.DefaultTargetGroup.Arn(),
-			},
-		},
-	}, opts...); err != nil {
-		return nil, err
-	}
-
-	if _, err := ecs.NewEC2Service(e.Ctx, namer.ResourceName("query"), &ecs.EC2ServiceArgs{
-		Name:                 e.CommonNamer.DisplayName(255, pulumi.ToStringArray([]string{"nginx", "ec2", "query"})...),
-		Cluster:              clusterArn,
-		DesiredCount:         pulumi.IntPtr(1),
-		EnableExecuteCommand: pulumi.BoolPtr(true),
-		TaskDefinitionArgs: &ecs.EC2ServiceTaskDefinitionArgs{
-			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
-				"query": {
-					Name:  pulumi.String("query"),
-					Image: pulumi.String("ghcr.io/datadog/apps-http-client:main"),
-					Command: pulumi.StringArray{
-						pulumi.String("-url"),
-						pulumi.Sprintf("http://%s", alb.LoadBalancer.DnsName()),
-					},
-					Cpu:    pulumi.IntPtr(50),
-					Memory: pulumi.IntPtr(32),
-				},
-			},
-			ExecutionRole: &awsx.DefaultRoleWithPolicyArgs{
-				RoleArn: pulumi.StringPtr(e.ECSTaskExecutionRole()),
-			},
-			TaskRole: &awsx.DefaultRoleWithPolicyArgs{
-				RoleArn: pulumi.StringPtr(e.ECSTaskRole()),
-			},
-			NetworkMode: pulumi.StringPtr("bridge"),
-			Family:      e.CommonNamer.DisplayName(255, pulumi.ToStringArray([]string{"nginx", "ec2", "query"})...),
 		},
 	}, opts...); err != nil {
 		return nil, err

--- a/components/datadog/apps/redis/ecsFargate.go
+++ b/components/datadog/apps/redis/ecsFargate.go
@@ -7,7 +7,6 @@ import (
 	ecsClient "github.com/DataDog/test-infra-definitions/resources/aws/ecs"
 	classicECS "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ecs"
 	"github.com/pulumi/pulumi-awsx/sdk/v2/go/awsx/ecs"
-	"github.com/pulumi/pulumi-awsx/sdk/v2/go/awsx/lb"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -26,26 +25,6 @@ func FargateAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, apiK
 	}
 
 	opts = append(opts, pulumi.Parent(EcsFargateComponent))
-
-	nlb, err := lb.NewNetworkLoadBalancer(e.Ctx, namer.ResourceName("lb"), &lb.NetworkLoadBalancerArgs{
-		Name:      e.CommonNamer.DisplayName(32, pulumi.String("redis"), pulumi.String("fg")),
-		SubnetIds: e.RandomSubnets(),
-		Internal:  pulumi.BoolPtr(true),
-		DefaultTargetGroup: &lb.TargetGroupArgs{
-			Name:       e.CommonNamer.DisplayName(32, pulumi.String("redis"), pulumi.String("fg")),
-			Port:       pulumi.IntPtr(6379),
-			Protocol:   pulumi.StringPtr("TCP"),
-			TargetType: pulumi.StringPtr("ip"),
-			VpcId:      pulumi.StringPtr(e.DefaultVPCID()),
-		},
-		Listener: &lb.ListenerArgs{
-			Port:     pulumi.IntPtr(6379),
-			Protocol: pulumi.StringPtr("TCP"),
-		},
-	}, opts...)
-	if err != nil {
-		return nil, err
-	}
 
 	serverContainer := &ecs.TaskDefinitionContainerDefinitionArgs{
 		Name:  pulumi.String("redis"),
@@ -71,7 +50,27 @@ func FargateAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, apiK
 		LogConfiguration: ecsClient.GetFirelensLogConfiguration(pulumi.String("redis"), pulumi.String("redis"), apiKeySSMParamName),
 	}
 
-	serverTaskDef, err := ecsClient.FargateTaskDefinitionWithAgent(e, "redis-fg-server", pulumi.String("redis-fg"), 1024, 2048, map[string]ecs.TaskDefinitionContainerDefinitionArgs{"redis": *serverContainer}, apiKeySSMParamName, fakeIntake, opts...)
+	queryContainer := &ecs.TaskDefinitionContainerDefinitionArgs{
+		Name:  e.CommonNamer.DisplayName(255, pulumi.String("query")),
+		Image: pulumi.String("ghcr.io/datadog/apps-redis-client:main"),
+		Command: pulumi.StringArray{
+			pulumi.String("-addr"),
+			pulumi.Sprintf("localhost:6379"),
+		},
+		Cpu:       pulumi.IntPtr(50),
+		Memory:    pulumi.IntPtr(32),
+		Essential: pulumi.BoolPtr(true),
+	}
+
+	serverTaskDef, err := ecsClient.FargateTaskDefinitionWithAgent(e, "redis-fg", pulumi.String("redis-fg"), 1024, 2048,
+		map[string]ecs.TaskDefinitionContainerDefinitionArgs{
+			"redis": *serverContainer,
+			"query": *queryContainer,
+		},
+		apiKeySSMParamName,
+		fakeIntake,
+		opts...,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -83,49 +82,9 @@ func FargateAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, apiK
 		NetworkConfiguration: classicECS.ServiceNetworkConfigurationArgs{
 			AssignPublicIp: pulumi.BoolPtr(e.ECSServicePublicIP()),
 			SecurityGroups: pulumi.ToStringArray(e.DefaultSecurityGroups()),
-			Subnets:        nlb.LoadBalancer.Subnets(),
+			Subnets:        e.RandomSubnets(),
 		},
 		TaskDefinition:            serverTaskDef.TaskDefinition.Arn(),
-		EnableExecuteCommand:      pulumi.BoolPtr(true),
-		ContinueBeforeSteadyState: pulumi.BoolPtr(true),
-		LoadBalancers: classicECS.ServiceLoadBalancerArray{
-			&classicECS.ServiceLoadBalancerArgs{
-				ContainerName:  pulumi.String("redis"),
-				ContainerPort:  pulumi.Int(6379),
-				TargetGroupArn: nlb.DefaultTargetGroup.Arn(),
-			},
-		},
-	}, opts...); err != nil {
-		return nil, err
-	}
-
-	queryContainer := &ecs.TaskDefinitionContainerDefinitionArgs{
-		Name:  e.CommonNamer.DisplayName(255, pulumi.String("query")),
-		Image: pulumi.String("ghcr.io/datadog/apps-redis-client:main"),
-		Command: pulumi.StringArray{
-			pulumi.String("-addr"),
-			pulumi.Sprintf("%s:6379", nlb.LoadBalancer.DnsName()),
-		},
-		Cpu:       pulumi.IntPtr(50),
-		Memory:    pulumi.IntPtr(32),
-		Essential: pulumi.BoolPtr(true),
-	}
-
-	queryTaskDef, err := ecsClient.FargateTaskDefinitionWithAgent(e, "redis-fg-query", pulumi.String("redis-fg-query"), 1024, 2048, map[string]ecs.TaskDefinitionContainerDefinitionArgs{"query": *queryContainer}, apiKeySSMParamName, fakeIntake, opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	if _, err := ecs.NewFargateService(e.Ctx, namer.ResourceName("query"), &ecs.FargateServiceArgs{
-		Cluster:      clusterArn,
-		Name:         e.CommonNamer.DisplayName(255, pulumi.ToStringArray([]string{"redis", "fg", "query"})...),
-		DesiredCount: pulumi.IntPtr(1),
-		NetworkConfiguration: classicECS.ServiceNetworkConfigurationArgs{
-			AssignPublicIp: pulumi.BoolPtr(e.ECSServicePublicIP()),
-			SecurityGroups: pulumi.ToStringArray(e.DefaultSecurityGroups()),
-			Subnets:        nlb.LoadBalancer.Subnets(),
-		},
-		TaskDefinition:            queryTaskDef.TaskDefinition.Arn(),
 		EnableExecuteCommand:      pulumi.BoolPtr(true),
 		ContinueBeforeSteadyState: pulumi.BoolPtr(true),
 	}, opts...); err != nil {


### PR DESCRIPTION
What does this PR do?
---------------------

Remove LBs from `nginx` and `redis` on ECS/Fargate.
On ECS EC2 it's replaced by `links`.
On ECS Fargate we share network namespace, so localhost.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
