### PR TITLE
CI(auto-bump): Automatically create test-infra bump PR on datadog-agent

### DIFF
--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -45,7 +45,7 @@ jobs:
         working-directory: datadog-agent
         run: |
           GO_MOD_ONLY="--go-mod-only"
-          if [[ ${github.pull_request_merged} == 'true']]; then
+          if [[ '${github.pull_request_merged}' == 'true']]; then
             GO_MOD_ONLY=""
           fi
           inv -e buildimages.update-test-infra-definitions --commit-sha ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -60,9 +60,9 @@ jobs:
           branch: 'automated/test-infra-definitions/${{ github.event.number }}'
           labels: 'team/agent-developer-tools,changelog/no-changelog,qa/no-code-change'
           body: >
-            Automatically created by merging ${{ github.event.pull_request.html_url }}/n
+            Automatically created by merging ${{ github.event.pull_request.html_url }}
 
-            Here is the full changelog between your 2 changes: https://github.com/DataDog/test-infra-definitions/compare/${{steps.get-previous-sha.outputs.PREVIOUS_SHA}}..${{github.event.pull_request.head.sha}}
+            Here is the full changelog between the two version of test-infra-definitions: https://github.com/DataDog/test-infra-definitions/compare/${{steps.get-previous-sha.outputs.PREVIOUS_SHA}}..${{github.event.pull_request.head.sha}}
 
 
             :warning: This PR is opened with the skip-qa labels by default. Please make sure this is appropriate

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -44,16 +44,11 @@ jobs:
       - name: Update test-infra-defintions version
         working-directory: datadog-agent
         run: |
-          GO_MOD_ONLY="--go-mod-only"
-          if [[ '${{github.pull_request_merged}}' == 'true' ]]; then
-            GO_MOD_ONLY=""
-          fi
-          inv -e buildimages.update-test-infra-definitions --commit-sha ${{ github.event.pull_request.head.sha }} $GO_MOD_ONLY
+          inv -e buildimages.update-test-infra-definitions --commit-sha ${{ github.event.pull_request.head.sha }}
 
       - name: create datadog-agent PR
         uses: peter-evans/create-pull-request@v5
         with:
-          draft: ${{ github.event.pull_request_merged != 'true'}}
           token: ${{ steps.app-token.outputs.token }}
           base: main
           delete-branch: true

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -1,0 +1,62 @@
+name: Open datadog-agent PR
+run-name:
+on:
+  pull_request:
+    types:
+      - closed
+      - push
+
+jobs:
+  open_bump_pr:
+    if: !contains(github.event.pull_request.labels.*.name, 'no-auto-bump')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.DATADOG_APP_ID }}
+          private-key: ${{ secrets.DATADOG_APP_PRIVATE_KEY }}
+          repositories: datadog-agent
+
+      - name: Clone datadog-agent repo
+        uses: actions/checkout@v4
+        with:
+          repository: datadog/datadog-agent
+          persist-credentials: false
+          path: datadog-agent
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Setup Python3
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11.5"
+          cache: "pip"
+
+      - name: Install python deps
+        working-directory: datadog-agent
+        run: |
+          pip3 install -r requirements.txt
+
+       - name: Update test-infra-defintions version
+        working-directory: datadog-agent
+        run: |
+          inv -e update-test-infra-definitions --commit-sha ${{ github.event.pull_request.head.sha }}
+
+      - name: create datadog-agent PR
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          base: main
+          delete-branch: true
+          path: datadog-agent
+          add-paths: release.json
+          commit-message: 'omnibus: bump OMNIBUS_RUBY_VERSION'
+          title: '[omnibus][automated] Bump OMNIBUS_RUBY_VERSION'
+          branch: 'automated/omnibus-ruby/${{ github.event.number }}'
+          labels: 'team/agent-platform,changelog/no-changelog,qa/no-code-change'
+          body: >
+            Automatically created by merging ${{ github.event.pull_request.html_url }}
+
+            :warning: This PR is opened with the skip-qa labels by default. Please make sure this is appropriate

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   open_bump_pr:
-    # if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-auto-bump') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-auto-bump') }}
     runs-on: ubuntu-latest
     steps:
       - name: Create Token

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -65,4 +65,4 @@ jobs:
             Here is the full changelog between the two version of test-infra-definitions: https://github.com/DataDog/test-infra-definitions/compare/${{steps.get-previous-sha.outputs.PREVIOUS_SHA}}..${{github.event.pull_request.head.sha}}
 
 
-            :warning: This PR is opened with the skip-qa labels by default. Please make sure this is appropriate
+            :warning: This PR is opened with the `qa/no-code-change` and `changelog/no-changelog` labels by default. Please make sure this is appropriate

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -53,10 +53,6 @@ jobs:
           base: main
           delete-branch: true
           path: datadog-agent
