### PR TITLE
Add silent, show-error, fail and retries to curl commands

### DIFF
--- a/components/datadog/agent/host_linuxos.go
+++ b/components/datadog/agent/host_linuxos.go
@@ -35,7 +35,7 @@ func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersio
 		commandLine := strings.Join(testEnvVars, " ")
 
 		return fmt.Sprintf(
-			`curl -L https://s3.amazonaws.com/dd-agent/scripts/%v --retry 10 -o install-script.sh && for i in 1 2 3; do DD_API_KEY=%%s %v bash install-script.sh  && break || sleep 2; done`,
+			`curl --retry 10 -fsSL https://s3.amazonaws.com/dd-agent/scripts/%v  -o install-script.sh && for i in 1 2 3; do DD_API_KEY=%%s %v bash install-script.sh  && break || sleep 2 && done`,
 			"install_script_agent7.sh",
 			commandLine), nil
 	}
@@ -51,7 +51,7 @@ func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersio
 	}
 
 	return fmt.Sprintf(
-		`curl -L https://s3.amazonaws.com/dd-agent/scripts/%v --retry 10 -o install-script.sh && for i in 1 2 3; do DD_API_KEY=%%s %v DD_INSTALL_ONLY=true bash install-script.sh  && break || sleep 2; done`,
+		`curl --retry 10 -fsSL https://s3.amazonaws.com/dd-agent/scripts/%v -o install-script.sh && for i in 1 2 3; do DD_API_KEY=%%s %v DD_INSTALL_ONLY=true bash install-script.sh  && break || sleep 2; done`,
 		fmt.Sprintf("install_script_agent%s.sh", version.Major),
 		commandLine), nil
 }

--- a/components/docker/docker.go
+++ b/components/docker/docker.go
@@ -159,7 +159,7 @@ func (d *Manager) install() (*remote.Command, error) {
 }
 
 func (d *Manager) installCompose() (*remote.Command, error) {
-	installCompose := pulumi.Sprintf("bash -c '(docker-compose version | grep %s) || (curl -SL https://github.com/docker/compose/releases/download/%s/docker-compose-linux-$(uname -p) -o /usr/local/bin/docker-compose && sudo chmod 755 /usr/local/bin/docker-compose)'", composeVersion, composeVersion)
+	installCompose := pulumi.Sprintf("bash -c '(docker-compose version | grep %s) || (curl --retry 10 -fsSL https://github.com/docker/compose/releases/download/%s/docker-compose-linux-$(uname -p) -o /usr/local/bin/docker-compose && sudo chmod 755 /usr/local/bin/docker-compose)'", composeVersion, composeVersion)
 	return d.host.OS.Runner().Command(
 		d.namer.ResourceName("install-compose"),
 		&command.Args{

--- a/components/kubernetes/kind.go
+++ b/components/kubernetes/kind.go
@@ -56,7 +56,7 @@ func NewKindCluster(env config.CommonEnvironment, vm *remote.Host, resourceName,
 		kindInstall, err := runner.Command(
 			commonEnvironment.CommonNamer.ResourceName("kind-install"),
 			&command.Args{
-				Create: pulumi.Sprintf(`curl -Lo ./kind "https://kind.sigs.k8s.io/dl/%s/kind-linux-%s" && sudo install kind /usr/local/bin/kind`, kindVersionConfig.kindVersion, kindArch),
+				Create: pulumi.Sprintf(`curl --retry 10 --fsSLo ./kind "https://kind.sigs.k8s.io/dl/%s/kind-linux-%s" && sudo install kind /usr/local/bin/kind`, kindVersionConfig.kindVersion, kindArch),
 			},
 			opts...,
 		)


### PR DESCRIPTION
What does this PR do?
---------------------

Add `-fsS --retry 10` options to curl command

Which scenarios this will impact?
-------------------

host, docker, kind

Motivation
----------

We see weird failures at agent install, failing at the create config file step, while curl reports "empty server response". I suspect the command does not return an error code. Adding these options everywhere to have more infos in logs and to uniform curl usage.

Additional Notes
----------------
