### PR TITLE
add graceful shutdown with poison pill to tracegen

### DIFF
--- a/components/datadog/apps/tracegen/images/tracegen/main.go
+++ b/components/datadog/apps/tracegen/images/tracegen/main.go
@@ -26,8 +26,7 @@ func reportStats(done chan struct{}) {
 		select {
 		case <-done:
 			return
-		default:
-			time.Sleep(5 * time.Second)
+		case <-time.After(5 * time.Second):
 			tc := tracecount.Swap(0)
 			sc := spancount.Swap(0)
 			fmt.Printf("Finished %d traces/s, %d spans/second.\n", tc/5, sc/5)
@@ -99,6 +98,7 @@ func main() {
 		<-sigs
 		close(done)
 		fmt.Println("Exiting tracegen.")
+		time.Sleep(10 * time.Second) // alow time for other goroutines to shut down.
 		os.Exit(0)
 	}()
 
@@ -120,6 +120,8 @@ func main() {
 	for {
 		select {
 		case <-done:
+			sp := tracer.StartSpan("poison_pill")
+			sp.Finish()
 			return
 		default:
 			istart := time.Now()


### PR DESCRIPTION
What does this PR do?
---------------------

This PR makes the tracegen send one final trace on shutdown, which can signal to consumers in the pipeline that no more traces for this run are coming.

Which scenarios this will impact?
-------------------

This will affect the APM scenarios

Motivation
----------

Sometimes tests get data from previous tests, when the data hasn't made its way fully from the tracegen, through the agent, to the intake before the next test starts.

Additional Notes
----------------