-          add-paths: |
-            .gitlab-ci.yml
-            test/new-e2e/go.mod
-            test/new-e2e/go.sum
           commit-message: 'test-infra-definitions: bump test-infra-definitions version'
           title: '[test-infra-definitions][automated] Bump test-infra-definitions'
           branch: 'automated/test-infra-definitions/${{ github.event.number }}'

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -60,6 +60,7 @@ jobs:
           body: >
             Automatically created by merging ${{ github.event.pull_request.html_url }}/n
 
-            Here is the full changelog between your 2 changes: https://github.com/DataDog/test-infra-definitions/compare/${{steps.get-previous-sha.outputs.PREVIOUS_SHA}}..${{github.event.pull_request.head.sha}}\n
+            Here is the full changelog between your 2 changes: https://github.com/DataDog/test-infra-definitions/compare/${{steps.get-previous-sha.outputs.PREVIOUS_SHA}}..${{github.event.pull_request.head.sha}}
             
+
             :warning: This PR is opened with the skip-qa labels by default. Please make sure this is appropriate

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -5,6 +5,7 @@ on:
     types:
       - closed
       - push
+      - opened
 
 jobs:
   open_bump_pr:

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -2,10 +2,12 @@ name: Open datadog-agent PR
 run-name:
 on:
   pull_request:
+    types:
+      - closed
 
 jobs:
   open_bump_pr:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-auto-bump') }}
+    if: github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'no-auto-bump')
     runs-on: ubuntu-latest
     steps:
       - name: Create Token

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           pip3 install -r requirements.txt
 
-       - name: Update test-infra-defintions version
+      - name: Update test-infra-defintions version
         working-directory: datadog-agent
         run: |
           inv -e update-test-infra-definitions --commit-sha ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -45,7 +45,7 @@ jobs:
         working-directory: datadog-agent
         run: |
           GO_MOD_ONLY="--go-mod-only"
-          if [[ '${github.pull_request_merged}' == 'true']]; then
+          if [['${github.pull_request_merged}' == 'true']]; then
             GO_MOD_ONLY=""
           fi
           inv -e buildimages.update-test-infra-definitions --commit-sha ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -44,11 +44,16 @@ jobs:
       - name: Update test-infra-defintions version
         working-directory: datadog-agent
         run: |
+          GO_MOD_ONLY="--go-mod-only"
+          if [[ ${github.pull_request_merged} == 'true']]; then
+            GO_MOD_ONLY=""
+          fi
           inv -e buildimages.update-test-infra-definitions --commit-sha ${{ github.event.pull_request.head.sha }}
 
       - name: create datadog-agent PR
         uses: peter-evans/create-pull-request@v5
         with:
+          draft: ${{ github.event.pull_request_merged != 'true'}}
           token: ${{ steps.app-token.outputs.token }}
           base: main
           delete-branch: true
@@ -61,6 +66,6 @@ jobs:
             Automatically created by merging ${{ github.event.pull_request.html_url }}/n
 
             Here is the full changelog between your 2 changes: https://github.com/DataDog/test-infra-definitions/compare/${{steps.get-previous-sha.outputs.PREVIOUS_SHA}}..${{github.event.pull_request.head.sha}}
-            
+
 
             :warning: This PR is opened with the skip-qa labels by default. Please make sure this is appropriate

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   open_bump_pr:
-    if: !contains(github.event.pull_request.labels.*.name, 'no-auto-bump')
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-auto-bump') }}
     runs-on: ubuntu-latest
     steps:
       - name: Create Token

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Update test-infra-defintions version
         working-directory: datadog-agent
         run: |
-          inv -e update-test-infra-definitions --commit-sha ${{ github.event.pull_request.head.sha }}
+          inv -e buildimages.update-test-infra-definitions --commit-sha ${{ github.event.pull_request.head.sha }}
 
       - name: create datadog-agent PR
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -48,7 +48,7 @@ jobs:
           if [[ '${{github.pull_request_merged}}' == 'true' ]]; then
             GO_MOD_ONLY=""
           fi
-          inv -e buildimages.update-test-infra-definitions --commit-sha ${{ github.event.pull_request.head.sha }}
+          inv -e buildimages.update-test-infra-definitions --commit-sha ${{ github.event.pull_request.head.sha }} $GO_MOD_ONLY
 
       - name: create datadog-agent PR
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -24,7 +24,12 @@ jobs:
           path: datadog-agent
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
-
+      - name: Get previous SHA
+        id: get-previous-sha
+        working-directory: datadog-agent
+        run: |
+          PREVIOUS_SHA=$(cat .gitlab-ci.yml | grep TEST_INFRA_DEFINITIONS_BUILDIMAGES: | awk -F " " '{print $NF}')
+          echo PREVIOUS_SHA=${PREVIOUS_SHA} >> "${GITHUB_OUTPUT}"
       - name: Setup Python3
         uses: actions/setup-python@v4
         with:
