### PR TITLE
Fix DD_TRACE_AGENT_URL in the k8s UDS scenario

### DIFF
--- a/components/datadog/apps/tracegen/k8s.go
+++ b/components/datadog/apps/tracegen/k8s.go
@@ -65,7 +65,7 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 							Env: &corev1.EnvVarArray{
 								&corev1.EnvVarArgs{
 									Name:  pulumi.String("DD_TRACE_AGENT_URL"),
-									Value: pulumi.String("/var/run/datadog/apm.socket"),
+									Value: pulumi.String("unix:///var/run/datadog/apm.socket"),
 								},
 							},
 							Resources: &corev1.ResourceRequirementsArgs{


### PR DESCRIPTION
What does this PR do?
---------------------

Fix `DD_TRACE_AGENT_URL` value in the k8s definition of tracegen

Which scenarios this will impact?
-------------------

APM scenario on k8s + UDS

Motivation
----------

Bug fix

Additional Notes
----------------
