### PR TITLE
Fix: pin cpustress image tag

### DIFF
--- a/components/datadog/apps/cpustress/common.go
+++ b/components/datadog/apps/cpustress/common.go
@@ -1,0 +1,12 @@
+package cpustress
+
+import "fmt"
+
+const (
+	defaultStressNgImageRepo = "ghcr.io/colinianking/stress-ng"
+	defaultStressNgImageTag  = "409201de7458c639c68088d28ec8270ef599fe47"
+)
+
+func getStressNGImage() string {
+	return fmt.Sprintf("%s:%s", defaultStressNgImageRepo, defaultStressNgImageTag)
+}

--- a/components/datadog/apps/cpustress/ecs.go
+++ b/components/datadog/apps/cpustress/ecs.go
@@ -33,7 +33,7 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...
 			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
 				"stress-ng": {
 					Name:  pulumi.String("stress-ng"),
-					Image: pulumi.String("ghcr.io/colinianking/stress-ng"),
+					Image: pulumi.String(getStressNGImage()),
 					Command: pulumi.StringArray{
 						pulumi.String("--cpu=1"),
 						pulumi.String("--cpu-load=15"),

--- a/components/datadog/apps/cpustress/k8s.go
+++ b/components/datadog/apps/cpustress/k8s.go
@@ -61,7 +61,7 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 					Containers: corev1.ContainerArray{
 						corev1.ContainerArgs{
 							Name:  pulumi.String("stress-ng"),
-							Image: pulumi.String("ghcr.io/colinianking/stress-ng"),
+							Image: pulumi.String(getStressNGImage()),
 							Args: pulumi.StringArray{
 								pulumi.String("--cpu=1"),
 								pulumi.String("--cpu-load=15"),


### PR DESCRIPTION
What does this PR do?
---------------------

Pin the `stress-ng` image tag for e2e stability and reproducibility.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
