### PR TITLE
Fix(e2e): Set dependencies correctly to reduce test flakiness

### DIFF
--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/common"
 	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -193,7 +194,7 @@ func WithTelemetry() func(*Params) error {
 
 func WithPulumiResourceOptions(resources ...pulumi.ResourceOption) func(*Params) error {
 	return func(p *Params) error {
-		p.ResourceOptions = resources
+		p.ResourceOptions = append(p.ResourceOptions, resources...)
 		return nil
 	}
 }
@@ -242,7 +243,10 @@ func WithIntakeHostname(hostname string) func(*Params) error {
 //
 // This option is overwritten by `WithIntakeHostname`.
 func WithFakeintake(fakeintake *fakeintake.Fakeintake) func(*Params) error {
-	return withIntakeHostname(fakeintake.Host)
+	return func(p *Params) error {
+		p.ResourceOptions = append(p.ResourceOptions, utils.PulumiDependsOn(fakeintake))
+		return withIntakeHostname(fakeintake.Host)(p)
+	}
 }
 
 // WithLogs enables the log agent

--- a/components/datadog/dockeragentparams/params.go
+++ b/components/datadog/dockeragentparams/params.go
@@ -87,7 +87,7 @@ func WithFullImagePath(fullImagePath string) func(*Params) error {
 
 func WithPulumiDependsOn(resources ...pulumi.ResourceOption) func(*Params) error {
 	return func(p *Params) error {
-		p.PulumiDependsOn = resources
+		p.PulumiDependsOn = append(p.PulumiDependsOn, resources...)
 		return nil
 	}
 }
@@ -122,7 +122,10 @@ func WithIntake(url string) func(*Params) error {
 // This option is overwritten by `WithIntakeHostname`.
 func WithFakeintake(fakeintake *fakeintake.Fakeintake) func(*Params) error {
 	shouldSkipSSLValidation := fakeintake.Scheme == "http"
-	return withIntakeHostname(fakeintake.URL, shouldSkipSSLValidation)
+	return func(p *Params) error {
+		p.PulumiDependsOn = append(p.PulumiDependsOn, utils.PulumiDependsOn(fakeintake))
+		return withIntakeHostname(fakeintake.URL, shouldSkipSSLValidation)(p)
+	}
 }
 
 func withIntakeHostname(url pulumi.StringInput, shouldSkipSSLValidation bool) func(*Params) error {

--- a/components/datadog/kubernetesagentparams/params.go
+++ b/components/datadog/kubernetesagentparams/params.go
@@ -89,7 +89,7 @@ func WithNamespace(namespace string) func(*Params) error {
 // WithPulumiDependsOn sets the resources to depend on.
 func WithPulumiResourceOptions(resources ...pulumi.ResourceOption) func(*Params) error {
 	return func(p *Params) error {
-		p.PulumiResourceOptions = resources
+		p.PulumiResourceOptions = append(p.PulumiResourceOptions, resources...)
 		return nil
 	}
 }
@@ -113,6 +113,7 @@ func WithHelmValues(values string) func(*Params) error {
 // WithFakeintake configures the Agent to use the given fake intake.
 func WithFakeintake(fakeintake *fakeintake.Fakeintake) func(*Params) error {
 	return func(p *Params) error {
+		p.PulumiResourceOptions = append(p.PulumiResourceOptions, utils.PulumiDependsOn(fakeintake))
 		p.FakeIntake = fakeintake
 		return nil
 	}


### PR DESCRIPTION
What does this PR do?
---------------------

Set the Pulumi dependency between fakeintake and agent to avoid flakiness in test

It changes a bit the effect of `WithPulumiResourceOptions` to make sure we do not override  Pulumi dependencies added by `WithFakeintake`

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
