### PR TITLE
[CONTINT-3937] Replace Dogstatsd library version to work with amazon linux

### DIFF
--- a/components/datadog/apps/dogstatsd/images/dogstatsd/go.mod
+++ b/components/datadog/apps/dogstatsd/images/dogstatsd/go.mod
@@ -2,10 +2,12 @@ module dogstatsd
 
 go 1.21
 
-// Temporary replacement of the main branch until https://github.com/DataDog/datadog-go/pull/302 is released
-require github.com/DataDog/datadog-go/v5 v5.5.1-0.20240307111531-3f5998a2da25
+require github.com/DataDog/datadog-go/v5 v5.5.0
 
 require (
 	github.com/Microsoft/go-winio v0.5.0 // indirect
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
 )
+
+// Temporary replacement of the main branch until https://github.com/DataDog/datadog-go/pull/304 is released
+replace github.com/DataDog/datadog-go/v5 => github.com/DataDog/datadog-go/v5 v5.5.1-0.20240318112615-19bca2118b52

--- a/components/datadog/apps/dogstatsd/images/dogstatsd/go.mod
+++ b/components/datadog/apps/dogstatsd/images/dogstatsd/go.mod
@@ -10,4 +10,4 @@ require (
 )
 
 // Temporary replacement of the main branch until https://github.com/DataDog/datadog-go/pull/304 is released
-replace github.com/DataDog/datadog-go/v5 => github.com/DataDog/datadog-go/v5 v5.5.1-0.20240318112615-19bca2118b52
+replace github.com/DataDog/datadog-go/v5 => github.com/DataDog/datadog-go/v5 v5.5.1-0.20240327105053-fa1f6814eaf7

--- a/components/datadog/apps/dogstatsd/images/dogstatsd/go.sum
+++ b/components/datadog/apps/dogstatsd/images/dogstatsd/go.sum
@@ -1,5 +1,5 @@
-github.com/DataDog/datadog-go/v5 v5.5.1-0.20240307111531-3f5998a2da25 h1:yhJAhV6ew3Ybea81k7h04X/3VT6FJq3NMj53jd2n1kw=
-github.com/DataDog/datadog-go/v5 v5.5.1-0.20240307111531-3f5998a2da25/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
+github.com/DataDog/datadog-go/v5 v5.5.1-0.20240318112615-19bca2118b52 h1:t5mc716gQVRjd2i/6i3YvPQmEDnon8nFHrCY5Qiv01g=
+github.com/DataDog/datadog-go/v5 v5.5.1-0.20240318112615-19bca2118b52/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/Microsoft/go-winio v0.5.0 h1:Elr9Wn+sGKPlkaBvwu4mTrxtmOp3F3yV9qhaHbXGjwU=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/components/datadog/apps/dogstatsd/images/dogstatsd/go.sum
+++ b/components/datadog/apps/dogstatsd/images/dogstatsd/go.sum
@@ -1,5 +1,5 @@
-github.com/DataDog/datadog-go/v5 v5.5.1-0.20240318112615-19bca2118b52 h1:t5mc716gQVRjd2i/6i3YvPQmEDnon8nFHrCY5Qiv01g=
-github.com/DataDog/datadog-go/v5 v5.5.1-0.20240318112615-19bca2118b52/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
+github.com/DataDog/datadog-go/v5 v5.5.1-0.20240327105053-fa1f6814eaf7 h1:pOfzUVqO/rT7VTY9L7qK5oeiuBBIiuZgt0Nf7J3ywDQ=
+github.com/DataDog/datadog-go/v5 v5.5.1-0.20240327105053-fa1f6814eaf7/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/Microsoft/go-winio v0.5.0 h1:Elr9Wn+sGKPlkaBvwu4mTrxtmOp3F3yV9qhaHbXGjwU=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
What does this PR do?
---------------------
This PR replaces the dogstasd version to run with https://github.com/DataDog/datadog-go/pull/304.
It fixes origin detection on Amazon Linux ECS Optimized

Which scenarios this will impact?
-------------------
all using dogstatsd

Motivation
----------

Additional Notes
----------------
From my test, the containerid is now retrieved properly. I used a modified dogstatsd app that prints the content of the message:
```
[ec2-user@ip-10-1-56-42 ~]$ k -n workload-dogstatsd logs dogstatsd-udp-origin-detection-85b7dd9944-flk4c
2024/03/18 11:39:50 page.views:1|c|c:27b8312e67ae6bf568fdd350d44009785d07916bd3d115fb9f8d0fb6fba313c5

[ec2-user@ip-10-1-56-42 ~]$ k -n workload-dogstatsd get pod dogstatsd-udp-origin-detection-85b7dd9944-flk4c -o yaml | grep -i 27b8312
  - containerID: containerd://27b8312e67ae6bf568fdd350d44009785d07916bd3d115fb9f8d0fb6fba313c5

```
