### PR TITLE
[apps] use common signature for k8s apps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.52.2
+    rev: v1.55.2
     hooks:
     - id: golangci-lint
   - repo: local

--- a/components/datadog/apps/cpustress/k8s.go
+++ b/components/datadog/apps/cpustress/k8s.go
@@ -12,10 +12,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*componentskube.WorkloadComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
-	k8sComponent := &componentskube.WorkloadComponent{}
+	k8sComponent := &componentskube.Workload{}
 	if err := e.Ctx.RegisterComponentResource("dd:apps", "cpustress", k8sComponent, opts...); err != nil {
 		return nil, err
 	}

--- a/components/datadog/apps/cpustress/k8s.go
+++ b/components/datadog/apps/cpustress/k8s.go
@@ -3,6 +3,7 @@ package cpustress
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
 
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
@@ -11,14 +12,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-type K8sComponent struct {
-	pulumi.ResourceState
-}
-
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (pulumi.ComponentResource, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*componentskube.WorkloadComponent, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
-	k8sComponent := &K8sComponent{}
+	k8sComponent := &componentskube.WorkloadComponent{}
 	if err := e.Ctx.RegisterComponentResource("dd:apps", "cpustress", k8sComponent, opts...); err != nil {
 		return nil, err
 	}

--- a/components/datadog/apps/cpustress/k8s.go
+++ b/components/datadog/apps/cpustress/k8s.go
@@ -15,7 +15,7 @@ type K8sComponent struct {
 	pulumi.ResourceState
 }
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (pulumi.ComponentResource, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &K8sComponent{}

--- a/components/datadog/apps/dogstatsd/k8s.go
+++ b/components/datadog/apps/dogstatsd/k8s.go
@@ -17,7 +17,7 @@ type K8sComponent struct {
 	pulumi.ResourceState
 }
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, statsdPort int, statsdSocket string, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, statsdPort int, statsdSocket string, opts ...pulumi.ResourceOption) (pulumi.ComponentResource, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &K8sComponent{}

--- a/components/datadog/apps/dogstatsd/k8s.go
+++ b/components/datadog/apps/dogstatsd/k8s.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
 
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
@@ -13,14 +14,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-type K8sComponent struct {
-	pulumi.ResourceState
-}
-
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, statsdPort int, statsdSocket string, opts ...pulumi.ResourceOption) (pulumi.ComponentResource, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, statsdPort int, statsdSocket string, opts ...pulumi.ResourceOption) (*componentskube.WorkloadComponent, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
-	k8sComponent := &K8sComponent{}
+	k8sComponent := &componentskube.WorkloadComponent{}
 	if err := e.Ctx.RegisterComponentResource("dd:apps", fmt.Sprintf("dogstatsd-%d", statsdPort), k8sComponent, opts...); err != nil {
 		return nil, err
 	}

--- a/components/datadog/apps/dogstatsd/k8s.go
+++ b/components/datadog/apps/dogstatsd/k8s.go
@@ -14,10 +14,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, statsdPort int, statsdSocket string, opts ...pulumi.ResourceOption) (*componentskube.WorkloadComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, statsdPort int, statsdSocket string, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
-	k8sComponent := &componentskube.WorkloadComponent{}
+	k8sComponent := &componentskube.Workload{}
 	if err := e.Ctx.RegisterComponentResource("dd:apps", fmt.Sprintf("dogstatsd-%d", statsdPort), k8sComponent, opts...); err != nil {
 		return nil, err
 	}

--- a/components/datadog/apps/mutatedbyadmissioncontroller/k8s.go
+++ b/components/datadog/apps/mutatedbyadmissioncontroller/k8s.go
@@ -14,7 +14,7 @@ type K8sComponent struct {
 	pulumi.ResourceState
 }
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (pulumi.ComponentResource, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &K8sComponent{}

--- a/components/datadog/apps/mutatedbyadmissioncontroller/k8s.go
+++ b/components/datadog/apps/mutatedbyadmissioncontroller/k8s.go
@@ -12,10 +12,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*componentskube.WorkloadComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
-	k8sComponent := &componentskube.WorkloadComponent{}
+	k8sComponent := &componentskube.Workload{}
 	if err := e.Ctx.RegisterComponentResource("dd:apps", "mutated", k8sComponent, opts...); err != nil {
 		return nil, err
 	}

--- a/components/datadog/apps/mutatedbyadmissioncontroller/k8s.go
+++ b/components/datadog/apps/mutatedbyadmissioncontroller/k8s.go
@@ -3,6 +3,8 @@ package mutatedbyadmissioncontroller
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"
 
+	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
+
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
 	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
@@ -10,14 +12,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-type K8sComponent struct {
-	pulumi.ResourceState
-}
-
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (pulumi.ComponentResource, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*componentskube.WorkloadComponent, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
-	k8sComponent := &K8sComponent{}
+	k8sComponent := &componentskube.WorkloadComponent{}
 	if err := e.Ctx.RegisterComponentResource("dd:apps", "mutated", k8sComponent, opts...); err != nil {
 		return nil, err
 	}

--- a/components/datadog/apps/nginx/k8s.go
+++ b/components/datadog/apps/nginx/k8s.go
@@ -20,10 +20,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, dependsOnCrd pulumi.ResourceOption, opts ...pulumi.ResourceOption) (*componentskube.WorkloadComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, dependsOnCrd pulumi.ResourceOption, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
-	k8sComponent := &componentskube.WorkloadComponent{}
+	k8sComponent := &componentskube.Workload{}
 	if err := e.Ctx.RegisterComponentResource("dd:apps", "nginx", k8sComponent, opts...); err != nil {
 		return nil, err
 	}

--- a/components/datadog/apps/nginx/k8s.go
+++ b/components/datadog/apps/nginx/k8s.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
 	ddv1alpha1 "github.com/DataDog/test-infra-definitions/components/kubernetes/crds/kubernetes/datadoghq/v1alpha1"
 
 	"github.com/Masterminds/semver"
@@ -19,14 +20,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-type K8sComponent struct {
-	pulumi.ResourceState
-}
-
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, dependsOnCrd pulumi.ResourceOption, opts ...pulumi.ResourceOption) (pulumi.ComponentResource, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, dependsOnCrd pulumi.ResourceOption, opts ...pulumi.ResourceOption) (*componentskube.WorkloadComponent, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
-	k8sComponent := &K8sComponent{}
+	k8sComponent := &componentskube.WorkloadComponent{}
 	if err := e.Ctx.RegisterComponentResource("dd:apps", "nginx", k8sComponent, opts...); err != nil {
 		return nil, err
 	}

--- a/components/datadog/apps/nginx/k8s.go
+++ b/components/datadog/apps/nginx/k8s.go
@@ -23,7 +23,7 @@ type K8sComponent struct {
 	pulumi.ResourceState
 }
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, dependsOnCrd pulumi.ResourceOption, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, dependsOnCrd pulumi.ResourceOption, opts ...pulumi.ResourceOption) (pulumi.ComponentResource, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &K8sComponent{}

--- a/components/datadog/apps/prometheus/k8s.go
+++ b/components/datadog/apps/prometheus/k8s.go
@@ -3,7 +3,7 @@ package prometheus
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
-
+	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
 	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
@@ -11,14 +11,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-type K8sComponent struct {
-	pulumi.ResourceState
-}
-
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (pulumi.ComponentResource, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*componentskube.WorkloadComponent, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
-	k8sComponent := &K8sComponent{}
+	k8sComponent := &componentskube.WorkloadComponent{}
 	if err := e.Ctx.RegisterComponentResource("dd:apps", "prometheus", k8sComponent, opts...); err != nil {
 		return nil, err
 	}

--- a/components/datadog/apps/prometheus/k8s.go
+++ b/components/datadog/apps/prometheus/k8s.go
@@ -15,7 +15,7 @@ type K8sComponent struct {
 	pulumi.ResourceState
 }
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (pulumi.ComponentResource, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &K8sComponent{}

--- a/components/datadog/apps/prometheus/k8s.go
+++ b/components/datadog/apps/prometheus/k8s.go
@@ -11,10 +11,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*componentskube.WorkloadComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
-	k8sComponent := &componentskube.WorkloadComponent{}
+	k8sComponent := &componentskube.Workload{}
 	if err := e.Ctx.RegisterComponentResource("dd:apps", "prometheus", k8sComponent, opts...); err != nil {
 		return nil, err
 	}

--- a/components/datadog/apps/redis/k8s.go
+++ b/components/datadog/apps/redis/k8s.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
 	ddv1alpha1 "github.com/DataDog/test-infra-definitions/components/kubernetes/crds/kubernetes/datadoghq/v1alpha1"
 	"github.com/Masterminds/semver"
 
@@ -19,14 +20,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-type K8sComponent struct {
-	pulumi.ResourceState
-}
-
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, dependsOnCrd pulumi.ResourceOption, opts ...pulumi.ResourceOption) (pulumi.ComponentResource, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, dependsOnCrd pulumi.ResourceOption, opts ...pulumi.ResourceOption) (*componentskube.WorkloadComponent, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
-	k8sComponent := &K8sComponent{}
+	k8sComponent := &componentskube.WorkloadComponent{}
 	if err := e.Ctx.RegisterComponentResource("dd:apps", "redis", k8sComponent, opts...); err != nil {
 		return nil, err
 	}

--- a/components/datadog/apps/redis/k8s.go
+++ b/components/datadog/apps/redis/k8s.go
@@ -20,10 +20,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, dependsOnCrd pulumi.ResourceOption, opts ...pulumi.ResourceOption) (*componentskube.WorkloadComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, dependsOnCrd pulumi.ResourceOption, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
-	k8sComponent := &componentskube.WorkloadComponent{}
+	k8sComponent := &componentskube.Workload{}
 	if err := e.Ctx.RegisterComponentResource("dd:apps", "redis", k8sComponent, opts...); err != nil {
 		return nil, err
 	}

--- a/components/datadog/apps/redis/k8s.go
+++ b/components/datadog/apps/redis/k8s.go
@@ -23,7 +23,7 @@ type K8sComponent struct {
 	pulumi.ResourceState
 }
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, dependsOnCrd pulumi.ResourceOption, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, dependsOnCrd pulumi.ResourceOption, opts ...pulumi.ResourceOption) (pulumi.ComponentResource, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &K8sComponent{}

--- a/components/datadog/apps/tracegen/k8s.go
+++ b/components/datadog/apps/tracegen/k8s.go
@@ -15,10 +15,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*componentskube.WorkloadComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
-	k8sComponent := &componentskube.WorkloadComponent{}
+	k8sComponent := &componentskube.Workload{}
 	if err := e.Ctx.RegisterComponentResource("dd:apps", fmt.Sprintf("%s-tracegen", namespace), k8sComponent, opts...); err != nil {
 		return nil, err
 	}

--- a/components/datadog/apps/tracegen/k8s.go
+++ b/components/datadog/apps/tracegen/k8s.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
 
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 
@@ -14,14 +15,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-type K8sComponent struct {
-	pulumi.ResourceState
-}
-
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (pulumi.ComponentResource, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*componentskube.WorkloadComponent, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
-	k8sComponent := &K8sComponent{}
+	k8sComponent := &componentskube.WorkloadComponent{}
 	if err := e.Ctx.RegisterComponentResource("dd:apps", fmt.Sprintf("%s-tracegen", namespace), k8sComponent, opts...); err != nil {
 		return nil, err
 	}

--- a/components/datadog/apps/tracegen/k8s.go
+++ b/components/datadog/apps/tracegen/k8s.go
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/common/utils"
 
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+
 	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
 	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
 	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
@@ -17,7 +18,7 @@ type K8sComponent struct {
 	pulumi.ResourceState
 }
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (pulumi.ComponentResource, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &K8sComponent{}

--- a/components/datadog/dogstatsd-standalone/k8s.go
+++ b/components/datadog/dogstatsd-standalone/k8s.go
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
 	"github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
+	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
 	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
@@ -23,14 +24,10 @@ const HostPort = 8128
 // It's not the default to avoid conflict with the agent.
 const Socket = "/var/run/datadog/dsd-standalone.socket"
 
-type K8sComponent struct {
-	pulumi.ResourceState
-}
-
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, fakeIntake *fakeintake.Fakeintake, kubeletTLSVerify bool, clusterName string, opts ...pulumi.ResourceOption) (*K8sComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, fakeIntake *fakeintake.Fakeintake, kubeletTLSVerify bool, clusterName string, opts ...pulumi.ResourceOption) (*componentskube.WorkloadComponent, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
-	k8sComponent := &K8sComponent{}
+	k8sComponent := &componentskube.WorkloadComponent{}
 	if err := e.Ctx.RegisterComponentResource("dd:dogstatsd-standalone", "dogstatsd", k8sComponent, opts...); err != nil {
 		return nil, err
 	}

--- a/components/datadog/dogstatsd-standalone/k8s.go
+++ b/components/datadog/dogstatsd-standalone/k8s.go
@@ -24,10 +24,10 @@ const HostPort = 8128
 // It's not the default to avoid conflict with the agent.
 const Socket = "/var/run/datadog/dsd-standalone.socket"
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, fakeIntake *fakeintake.Fakeintake, kubeletTLSVerify bool, clusterName string, opts ...pulumi.ResourceOption) (*componentskube.WorkloadComponent, error) {
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, fakeIntake *fakeintake.Fakeintake, kubeletTLSVerify bool, clusterName string, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
-	k8sComponent := &componentskube.WorkloadComponent{}
+	k8sComponent := &componentskube.Workload{}
 	if err := e.Ctx.RegisterComponentResource("dd:dogstatsd-standalone", "dogstatsd", k8sComponent, opts...); err != nil {
 		return nil, err
 	}

--- a/components/kubernetes/component.go
+++ b/components/kubernetes/component.go
@@ -28,7 +28,8 @@ func (c *Cluster) Export(ctx *pulumi.Context, out *ClusterOutput) error {
 	return components.Export(ctx, c, out)
 }
 
-type WorkloadComponent struct {
+// Workload is a Component that represents a Kubernetes workload
+type Workload struct {
 	pulumi.ResourceState
 	components.Component
 }

--- a/components/kubernetes/component.go
+++ b/components/kubernetes/component.go
@@ -27,3 +27,8 @@ type Cluster struct {
 func (c *Cluster) Export(ctx *pulumi.Context, out *ClusterOutput) error {
 	return components.Export(ctx, c, out)
 }
+
+type WorkloadComponent struct {
+	pulumi.ResourceState
+	components.Component
+}


### PR DESCRIPTION
What does this PR do?
---------------------

* Return `pulumi.ComponentResource` from k8s deployment app definitions

Which scenarios this will impact?
-------------------

eks, kind

Motivation
----------

We are adding custom workloads to Kind provider in datadog-agent side, we need a common type for the deployment functions to allow adding custom apps to the deployment through a `WithWorkloadApp` in https://github.com/DataDog/datadog-agent/pull/23632

Additional Notes
----------------