@@ -49,11 +54,11 @@ jobs:
           delete-branch: true
           path: datadog-agent
           add-paths: release.json
-          commit-message: 'omnibus: bump OMNIBUS_RUBY_VERSION'
-          title: '[omnibus][automated] Bump OMNIBUS_RUBY_VERSION'
-          branch: 'automated/omnibus-ruby/${{ github.event.number }}'
-          labels: 'team/agent-platform,changelog/no-changelog,qa/no-code-change'
+          commit-message: 'test-infra-definitions: bump test-infra-definitions version'
+          title: '[test-infra-definitions][automated] Bump test-infra-definitions'
+          branch: 'automated/test-infra-definitions/${{ github.event.number }}'
+          labels: 'team/agent-developer-tools,changelog/no-changelog,qa/no-code-change'
           body: >
             Automatically created by merging ${{ github.event.pull_request.html_url }}
-
+            Here is the full changelog between your 2 changes: https://github.com/DataDog/test-infra-definitions/compare/{{steps.get-previous-sha.outputs.PREVIOUS_SHA}}..{{github.event.pull_request.head.sha}}
             :warning: This PR is opened with the skip-qa labels by default. Please make sure this is appropriate

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -58,6 +58,8 @@ jobs:
           branch: 'automated/test-infra-definitions/${{ github.event.number }}'
           labels: 'team/agent-developer-tools,changelog/no-changelog,qa/no-code-change'
           body: >
-            Automatically created by merging ${{ github.event.pull_request.html_url }}
-            Here is the full changelog between your 2 changes: https://github.com/DataDog/test-infra-definitions/compare/{{steps.get-previous-sha.outputs.PREVIOUS_SHA}}..{{github.event.pull_request.head.sha}}
+            Automatically created by merging ${{ github.event.pull_request.html_url }}/n
+
+            Here is the full changelog between your 2 changes: https://github.com/DataDog/test-infra-definitions/compare/${{steps.get-previous-sha.outputs.PREVIOUS_SHA}}..${{github.event.pull_request.head.sha}}\n
+            
             :warning: This PR is opened with the skip-qa labels by default. Please make sure this is appropriate

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -2,10 +2,6 @@ name: Open datadog-agent PR
 run-name:
 on:
   pull_request:
-    types:
-      - closed
-      - push
-      - opened
 
 jobs:
   open_bump_pr:

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -45,7 +45,7 @@ jobs:
         working-directory: datadog-agent
         run: |
           GO_MOD_ONLY="--go-mod-only"
-          if [['${github.pull_request_merged}' == 'true']]; then
+          if [['${{github.pull_request_merged}}' == 'true']]; then
             GO_MOD_ONLY=""
           fi
           inv -e buildimages.update-test-infra-definitions --commit-sha ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -53,7 +53,10 @@ jobs:
           base: main
           delete-branch: true
           path: datadog-agent
-          add-paths: release.json
+          add-paths: |
+            .gitlab-ci.yml
+            test/new-e2e/go.mod
+            test/new-e2e/go.sum
           commit-message: 'test-infra-definitions: bump test-infra-definitions version'
           title: '[test-infra-definitions][automated] Bump test-infra-definitions'
           branch: 'automated/test-infra-definitions/${{ github.event.number }}'

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -45,7 +45,7 @@ jobs:
         working-directory: datadog-agent
         run: |
           GO_MOD_ONLY="--go-mod-only"
-          if [['${{github.pull_request_merged}}' == 'true']]; then
+          if [[ '${{github.pull_request_merged}}' == 'true' ]]; then
             GO_MOD_ONLY=""
           fi
           inv -e buildimages.update-test-infra-definitions --commit-sha ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/auto-bump-datadog-agent.yml
+++ b/.github/workflows/auto-bump-datadog-agent.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   open_bump_pr:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-auto-bump') }}
+    # if: ${{ !contains(github.event.pull_request.labels.*.name, 'no-auto-bump') }}
     runs-on: ubuntu-latest
     steps:
       - name: Create Token


### PR DESCRIPTION
What does this PR do?
---------------------

This PR add a new github action workflow to automatically creates the test-infra bump PR on datadog-agent when the PR is merged




Example auto bump PR: https://github.com/DataDog/datadog-agent/pull/23989

Thanks @julien-lebot for the invoke task bumping test-infra on datadog-agent side 🙇 

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------

I tried to use the action to create a PR that can be modified by the user while being automatically updated by the action when new changes are added to the test-infra PR. But it does not work since the action by design always force push to the created branch
