### PR TITLE
fix(install-script): Fix curl retry to reduce flakiness

### DIFF
--- a/components/datadog/agent/host_linuxos.go
+++ b/components/datadog/agent/host_linuxos.go
@@ -35,7 +35,7 @@ func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersio
 		commandLine := strings.Join(testEnvVars, " ")
 
 		return fmt.Sprintf(
-			`curl --retry 10 -fsSL https://s3.amazonaws.com/dd-agent/scripts/%v  -o install-script.sh && for i in 1 2 3; do DD_API_KEY=%%s %v bash install-script.sh  && break || sleep 2; done`,
+			`for i in 1 2 3 4 5; do curl -L https://s3.amazonaws.com/dd-agent/scripts/%v -o install-script.sh && break || sleep $((2**$i)); done &&  for i in 1 2 3; do DD_API_KEY=%%s %v DD_INSTALL_ONLY=true bash install-script.sh  && break || sleep $((2**$i)); done`,
 			"install_script_agent7.sh",
 			commandLine), nil
 	}
@@ -51,7 +51,7 @@ func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersio
 	}
 
 	return fmt.Sprintf(
-		`curl --retry 10 -fsSL https://s3.amazonaws.com/dd-agent/scripts/%v -o install-script.sh && for i in 1 2 3; do DD_API_KEY=%%s %v DD_INSTALL_ONLY=true bash install-script.sh  && break || sleep 2; done`,
+		`for i in 1 2 3 4 5; do curl -L https://s3.amazonaws.com/dd-agent/scripts/%v -o install-script.sh && break || sleep $((2**$i)); done &&  for i in 1 2 3; do DD_API_KEY=%%s %v DD_INSTALL_ONLY=true bash install-script.sh  && break || sleep $((2**$i)); done`,
 		fmt.Sprintf("install_script_agent%s.sh", version.Major),
 		commandLine), nil
 }

--- a/components/datadog/agent/host_linuxos.go
+++ b/components/datadog/agent/host_linuxos.go
@@ -35,7 +35,7 @@ func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersio
 		commandLine := strings.Join(testEnvVars, " ")
 
 		return fmt.Sprintf(
-			`for i in 1 2 3 4 5; do curl -L https://s3.amazonaws.com/dd-agent/scripts/%v -o install-script.sh && break || sleep $((2**$i)); done &&  for i in 1 2 3; do DD_API_KEY=%%s %v DD_INSTALL_ONLY=true bash install-script.sh  && break || sleep $((2**$i)); done`,
+			`for i in 1 2 3 4 5; do curl -fsSL https://s3.amazonaws.com/dd-agent/scripts/%v -o install-script.sh && break || sleep $((2**$i)); done &&  for i in 1 2 3; do DD_API_KEY=%%s %v DD_INSTALL_ONLY=true bash install-script.sh  && break || sleep $((2**$i)); done`,
 			"install_script_agent7.sh",
 			commandLine), nil
 	}
@@ -51,7 +51,7 @@ func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersio
 	}
 
 	return fmt.Sprintf(
-		`for i in 1 2 3 4 5; do curl -L https://s3.amazonaws.com/dd-agent/scripts/%v -o install-script.sh && break || sleep $((2**$i)); done &&  for i in 1 2 3; do DD_API_KEY=%%s %v DD_INSTALL_ONLY=true bash install-script.sh  && break || sleep $((2**$i)); done`,
+		`for i in 1 2 3 4 5; do curl -fsSL https://s3.amazonaws.com/dd-agent/scripts/%v -o install-script.sh && break || sleep $((2**$i)); done &&  for i in 1 2 3; do DD_API_KEY=%%s %v DD_INSTALL_ONLY=true bash install-script.sh  && break || sleep $((2**$i)); done`,
 		fmt.Sprintf("install_script_agent%s.sh", version.Major),
 		commandLine), nil
 }


### PR DESCRIPTION
What does this PR do?
---------------------

Using `--retry` with curl only retries errors that `curl` consider as transient. Only timeouts and 5xx errors.
We want to retry more error than that to avoid flakes. For example the `SSL_ERROR_ZERO_RETURN` error

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
