### PR TITLE
Allow passing additional parameters to the installer

### DIFF
--- a/components/datadog/agent/host.go
+++ b/components/datadog/agent/host.go
@@ -62,7 +62,7 @@ func NewHostAgent(e *config.CommonEnvironment, host *remoteComp.Host, options ..
 }
 
 func (h *HostAgent) installAgent(env *config.CommonEnvironment, params *agentparams.Params, baseOpts ...pulumi.ResourceOption) error {
-	installCmdStr, err := h.manager.getInstallCommand(params.Version)
+	installCmdStr, err := h.manager.getInstallCommand(params.Version, params.AdditionalInstallParameters)
 	if err != nil {
 		return err
 	}

--- a/components/datadog/agent/host_linuxos.go
+++ b/components/datadog/agent/host_linuxos.go
@@ -21,7 +21,7 @@ func newLinuxManager(host *remoteComp.Host) agentOSManager {
 	return &agentLinuxManager{targetOS: host.OS}
 }
 
-func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersion) (string, error) {
+func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersion, _ []string) (string, error) {
 	if version.PipelineID != "" {
 		testEnvVars := []string{}
 		testEnvVars = append(testEnvVars, "TESTING_APT_URL=apttesting.datad0g.com")

--- a/components/datadog/agent/host_os.go
+++ b/components/datadog/agent/host_os.go
@@ -2,9 +2,9 @@ package agent
 
 import (
 	"fmt"
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 
 	"github.com/DataDog/test-infra-definitions/components/command"
-	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/components/os"
 	remoteComp "github.com/DataDog/test-infra-definitions/components/remote"
 
@@ -14,7 +14,7 @@ import (
 
 // internal interface to be able to provide the different OS-specific commands
 type agentOSManager interface {
-	getInstallCommand(version agentparams.PackageVersion) (string, error)
+	getInstallCommand(version agentparams.PackageVersion, additionalInstallParameters []string) (string, error)
 	getAgentConfigFolder() string
 	restartAgentServices(transform command.Transformer, opts ...pulumi.ResourceOption) (*remote.Command, error)
 }

--- a/components/datadog/agentparams/msi/install_params.go
+++ b/components/datadog/agentparams/msi/install_params.go
@@ -1,8 +1,3 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2023-present Datadog, Inc.
-
 package msi
 
 import (

--- a/components/datadog/agentparams/msi/install_params.go
+++ b/components/datadog/agentparams/msi/install_params.go
@@ -1,0 +1,89 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package msi
+
+import (
+	"fmt"
+	"github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
+	"reflect"
+)
+
+// MSIInstallAgentParams are the parameters used for installing the Agent using msiexec.
+type MSIInstallAgentParams struct {
+	AgentUser           string `installer_arg:"DDAGENTUSER_NAME"`
+	AgentUserPassword   string `installer_arg:"DDAGENTUSER_PASSWORD"`
+	DdURL               string `installer_arg:"DD_URL"`
+	WixFailWhenDeferred string `installer_arg:"WIXFAILWHENDEFERRED"`
+	InstallLogFile      string
+}
+
+// MSIInstallAgentOption is an optional function parameter type for MSIInstallAgentParams options
+type MSIInstallAgentOption = func(*MSIInstallAgentParams)
+
+func NewInstallParams(msiInstallParams ...MSIInstallAgentOption) []string {
+	msiInstallAgentParams := &MSIInstallAgentParams{}
+	for _, o := range msiInstallParams {
+		o(msiInstallAgentParams)
+	}
+	return msiInstallAgentParams.toArgs()
+}
+
+// ToArgs convert the params to a list of valid msi switches, based on the `installer_arg` tag
+func (p *MSIInstallAgentParams) toArgs() []string {
+	var args []string
+	typeOfMSIInstallAgentParams := reflect.TypeOf(*p)
+	for fieldIndex := 0; fieldIndex < typeOfMSIInstallAgentParams.NumField(); fieldIndex++ {
+		field := typeOfMSIInstallAgentParams.Field(fieldIndex)
+		installerArg := field.Tag.Get("installer_arg")
+		if installerArg != "" {
+			installerArgValue := reflect.ValueOf(*p).FieldByName(field.Name).String()
+			if installerArgValue != "" {
+				args = append(args, fmt.Sprintf("%s=%s", installerArg, installerArgValue))
+			}
+		}
+	}
+	return args
+}
+
+// WithAgentUser specifies the DDAGENTUSER_NAME parameter.
+func WithAgentUser(username string) MSIInstallAgentOption {
+	return func(i *MSIInstallAgentParams) {
+		i.AgentUser = username
+	}
+}
+
+// WithAgentUserPassword specifies the DDAGENTUSER_PASSWORD parameter.
+func WithAgentUserPassword(password string) MSIInstallAgentOption {
+	return func(i *MSIInstallAgentParams) {
+		i.AgentUserPassword = password
+	}
+}
+
+// WithDdURL specifies the DD_URL parameter.
+func WithDdURL(ddURL string) MSIInstallAgentOption {
+	return func(i *MSIInstallAgentParams) {
+		i.DdURL = ddURL
+	}
+}
+
+// WithInstallLogFile specifies the file where to save the MSI install logs.
+func WithInstallLogFile(logFileName string) MSIInstallAgentOption {
+	return func(i *MSIInstallAgentParams) {
+		i.InstallLogFile = logFileName
+	}
+}
+
+// WithFakeIntake configures the Agent to use a fake intake URL.
+func WithFakeIntake(fakeIntake *fakeintake.FakeintakeOutput) MSIInstallAgentOption {
+	return WithDdURL(fakeIntake.URL)
+}
+
+// WithWixFailWhenDeferred sets the WixFailWhenDeferred parameter.
+func WithWixFailWhenDeferred() MSIInstallAgentOption {
+	return func(i *MSIInstallAgentParams) {
+		i.WixFailWhenDeferred = "1"
+	}
+}

--- a/components/datadog/agentparams/msi/install_params.go
+++ b/components/datadog/agentparams/msi/install_params.go
@@ -22,6 +22,13 @@ type MSIInstallAgentParams struct {
 // MSIInstallAgentOption is an optional function parameter type for MSIInstallAgentParams options
 type MSIInstallAgentOption = func(*MSIInstallAgentParams)
 
+// NewInstallParams instantiates a new MSIInstallAgentParams and runs all the given MSIInstallAgentOption
+// Example usage:
+// awshost.WithAgentOptions(
+//	agentparams.WithAdditionalInstallParameters(
+//		msiparams.NewInstallParams(
+//			msiparams.WithAgentUser(fmt.Sprintf("%s\\%s", TestDomain, TestUser)),
+//			msiparams.WithAgentUserPassword(TestPassword)))),
 func NewInstallParams(msiInstallParams ...MSIInstallAgentOption) []string {
 	msiInstallAgentParams := &MSIInstallAgentParams{}
 	for _, o := range msiInstallParams {

--- a/components/datadog/agentparams/msi/install_params.go
+++ b/components/datadog/agentparams/msi/install_params.go
@@ -24,9 +24,9 @@ type InstallAgentOption = func(*InstallAgentParams)
 
 // NewInstallParams instantiates a new InstallAgentParams and runs all the given InstallAgentOption
 // Example usage:
-// awshost.WithAgentOptions(
 //
-//	agentparams.WithAdditionalInstallParameters(
+//	awshost.WithAgentOptions(
+//	  agentparams.WithAdditionalInstallParameters(
 //		msiparams.NewInstallParams(
 //			msiparams.WithAgentUser(fmt.Sprintf("%s\\%s", TestDomain, TestUser)),
 //			msiparams.WithAgentUserPassword(TestPassword)))),

--- a/components/datadog/agentparams/msi/install_params.go
+++ b/components/datadog/agentparams/msi/install_params.go
@@ -12,7 +12,7 @@ type InstallAgentParams struct {
 	AgentUserPassword string `installer_arg:"DDAGENTUSER_PASSWORD"`
 	DdURL             string `installer_arg:"DD_URL"`
 	Site              string `installer_arg:"SITE"`
-	InstallLogFile    string
+	InstallLogFile    string `installer_arg:"/log"`
 }
 
 // InstallAgentOption is an optional function parameter type for InstallAgentParams options
@@ -44,7 +44,11 @@ func (p *InstallAgentParams) ToArgs() []string {
 		if installerArg != "" {
 			installerArgValue := reflect.ValueOf(*p).FieldByName(field.Name).String()
 			if installerArgValue != "" {
-				args = append(args, fmt.Sprintf("%s=%s", installerArg, installerArgValue))
+				format := "%s=%s"
+				if field.Name == "InstallLogFile" {
+					format = "%s %s"
+				}
+				args = append(args, fmt.Sprintf(format, installerArg, installerArgValue))
 			}
 		}
 	}

--- a/components/datadog/agentparams/msi/install_params.go
+++ b/components/datadog/agentparams/msi/install_params.go
@@ -11,26 +11,27 @@ import (
 	"reflect"
 )
 
-// MSIInstallAgentParams are the parameters used for installing the Agent using msiexec.
-type MSIInstallAgentParams struct {
-	AgentUser           string `installer_arg:"DDAGENTUSER_NAME"`
-	AgentUserPassword   string `installer_arg:"DDAGENTUSER_PASSWORD"`
-	DdURL               string `installer_arg:"DD_URL"`
-	InstallLogFile      string
+// InstallAgentParams are the parameters used for installing the Agent using msiexec.
+type InstallAgentParams struct {
+	AgentUser         string `installer_arg:"DDAGENTUSER_NAME"`
+	AgentUserPassword string `installer_arg:"DDAGENTUSER_PASSWORD"`
+	DdURL             string `installer_arg:"DD_URL"`
+	InstallLogFile    string
 }
 
-// MSIInstallAgentOption is an optional function parameter type for MSIInstallAgentParams options
-type MSIInstallAgentOption = func(*MSIInstallAgentParams)
+// InstallAgentOption is an optional function parameter type for InstallAgentParams options
+type InstallAgentOption = func(*InstallAgentParams)
 
-// NewInstallParams instantiates a new MSIInstallAgentParams and runs all the given MSIInstallAgentOption
+// NewInstallParams instantiates a new InstallAgentParams and runs all the given InstallAgentOption
 // Example usage:
 // awshost.WithAgentOptions(
+//
 //	agentparams.WithAdditionalInstallParameters(
 //		msiparams.NewInstallParams(
 //			msiparams.WithAgentUser(fmt.Sprintf("%s\\%s", TestDomain, TestUser)),
 //			msiparams.WithAgentUserPassword(TestPassword)))),
-func NewInstallParams(msiInstallParams ...MSIInstallAgentOption) []string {
-	msiInstallAgentParams := &MSIInstallAgentParams{}
+func NewInstallParams(msiInstallParams ...InstallAgentOption) []string {
+	msiInstallAgentParams := &InstallAgentParams{}
 	for _, o := range msiInstallParams {
 		o(msiInstallAgentParams)
 	}
@@ -38,7 +39,7 @@ func NewInstallParams(msiInstallParams ...MSIInstallAgentOption) []string {
 }
 
 // ToArgs convert the params to a list of valid msi switches, based on the `installer_arg` tag
-func (p *MSIInstallAgentParams) toArgs() []string {
+func (p *InstallAgentParams) toArgs() []string {
 	var args []string
 	typeOfMSIInstallAgentParams := reflect.TypeOf(*p)
 	for fieldIndex := 0; fieldIndex < typeOfMSIInstallAgentParams.NumField(); fieldIndex++ {
@@ -55,35 +56,34 @@ func (p *MSIInstallAgentParams) toArgs() []string {
 }
 
 // WithAgentUser specifies the DDAGENTUSER_NAME parameter.
-func WithAgentUser(username string) MSIInstallAgentOption {
-	return func(i *MSIInstallAgentParams) {
+func WithAgentUser(username string) InstallAgentOption {
+	return func(i *InstallAgentParams) {
 		i.AgentUser = username
 	}
 }
 
 // WithAgentUserPassword specifies the DDAGENTUSER_PASSWORD parameter.
-func WithAgentUserPassword(password string) MSIInstallAgentOption {
-	return func(i *MSIInstallAgentParams) {
+func WithAgentUserPassword(password string) InstallAgentOption {
+	return func(i *InstallAgentParams) {
 		i.AgentUserPassword = password
 	}
 }
 
 // WithDdURL specifies the DD_URL parameter.
-func WithDdURL(ddURL string) MSIInstallAgentOption {
-	return func(i *MSIInstallAgentParams) {
+func WithDdURL(ddURL string) InstallAgentOption {
+	return func(i *InstallAgentParams) {
 		i.DdURL = ddURL
 	}
 }
 
 // WithInstallLogFile specifies the file where to save the MSI install logs.
-func WithInstallLogFile(logFileName string) MSIInstallAgentOption {
-	return func(i *MSIInstallAgentParams) {
+func WithInstallLogFile(logFileName string) InstallAgentOption {
+	return func(i *InstallAgentParams) {
 		i.InstallLogFile = logFileName
 	}
 }
 
 // WithFakeIntake configures the Agent to use a fake intake URL.
-func WithFakeIntake(fakeIntake *fakeintake.FakeintakeOutput) MSIInstallAgentOption {
+func WithFakeIntake(fakeIntake *fakeintake.FakeintakeOutput) InstallAgentOption {
 	return WithDdURL(fakeIntake.URL)
 }
-

--- a/components/datadog/agentparams/msi/install_params.go
+++ b/components/datadog/agentparams/msi/install_params.go
@@ -16,6 +16,7 @@ type InstallAgentParams struct {
 	AgentUser         string `installer_arg:"DDAGENTUSER_NAME"`
 	AgentUserPassword string `installer_arg:"DDAGENTUSER_PASSWORD"`
 	DdURL             string `installer_arg:"DD_URL"`
+	Site              string `installer_arg:"SITE"`
 	InstallLogFile    string
 }
 
@@ -66,6 +67,14 @@ func WithAgentUser(username string) InstallAgentOption {
 func WithAgentUserPassword(password string) InstallAgentOption {
 	return func(i *InstallAgentParams) {
 		i.AgentUserPassword = password
+	}
+}
+
+// WithSite specifies the SITE parameter.
+func WithSite(site string) InstallAgentOption {
+	return func(i *InstallAgentParams) error {
+		i.Site = site
+		return nil
 	}
 }
 

--- a/components/datadog/agentparams/msi/install_params.go
+++ b/components/datadog/agentparams/msi/install_params.go
@@ -36,11 +36,11 @@ func NewInstallParams(msiInstallParams ...InstallAgentOption) []string {
 	for _, o := range msiInstallParams {
 		o(msiInstallAgentParams)
 	}
-	return msiInstallAgentParams.toArgs()
+	return msiInstallAgentParams.ToArgs()
 }
 
 // ToArgs convert the params to a list of valid msi switches, based on the `installer_arg` tag
-func (p *InstallAgentParams) toArgs() []string {
+func (p *InstallAgentParams) ToArgs() []string {
 	var args []string
 	typeOfMSIInstallAgentParams := reflect.TypeOf(*p)
 	for fieldIndex := 0; fieldIndex < typeOfMSIInstallAgentParams.NumField(); fieldIndex++ {

--- a/components/datadog/agentparams/msi/install_params.go
+++ b/components/datadog/agentparams/msi/install_params.go
@@ -67,9 +67,8 @@ func WithAgentUserPassword(password string) InstallAgentOption {
 
 // WithSite specifies the SITE parameter.
 func WithSite(site string) InstallAgentOption {
-	return func(i *InstallAgentParams) error {
+	return func(i *InstallAgentParams) {
 		i.Site = site
-		return nil
 	}
 }
 

--- a/components/datadog/agentparams/msi/install_params.go
+++ b/components/datadog/agentparams/msi/install_params.go
@@ -16,7 +16,6 @@ type MSIInstallAgentParams struct {
 	AgentUser           string `installer_arg:"DDAGENTUSER_NAME"`
 	AgentUserPassword   string `installer_arg:"DDAGENTUSER_PASSWORD"`
 	DdURL               string `installer_arg:"DD_URL"`
-	WixFailWhenDeferred string `installer_arg:"WIXFAILWHENDEFERRED"`
 	InstallLogFile      string
 }
 
@@ -81,9 +80,3 @@ func WithFakeIntake(fakeIntake *fakeintake.FakeintakeOutput) MSIInstallAgentOpti
 	return WithDdURL(fakeIntake.URL)
 }
 
-// WithWixFailWhenDeferred sets the WixFailWhenDeferred parameter.
-func WithWixFailWhenDeferred() MSIInstallAgentOption {
-	return func(i *MSIInstallAgentParams) {
-		i.WixFailWhenDeferred = "1"
-	}
-}

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -44,6 +44,9 @@ type Params struct {
 	Files               map[string]*FileDefinition
 	ExtraAgentConfig    []pulumi.StringInput
 	ResourceOptions     []pulumi.ResourceOption
+	// This is a list of additional installer flags that can be used to pass installer-specific
+	// parameters like the MSI flags.
+	AdditionalInstallParameters []string
 }
 
 type Option = func(*Params) error
@@ -246,6 +249,14 @@ func WithFakeintake(fakeintake *fakeintake.Fakeintake) func(*Params) error {
 func WithLogs() func(*Params) error {
 	return func(p *Params) error {
 		p.ExtraAgentConfig = append(p.ExtraAgentConfig, pulumi.String("logs_enabled: true"))
+		return nil
+	}
+}
+
+// WithAdditionalInstallParameters passes a list of parameters to the underlying installer
+func WithAdditionalInstallParameters(parameters []string) func(*Params) error {
+	return func(p *Params) error {
+		p.AdditionalInstallParameters = parameters
 		return nil
 	}
 }


### PR DESCRIPTION
What does this PR do?
---------------------
This PR adds a parameter to the `getInstallCommand` function that allows the caller to pass additional, installer/platform specific parameters.

Which scenarios this will impact?
-------------------
For now, only the Windows (and more specifically, the Windows Domain) tests.

Motivation
----------
It's not possible to install the Agent on a Domain Controller without specifying the `DDAGENTUSER_NAME` and `DDAGENTUSER_PASSWORD` parameters to the MSI.

Additional Notes
----------------
