### PR TITLE
Improvement(e2e): Make Docker Manager lazily install docker

### DIFF
--- a/components/command/package.go
+++ b/components/command/package.go
@@ -37,7 +37,7 @@ func NewGenericPackageManager(
 	return packageManager
 }
 
-func (m *GenericPackageManager) Ensure(packageRef string, transform Transformer, opts ...pulumi.ResourceOption) (*remote.Command, error) {
+func (m *GenericPackageManager) Ensure(packageRef string, transform Transformer, check string, opts ...pulumi.ResourceOption) (*remote.Command, error) {
 	opts = append(opts, m.opts...)
 	if m.updateCmd != "" {
 		updateDB, err := m.updateDB(opts)
@@ -47,8 +47,13 @@ func (m *GenericPackageManager) Ensure(packageRef string, transform Transformer,
 
 		opts = append(opts, utils.PulumiDependsOn(updateDB))
 	}
+	var cmdStr string
+	if check != "" {
+		cmdStr = fmt.Sprintf("bash -c '%s || %s %s'", check, m.installCmd, packageRef)
+	} else {
+		cmdStr = fmt.Sprintf("%s %s", m.installCmd, packageRef)
+	}
 
-	cmdStr := fmt.Sprintf("%s %s", m.installCmd, packageRef)
 	cmdName := m.namer.ResourceName("install-"+packageRef, utils.StrHash(cmdStr))
 	cmdArgs := Args{
 		Create:      pulumi.String(cmdStr),

--- a/components/docker/docker.go
+++ b/components/docker/docker.go
@@ -27,23 +27,18 @@ type Manager struct {
 	opts []pulumi.ResourceOption
 }
 
-func NewManager(e config.CommonEnvironment, host *remoteComp.Host, installDocker bool, opts ...pulumi.ResourceOption) (*Manager, pulumi.Resource, error) {
+func NewManager(e config.CommonEnvironment, host *remoteComp.Host, opts ...pulumi.ResourceOption) (*Manager, pulumi.Resource, error) {
 	manager := &Manager{
 		namer: e.CommonNamer.WithPrefix("docker"),
 		host:  host,
 		opts:  opts,
 	}
 
-	var err error
-	var installCmd pulumi.Resource
-	if installDocker {
-		installCmd, err = manager.install()
-		if err != nil {
-			return nil, nil, err
-		}
-
-		manager.opts = utils.MergeOptions(manager.opts, utils.PulumiDependsOn(installCmd))
+	installCmd, err := manager.install()
+	if err != nil {
+		return nil, nil, err
 	}
+	manager.opts = utils.MergeOptions(manager.opts, utils.PulumiDependsOn(installCmd))
 
 	composeCmd, err := manager.installCompose()
 	if err != nil {
@@ -126,7 +121,7 @@ func (d *Manager) ComposeStrUp(name string, composeManifests []ComposeInlineMani
 }
 
 func (d *Manager) install() (*remote.Command, error) {
-	dockerInstall, err := d.host.OS.PackageManager().Ensure("docker.io", nil, d.opts...)
+	dockerInstall, err := d.host.OS.PackageManager().Ensure("docker.io", nil, "docker version", d.opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/components/kubernetes/kind.go
+++ b/components/kubernetes/kind.go
@@ -33,17 +33,12 @@ func NewKindCluster(env config.CommonEnvironment, vm *remote.Host, resourceName,
 		runner := vm.OS.Runner()
 		commonEnvironment := env
 		packageManager := vm.OS.PackageManager()
-		curlCommand, err := packageManager.Ensure("curl", nil, opts...)
+		curlCommand, err := packageManager.Ensure("curl", nil, "", opts...)
 		if err != nil {
 			return err
 		}
 
-		shouldInstallDocker := true
-		// docker is installed by default on Amazon Linux ECS
-		if vm.OS.Descriptor().Flavor == os.AmazonLinuxECS {
-			shouldInstallDocker = false
-		}
-		_, dockerInstallCmd, err := docker.NewManager(env, vm, shouldInstallDocker, opts...)
+		_, dockerInstallCmd, err := docker.NewManager(env, vm, opts...)
 		if err != nil {
 			return err
 		}

--- a/components/os/os.go
+++ b/components/os/os.go
@@ -12,7 +12,7 @@ import (
 
 // Interfaces used by OS components
 type PackageManager interface {
-	Ensure(packageRef string, transform command.Transformer, opts ...pulumi.ResourceOption) (*remote.Command, error)
+	Ensure(packageRef string, transform command.Transformer, check string, opts ...pulumi.ResourceOption) (*remote.Command, error)
 }
 
 type ServiceManager interface {

--- a/scenarios/aws/ec2/vm.go
+++ b/scenarios/aws/ec2/vm.go
@@ -58,7 +58,7 @@ func NewVM(e aws.Environment, name string, params ...VMOption) (*remote.Host, er
 }
 
 func InstallECRCredentialsHelper(e aws.Environment, vm *remote.Host) (*goremote.Command, error) {
-	ecrCredsHelperInstall, err := vm.OS.PackageManager().Ensure("amazon-ecr-credential-helper", nil)
+	ecrCredsHelperInstall, err := vm.OS.PackageManager().Ensure("amazon-ecr-credential-helper", nil, "")
 	if err != nil {
 		return nil, err
 	}

--- a/scenarios/aws/ec2/vm_run.go
+++ b/scenarios/aws/ec2/vm_run.go
@@ -64,10 +64,6 @@ func VMRun(ctx *pulumi.Context) error {
 	return nil
 }
 
-var osWithDockerProvided = map[os.Flavor]struct{}{
-	os.AmazonLinuxECS: {},
-}
-
 func VMRunWithDocker(ctx *pulumi.Context) error {
 	env, err := aws.NewEnvironment(ctx)
 	if err != nil {
@@ -89,8 +85,7 @@ func VMRunWithDocker(ctx *pulumi.Context) error {
 		return err
 	}
 
-	_, isDockerInstalled := osWithDockerProvided[vm.OS.Descriptor().Flavor]
-	manager, _, err := docker.NewManager(*env.CommonEnvironment, vm, !isDockerInstalled, utils.PulumiDependsOn(installEcrCredsHelperCmd))
+	manager, _, err := docker.NewManager(*env.CommonEnvironment, vm, utils.PulumiDependsOn(installEcrCredsHelperCmd))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
What does this PR do?
---------------------

Change docker manager to install Docker only if it is not already installed.
To do this we had a new parameter to `Ensure` method implemented by Package managers:
- `check string` attribute: When this command is specified it will prefix the package manager install command, if the command succeed we skip the installation


Which scenarios this will impact?
-------------------

Docker

Motivation
----------

Additional Notes
----------------
