### PR TITLE
[ASCII-1318] Add `WithSkipAPIKeyInAgentConfig` option

### DIFF
--- a/components/datadog/agent/host.go
+++ b/components/datadog/agent/host.go
@@ -80,7 +80,7 @@ func (h *HostAgent) installAgent(env *config.CommonEnvironment, params *agentpar
 	configFiles := make(map[string]pulumi.StringInput)
 
 	// Update core Agent
-	_, content, err := h.updateCoreAgentConfig(env, "datadog.yaml", pulumi.String(params.AgentConfig), params.ExtraAgentConfig, params.SkipAPIKeyInAgentConfig, afterInstallOpts...)
+	_, content, err := h.updateCoreAgentConfig(env, "datadog.yaml", pulumi.String(params.AgentConfig), params.ExtraAgentConfig, params.SkipAPIKeyInConfig, afterInstallOpts...)
 	if err != nil {
 		return err
 	}
@@ -130,13 +130,13 @@ func (h *HostAgent) updateCoreAgentConfig(
 	configPath string,
 	configContent pulumi.StringInput,
 	extraAgentConfig []pulumi.StringInput,
-	skipAPIKeyInAgentConfig bool,
+	skipAPIKeyInConfig bool,
 	opts ...pulumi.ResourceOption,
 ) (*remote.Command, pulumi.StringInput, error) {
 	for _, extraConfig := range extraAgentConfig {
 		configContent = pulumi.Sprintf("%v\n%v", configContent, extraConfig)
 	}
-	if !skipAPIKeyInAgentConfig {
+	if !skipAPIKeyInConfig {
 		configContent = pulumi.Sprintf("api_key: %v\n%v", env.AgentAPIKey(), configContent)
 	}
 

--- a/components/datadog/agent/host.go
+++ b/components/datadog/agent/host.go
@@ -80,7 +80,7 @@ func (h *HostAgent) installAgent(env *config.CommonEnvironment, params *agentpar
 	configFiles := make(map[string]pulumi.StringInput)
 
 	// Update core Agent
-	_, content, err := h.updateCoreAgentConfig(env, "datadog.yaml", pulumi.String(params.AgentConfig), params.ExtraAgentConfig, params.WithoutDefaultAPIKey, afterInstallOpts...)
+	_, content, err := h.updateCoreAgentConfig(env, "datadog.yaml", pulumi.String(params.AgentConfig), params.ExtraAgentConfig, params.SkipAPIKeyInAgentConfig, afterInstallOpts...)
 	if err != nil {
 		return err
 	}
@@ -130,13 +130,13 @@ func (h *HostAgent) updateCoreAgentConfig(
 	configPath string,
 	configContent pulumi.StringInput,
 	extraAgentConfig []pulumi.StringInput,
-	withoutDefaultAPIKey bool,
+	skipAPIKeyInAgentConfig bool,
 	opts ...pulumi.ResourceOption,
 ) (*remote.Command, pulumi.StringInput, error) {
 	for _, extraConfig := range extraAgentConfig {
 		configContent = pulumi.Sprintf("%v\n%v", configContent, extraConfig)
 	}
-	if !withoutDefaultAPIKey {
+	if !skipAPIKeyInAgentConfig {
 		configContent = pulumi.Sprintf("api_key: %v\n%v", env.AgentAPIKey(), configContent)
 	}
 

--- a/components/datadog/agent/host.go
+++ b/components/datadog/agent/host.go
@@ -80,7 +80,7 @@ func (h *HostAgent) installAgent(env *config.CommonEnvironment, params *agentpar
 	configFiles := make(map[string]pulumi.StringInput)
 
 	// Update core Agent
-	_, content, err := h.updateCoreAgentConfig(env, "datadog.yaml", pulumi.String(params.AgentConfig), params.ExtraAgentConfig, afterInstallOpts...)
+	_, content, err := h.updateCoreAgentConfig(env, "datadog.yaml", pulumi.String(params.AgentConfig), params.ExtraAgentConfig, params.WithoutDefaultAPIKey, afterInstallOpts...)
 	if err != nil {
 		return err
 	}
@@ -130,12 +130,15 @@ func (h *HostAgent) updateCoreAgentConfig(
 	configPath string,
 	configContent pulumi.StringInput,
 	extraAgentConfig []pulumi.StringInput,
+	withoutDefaultAPIKey bool,
 	opts ...pulumi.ResourceOption,
 ) (*remote.Command, pulumi.StringInput, error) {
 	for _, extraConfig := range extraAgentConfig {
 		configContent = pulumi.Sprintf("%v\n%v", configContent, extraConfig)
 	}
-	configContent = pulumi.Sprintf("api_key: %v\n%v", env.AgentAPIKey(), configContent)
+	if !withoutDefaultAPIKey {
+		configContent = pulumi.Sprintf("api_key: %v\n%v", env.AgentAPIKey(), configContent)
+	}
 
 	cmd, err := h.updateConfig(configPath, configContent, opts...)
 	return cmd, configContent, err

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -22,12 +22,16 @@ import (
 //   - [WithAgentConfig]
 //   - [WithSystemProbeConfig]
 //   - [WithSecurityAgentConfig]
-//   - [WithFile]
 //   - [WithIntegration]
+//   - [WithFile]
 //   - [WithTelemetry]
-//   - [WithFakeintake]
+//   - [WithPulumiResourceOptions]
+//   - [withIntakeHostname]
 //   - [WithIntakeHostname]
+//   - [WithFakeintake]
 //   - [WithLogs]
+//   - [WithAdditionalInstallParameters]
+//   - [WithSkipAPIKeyInConfig]
 //
 // [Functional options pattern]: https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
 
@@ -48,7 +52,7 @@ type Params struct {
 	// This is a list of additional installer flags that can be used to pass installer-specific
 	// parameters like the MSI flags.
 	AdditionalInstallParameters []string
-	SkipAPIKeyInAgentConfig     bool
+	SkipAPIKeyInConfig          bool
 }
 
 type Option = func(*Params) error
@@ -266,10 +270,10 @@ func WithAdditionalInstallParameters(parameters []string) func(*Params) error {
 	}
 }
 
-// WithSkipAPIKeyInAgentConfig does not add the API key in the Agent configuration file.
-func WithSkipAPIKeyInAgentConfig() func(*Params) error {
+// WithSkipAPIKeyInConfig does not add the API key in the Agent configuration file.
+func WithSkipAPIKeyInConfig() func(*Params) error {
 	return func(p *Params) error {
-		p.SkipAPIKeyInAgentConfig = true
+		p.SkipAPIKeyInConfig = true
 		return nil
 	}
 }

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -48,7 +48,7 @@ type Params struct {
 	// This is a list of additional installer flags that can be used to pass installer-specific
 	// parameters like the MSI flags.
 	AdditionalInstallParameters []string
-	WithoutDefaultAPIKey        bool
+	SkipAPIKeyInAgentConfig     bool
 }
 
 type Option = func(*Params) error
@@ -266,10 +266,10 @@ func WithAdditionalInstallParameters(parameters []string) func(*Params) error {
 	}
 }
 
-// WithoutDefaultAPIKey does not add the default API key in the Agent configuration.
-func WithoutDefaultAPIKey() func(*Params) error {
+// WithSkipAPIKeyInAgentConfig does not add the API key in the Agent configuration file.
+func WithSkipAPIKeyInAgentConfig() func(*Params) error {
 	return func(p *Params) error {
-		p.WithoutDefaultAPIKey = true
+		p.SkipAPIKeyInAgentConfig = true
 		return nil
 	}
 }

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -48,6 +48,7 @@ type Params struct {
 	// This is a list of additional installer flags that can be used to pass installer-specific
 	// parameters like the MSI flags.
 	AdditionalInstallParameters []string
+	WithoutDefaultAPIKey        bool
 }
 
 type Option = func(*Params) error
@@ -119,7 +120,7 @@ func parseVersion(s string) (PackageVersion, error) {
 	return version, nil
 }
 
-// WithAgentConfig sets the configuration of the Agent. `{{API_KEY}}` can be used as a placeholder for the API key.
+// WithAgentConfig sets the configuration of the Agent.
 func WithAgentConfig(config string) func(*Params) error {
 	return func(p *Params) error {
 		p.AgentConfig = config
@@ -261,6 +262,14 @@ func WithLogs() func(*Params) error {
 func WithAdditionalInstallParameters(parameters []string) func(*Params) error {
 	return func(p *Params) error {
 		p.AdditionalInstallParameters = parameters
+		return nil
+	}
+}
+
+// WithoutDefaultAPIKey does not add the default API key in the Agent configuration.
+func WithoutDefaultAPIKey() func(*Params) error {
+	return func(p *Params) error {
+		p.WithoutDefaultAPIKey = true
 		return nil
 	}
 }


### PR DESCRIPTION
What does this PR do?
---------------------
The framework implicitly adds an api key to the agent config.
This PR adds an option to disable that behavior, leaving the user responsible for adding the api key by itself.

Which scenarios this will impact?
-------------------
Agent E2E tests.
The default behavior is unchanged.

Motivation
----------
Testing various features around the secret refresh of the API key requires having a dynamic API key. 

Additional Notes
----------------
