### PR TITLE
[kind] fix kind deployment

### DIFF
--- a/components/kubernetes/kind.go
+++ b/components/kubernetes/kind.go
@@ -56,7 +56,7 @@ func NewKindCluster(env config.CommonEnvironment, vm *remote.Host, resourceName,
 		kindInstall, err := runner.Command(
 			commonEnvironment.CommonNamer.ResourceName("kind-install"),
 			&command.Args{
-				Create: pulumi.Sprintf(`curl --retry 10 --fsSLo ./kind "https://kind.sigs.k8s.io/dl/%s/kind-linux-%s" && sudo install kind /usr/local/bin/kind`, kindVersionConfig.kindVersion, kindArch),
+				Create: pulumi.Sprintf(`curl --retry 10 -fsSLo ./kind "https://kind.sigs.k8s.io/dl/%s/kind-linux-%s" && sudo install kind /usr/local/bin/kind`, kindVersionConfig.kindVersion, kindArch),
 			},
 			opts...,
 		)

--- a/components/kubernetes/kind.go
+++ b/components/kubernetes/kind.go
@@ -38,7 +38,12 @@ func NewKindCluster(env config.CommonEnvironment, vm *remote.Host, resourceName,
 			return err
 		}
 
-		_, dockerInstallCmd, err := docker.NewManager(env, vm, true, opts...)
+		shouldInstallDocker := true
+		// docker is installed by default on Amazon Linux ECS
+		if vm.OS.Descriptor().Flavor == os.AmazonLinuxECS {
+			shouldInstallDocker = false
+		}
+		_, dockerInstallCmd, err := docker.NewManager(env, vm, shouldInstallDocker, opts...)
 		if err != nil {
 			return err
 		}

--- a/integration-tests/testfixture/config.yaml
+++ b/integration-tests/testfixture/config.yaml
@@ -3,7 +3,7 @@ configParams:
     apiKey: '00000000000000000000000000000000'
     appKey: '0000000000000000000000000000000000000000'
   aws:
-    account: agent-qa
+    account: ACCOUNT
     keyPairName: KEY_PAIR_NAME
     publicKeyPath: PUBLIC_KEY_PATH
     teamTag: test-ci

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -30,7 +30,7 @@ func Run(ctx *pulumi.Context) error {
 		return err
 	}
 
-	osDesc := os.DescriptorFromString(awsEnv.InfraOSDescriptor(), os.UbuntuDefault)
+	osDesc := os.DescriptorFromString(awsEnv.InfraOSDescriptor(), os.AmazonLinuxECSDefault)
 	vm, err := ec2.NewVM(awsEnv, "kind", ec2.WithOS(osDesc))
 	if err != nil {
 		return err

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -5,6 +5,7 @@ from tasks.aks import create_aks, destroy_aks
 from tasks.docker import create_docker, destroy_docker
 from tasks.ecs import create_ecs, destroy_ecs
 from tasks.eks import create_eks, destroy_eks
+from tasks.kind import create_kind, destroy_kind
 
 from .vm import create_vm, destroy_vm
 
@@ -19,4 +20,6 @@ ns.add_task(create_aks)  # pyright: ignore [reportArgumentType]
 ns.add_task(destroy_aks)  # pyright: ignore [reportArgumentType]
 ns.add_task(create_ecs)  # pyright: ignore [reportArgumentType]
 ns.add_task(destroy_ecs)  # pyright: ignore [reportArgumentType]
+ns.add_task(create_kind)  # pyright: ignore [reportArgumentType]
+ns.add_task(destroy_kind)  # pyright: ignore [reportArgumentType]
 ns.add_collection(setup)  # pyright: ignore [reportArgumentType]

--- a/tasks/kind.py
+++ b/tasks/kind.py
@@ -1,0 +1,110 @@
+from typing import Optional
+
+import pyperclip
+from invoke.context import Context
+from invoke.exceptions import Exit
+from invoke.tasks import task
+
+from . import doc, tool
+from .deploy import deploy
+from .destroy import destroy
+
+scenario_name = "aws/kind"
+
+
+# TODO add dogstatsd and workload options
+@task(
+    help={
+        "config_path": doc.config_path,
+        "install_agent": doc.install_agent,
+        "agent_version": doc.container_agent_version,
+        "stack_name": doc.stack_name,
+        "architecture": doc.architecture,
+        "use_fakeintake": doc.fakeintake,
+        "use_loadBalancer": doc.use_loadBalancer,
+        "interactive": doc.interactive,
+        "use_aws_vault": doc.use_aws_vault,
+    }
+)
+def create_kind(
+    ctx: Context,
+    config_path: Optional[str] = None,
+    stack_name: Optional[str] = None,
+    install_agent: Optional[bool] = True,
+    agent_version: Optional[str] = None,
+    architecture: Optional[str] = None,
+    use_fakeintake: Optional[bool] = False,
+    use_loadBalancer: Optional[bool] = False,
+    interactive: Optional[bool] = True,
+    use_aws_vault: Optional[bool] = True,
+):
+    """
+    Create a kind environment.
+    """
+
+    extra_flags = {}
+    extra_flags["ddinfra:osDescriptor"] = f"amazonlinuxecs::{_get_architecture(architecture)}"
+    extra_flags["ddinfra:deployFakeintakeWithLoadBalancer"] = use_loadBalancer
+
+    full_stack_name = deploy(
+        ctx,
+        scenario_name,
+        config_path,
+        key_pair_required=True,
+        stack_name=stack_name,
+        install_agent=install_agent,
+        agent_version=agent_version,
+        use_fakeintake=use_fakeintake,
+        extra_flags=extra_flags,
+        use_aws_vault=use_aws_vault,
+        app_key_required=True,
+    )
+
+    if interactive:
+        tool.notify(ctx, "Your Kind environment is now created")
+
+    _show_connection_message(ctx, full_stack_name, interactive)
+
+
+def _show_connection_message(ctx: Context, full_stack_name: str, copy_to_clipboard: Optional[bool]):
+    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
+    remoteHost = tool.RemoteHost("aws-kind", outputs)
+    host = remoteHost.host
+    user = remoteHost.user
+
+    command = f"\nssh {user}@{host}"
+    print(f"If you want to connect to the remote host, you can run the following command \n\n{command}")
+
+    if copy_to_clipboard:
+        input("Press a key to copy command to clipboard...")
+        pyperclip.copy(command)
+
+
+@task(
+    help={
+        "config_path": doc.config_path,
+        "stack_name": doc.stack_name,
+        "yes": doc.yes,
+        "use_aws_vault": doc.use_aws_vault,
+    }
+)
+def destroy_kind(
+    ctx: Context,
+    config_path: Optional[str] = None,
+    stack_name: Optional[str] = None,
+    yes: Optional[bool] = False,
+    use_aws_vault: Optional[bool] = True,
+):
+    """
+    Destroy an environment created by invoke create_docker.
+    """
+    destroy(ctx, scenario_name, config_path, stack_name, use_aws_vault, force_yes=yes)
+
+
+def _get_architecture(architecture: Optional[str]) -> str:
+    architectures = tool.get_architectures()
+    if architecture is None:
+        architecture = tool.get_default_architecture()
+    if architecture.lower() not in architectures:
+        raise Exit(f"The os family '{architecture}' is not supported. Possibles values are {', '.join(architectures)}")
+    return architecture


### PR DESCRIPTION
What does this PR do?
---------------------

* fix kind install command
* use AmazonECS family OS by default for Kind
* adds inv create-kind task
* adds integration test for kind

Which scenarios this will impact?
-------------------

kind

Motivation
----------

I broke kind install command with https://github.com/DataDog/test-infra-definitions/pull/671, this PR fixes it and adds an integration test for kind vm

Additional Notes
----------------

I tried to run tests in parallel with `t.Parallel` in subtests, but it failed, might race on config file. To be investigated.