### PR TITLE
Enable ACPI for arm64 VMs

### DIFF
--- a/scenarios/aws/microVMs/microvms/resources/distro/domain-arm64.xsl
+++ b/scenarios/aws/microVMs/microvms/resources/distro/domain-arm64.xsl
@@ -82,7 +82,6 @@
         </xsl:copy>
     </xsl:template>
 
-    <xsl:template match="features/acpi" />
     <xsl:template match="domain/devices/graphics" />
     <xsl:template match="domain/devices/audio" />
     <xsl:template match="domain/devices/video" />


### PR DESCRIPTION
What does this PR do?
---------------------

Which scenarios this will impact?
-------------------

Motivation
----------
Amazon linux 2023 arm64 VMs require ACPI to boot.

Additional Notes
----------------
