### PR TITLE
[CONTINT-3906] Add workloads for dogstatsd origin detection

### DIFF
--- a/components/datadog/agent/ecs.go
+++ b/components/datadog/agent/ecs.go
@@ -107,6 +107,11 @@ func ecsLinuxAgentSingleContainerDefinition(e config.CommonEnvironment, apiKeySS
 				Value: pulumi.StringPtr("true"),
 			},
 			ecs.TaskDefinitionKeyValuePairArgs{
+				Name:  pulumi.StringPtr("DD_DOGSTATSD_ORIGIN_DETECTION_CLIENT"),
+				Value: pulumi.StringPtr("true"),
+			},
+
+			ecs.TaskDefinitionKeyValuePairArgs{
 				Name:  pulumi.StringPtr("DD_DOGSTATSD_SOCKET"),
 				Value: pulumi.StringPtr("/var/run/datadog/dsd.socket"),
 			},

--- a/components/datadog/apps/dogstatsd/ecs.go
+++ b/components/datadog/apps/dogstatsd/ecs.go
@@ -79,8 +79,14 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...
 		TaskDefinitionArgs: &ecs.EC2ServiceTaskDefinitionArgs{
 			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
 				"dogstatsd": {
-					Name:   pulumi.String("dogstatsd"),
-					Image:  pulumi.String("ghcr.io/datadog/apps-dogstatsd:main"),
+					Name:  pulumi.String("dogstatsd"),
+					Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:main"),
+					Environment: ecs.TaskDefinitionKeyValuePairArray{
+						ecs.TaskDefinitionKeyValuePairArgs{
+							Name:  pulumi.StringPtr("ECS_AGENT_HOST"),
+							Value: pulumi.StringPtr("true"),
+						},
+					},
 					Cpu:    pulumi.IntPtr(10),
 					Memory: pulumi.IntPtr(32),
 				},

--- a/components/datadog/apps/dogstatsd/ecs.go
+++ b/components/datadog/apps/dogstatsd/ecs.go
@@ -71,5 +71,32 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...
 		return nil, err
 	}
 
+	if _, err := ecs.NewEC2Service(e.Ctx, namer.ResourceName("udp"), &ecs.EC2ServiceArgs{
+		Name:                 e.CommonNamer.DisplayName(255, pulumi.String("dogstatsd-udp")),
+		Cluster:              clusterArn,
+		DesiredCount:         pulumi.IntPtr(1),
+		EnableExecuteCommand: pulumi.BoolPtr(true),
+		TaskDefinitionArgs: &ecs.EC2ServiceTaskDefinitionArgs{
+			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
+				"dogstatsd": {
+					Name:   pulumi.String("dogstatsd"),
+					Image:  pulumi.String("ghcr.io/datadog/apps-dogstatsd:main"),
+					Cpu:    pulumi.IntPtr(10),
+					Memory: pulumi.IntPtr(32),
+				},
+			},
+			ExecutionRole: &awsx.DefaultRoleWithPolicyArgs{
+				RoleArn: pulumi.StringPtr(e.ECSTaskExecutionRole()),
+			},
+			TaskRole: &awsx.DefaultRoleWithPolicyArgs{
+				RoleArn: pulumi.StringPtr(e.ECSTaskRole()),
+			},
+			NetworkMode: pulumi.StringPtr("bridge"),
+			Family:      e.CommonNamer.DisplayName(255, pulumi.String("dogstatsd-udp-ec2")),
+		},
+	}, opts...); err != nil {
+		return nil, err
+	}
+
 	return ecsComponent, nil
 }

--- a/components/datadog/apps/dogstatsd/images/dogstatsd/go.mod
+++ b/components/datadog/apps/dogstatsd/images/dogstatsd/go.mod
@@ -2,7 +2,8 @@ module dogstatsd
 
 go 1.21
 
-require github.com/DataDog/datadog-go/v5 v5.5.0
+// Temporary replacement of the main branch until https://github.com/DataDog/datadog-go/pull/302 is released
+require github.com/DataDog/datadog-go/v5 v5.5.1-0.20240307111531-3f5998a2da25
 
 require (
 	github.com/Microsoft/go-winio v0.5.0 // indirect

--- a/components/datadog/apps/dogstatsd/images/dogstatsd/go.sum
+++ b/components/datadog/apps/dogstatsd/images/dogstatsd/go.sum
@@ -1,5 +1,5 @@
-github.com/DataDog/datadog-go/v5 v5.5.0 h1:G5KHeB8pWBNXT4Jtw0zAkhdxEAWSpWH00geHI6LDrKU=
-github.com/DataDog/datadog-go/v5 v5.5.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
+github.com/DataDog/datadog-go/v5 v5.5.1-0.20240307111531-3f5998a2da25 h1:yhJAhV6ew3Ybea81k7h04X/3VT6FJq3NMj53jd2n1kw=
+github.com/DataDog/datadog-go/v5 v5.5.1-0.20240307111531-3f5998a2da25/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/Microsoft/go-winio v0.5.0 h1:Elr9Wn+sGKPlkaBvwu4mTrxtmOp3F3yV9qhaHbXGjwU=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
What does this PR do?
---------------------
This PR:
- Adds dogstatsd in the k8s scenario without DD_ENTITY_ID
- Adds dogstatsd in the ECS scenario
- Changes the statsd library used by dogstatsd to include the origin detection bugfix

Which scenarios this will impact?
-------------------
aws/eks aws/kind aws/ecs azure/aks

Motivation
----------

Additional Notes
----------------
