### PR TITLE
[CONTINT-3935] Create a priorityClass for the agent

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -241,6 +241,7 @@ func buildLinuxHelmValues(installName, agentImagePath, agentImageTag, clusterAge
 				"tag":           pulumi.String(agentImageTag),
 				"doNotCheckTag": pulumi.Bool(true),
 			},
+			"priorityClassCreate": pulumi.Bool(true),
 			"podAnnotations": pulumi.StringMap{
 				"ad.datadoghq.com/agent.checks": pulumi.String(utils.JSONMustMarshal(
 					map[string]interface{}{


### PR DESCRIPTION
What does this PR do?
---------------------

Create a `priorityClass` for the agent.

Which scenarios this will impact?
-------------------

* `aws/eks`
* `aws/kindvm`

Motivation
----------

In the `datadog-agent` repository, the `TestEKSSuite` suite is currently flaky and fails to complete the pulumi stack creation from time to time with following error:
```
resource "urn:pulumi:ci-30352959-4670-eks-cluster::e2eci::pulumi:providers:kubernetes$dd:apps$kubernetes:apps/v1:Deployment::dogstatsd-uds-8125" was successfully created, but the Kubernetes API server reported that it failed to fully initialize or become live: 'dogstatsd-uds' timed out waiting to be Ready
```

It turned out that the `dogstatsd-uds` pod remain in `ContainerCreating` forever:
```
NOMINATED NODE   READINESS GATES
        workload-dogstatsd              pod/dogstatsd-uds-6b9544d9cf-9stph                     0/1     ContainerCreating   0          10m     <none>        ip-10-1-48-101.ec2.internal   <none>           <none>
```

This is because it cannot mount the dogstatsd socket that is supposed to be created by the agent.
Indeed, the agent pod supposed to run on the same node isn’t starting either:
```
        NAMESPACE                       NAME                                                   READY   STATUS              RESTARTS   AGE     IP            NODE                          NOMINATED NODE   READINESS GATES
        datadog                         pod/dda-linux-datadog-2twwr                            0/3     Pending             0          9m39s   <none>        <none>                        <none>           <none>
```

The issue is that recent PRs have added more fake app pods on the EKS cluster and EKS nodes have a capacity of 17 pods.
From time to time, the spread of pods on nodes is unbalanced and some nodes receive 17 pods before the agent is started.
![image](https://github.com/DataDog/test-infra-definitions/assets/1437785/e6ec117b-9650-4e14-9e47-6e9449c11024)
In such a case, we must allow the agent to evict another pod so that it will be scheduled elsewhere.
That’s the purpose of the `priorityClass`.

Additional Notes
----------------
