### PR TITLE
[dockerfile] increase verbosity in pulumi plugin install command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ RUN --mount=type=secret,id=github_token \
   cd /tmp/test-infra && \
   go mod download && \
   export PULUMI_CONFIG_PASSPHRASE=dummy && \
-  pulumi --non-interactive plugin install && \
+  pulumi --logflow --logtostderr -v 5 --non-interactive plugin install && \
   pulumi --non-interactive plugin install resource time v0.0.16 && \
   pulumi --non-interactive plugin ls && \
   cd / && \


### PR DESCRIPTION
What does this PR do?
---------------------

Increase verbosity at `pulumi plugin install` command, to improve investigation experience when a plugin is not installed

Which scenarios this will impact?
-------------------

None

Motivation
----------

A plugin whom go dependency is in `go.mod` is not installed automatically with the runner, the error was hidden in default pulumi plugin install output, this PR helps further investigations 

Additional Notes
----------------
