### PR TITLE
Use latest nightly version of the agent instead of stable as default

### DIFF
--- a/components/datadog/agent/host_linuxos.go
+++ b/components/datadog/agent/host_linuxos.go
@@ -46,12 +46,8 @@ func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersio
 		commandLine += fmt.Sprintf("DD_AGENT_MINOR_VERSION=%v ", version.Minor)
 	}
 
-	if version.BetaChannel {
-		commandLine += "REPO_URL=datad0g.com DD_AGENT_DIST_CHANNEL=beta "
-	}
-
-	if version.NightlyChannel {
-		commandLine += "REPO_URL=datad0g.com DD_AGENT_DIST_CHANNEL=nightly "
+	if version.Channel != "" && version.Channel != agentparams.StableChannel {
+		commandLine += fmt.Sprintf("REPO_URL=datad0g.com DD_AGENT_DIST_CHANNEL=%s ", version.Channel)
 	}
 
 	return fmt.Sprintf(

--- a/components/datadog/agent/host_linuxos.go
+++ b/components/datadog/agent/host_linuxos.go
@@ -50,6 +50,10 @@ func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersio
 		commandLine += "REPO_URL=datad0g.com DD_AGENT_DIST_CHANNEL=beta "
 	}
 
+	if version.NightlyChannel {
+		commandLine += "REPO_URL=datad0g.com DD_AGENT_DIST_CHANNEL=nightly "
+	}
+
 	return fmt.Sprintf(
 		`for i in 1 2 3 4 5; do curl -fsSL https://s3.amazonaws.com/dd-agent/scripts/%v -o install-script.sh && break || sleep $((2**$i)); done &&  for i in 1 2 3; do DD_API_KEY=%%s %v DD_INSTALL_ONLY=true bash install-script.sh  && break || sleep $((2**$i)); done`,
 		fmt.Sprintf("install_script_agent%s.sh", version.Major),

--- a/components/datadog/agent/host_windowsos.go
+++ b/components/datadog/agent/host_windowsos.go
@@ -5,12 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"golang.org/x/exp/slices"
 	"io"
 	"net/http"
 	"reflect"
 	"sort"
 	"strings"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/DataDog/test-infra-definitions/components/command"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
@@ -99,7 +100,7 @@ func getAgentURL(version agentparams.PackageVersion) (string, error) {
 		return getAgentURLFromPipelineID(version.PipelineID)
 	}
 
-	if version.BetaChannel {
+	if version.Channel == agentparams.BetaChannel {
 		finder, err := newAgentURLFinder("https://s3.amazonaws.com/dd-agent-mstesting/builds/beta/installers_v2.json")
 		if err != nil {
 			return "", err

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -62,7 +62,7 @@ func NewParams(env *config.CommonEnvironment, options ...Option) (*Params, error
 		Integrations: make(map[string]*FileDefinition),
 		Files:        make(map[string]*FileDefinition),
 	}
-	defaultVersion := WithLatest()
+	defaultVersion := WithLatestNightly()
 	if env.PipelineID() != "" {
 		defaultVersion = WithPipeline(env.PipelineID())
 	}
@@ -78,6 +78,15 @@ func WithLatest() func(*Params) error {
 	return func(p *Params) error {
 		p.Version.Major = "7"
 		p.Version.BetaChannel = false
+		p.Version.NightlyChannel = false
+		return nil
+	}
+}
+
+func WithLatestNightly() func(*Params) error {
+	return func(p *Params) error {
+		p.Version.Major = "7"
+		p.Version.NightlyChannel = true
 		return nil
 	}
 }

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -8,7 +8,6 @@ import (
 	"github.com/DataDog/test-infra-definitions/common"
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
-	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -78,7 +77,7 @@ func NewParams(env *config.CommonEnvironment, options ...Option) (*Params, error
 func WithLatest() func(*Params) error {
 	return func(p *Params) error {
 		p.Version.Major = "7"
-		p.Version.Channel = agentparams.StableChannel
+		p.Version.Channel = StableChannel
 		return nil
 	}
 }
@@ -86,7 +85,7 @@ func WithLatest() func(*Params) error {
 func WithLatestNightly() func(*Params) error {
 	return func(p *Params) error {
 		p.Version.Major = "7"
-		p.Version.Channel = agentparams.NightlyChannel
+		p.Version.Channel = NightlyChannel
 		return nil
 	}
 }
@@ -130,9 +129,9 @@ func parseVersion(s string) (PackageVersion, error) {
 	}
 	version.Minor = strings.TrimPrefix(s, prefix)
 
-	version.Channel = agentparams.StableChannel
+	version.Channel = StableChannel
 	if strings.Contains(s, "~") {
-		version.Channel = agentparams.BetaChannel
+		version.Channel = BetaChannel
 	}
 
 	return version, nil

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -8,6 +8,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/common"
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -77,8 +78,7 @@ func NewParams(env *config.CommonEnvironment, options ...Option) (*Params, error
 func WithLatest() func(*Params) error {
 	return func(p *Params) error {
 		p.Version.Major = "7"
-		p.Version.BetaChannel = false
-		p.Version.NightlyChannel = false
+		p.Version.Channel = agentparams.StableChannel
 		return nil
 	}
 }
@@ -86,7 +86,7 @@ func WithLatest() func(*Params) error {
 func WithLatestNightly() func(*Params) error {
 	return func(p *Params) error {
 		p.Version.Major = "7"
-		p.Version.NightlyChannel = true
+		p.Version.Channel = agentparams.NightlyChannel
 		return nil
 	}
 }
@@ -129,7 +129,12 @@ func parseVersion(s string) (PackageVersion, error) {
 		}
 	}
 	version.Minor = strings.TrimPrefix(s, prefix)
-	version.BetaChannel = strings.Contains(s, "~")
+
+	version.Channel = agentparams.StableChannel
+	if strings.Contains(s, "~") {
+		version.Channel = agentparams.BetaChannel
+	}
+
 	return version, nil
 }
 

--- a/components/datadog/agentparams/params_test.go
+++ b/components/datadog/agentparams/params_test.go
@@ -12,18 +12,18 @@ func TestParams(t *testing.T) {
 		version, err := parseVersion("7.43")
 		assert.NoError(t, err)
 		assert.Equal(t, version, PackageVersion{
-			Major:       "7",
-			Minor:       "43",
-			BetaChannel: false,
+			Major:   "7",
+			Minor:   "43",
+			Channel: StableChannel,
 		})
 	})
 	t.Run("parseVersion should correctly parse rc version", func(t *testing.T) {
 		version, err := parseVersion("7.45~rc.1")
 		assert.NoError(t, err)
 		assert.Equal(t, version, PackageVersion{
-			Major:       "7",
-			Minor:       "45~rc.1",
-			BetaChannel: true,
+			Major:   "7",
+			Minor:   "45~rc.1",
+			Channel: BetaChannel,
 		})
 	})
 	t.Run("parsePipelineVersion should correctly parse a pipeline ID and format the agent version pipeline", func(t *testing.T) {

--- a/components/datadog/agentparams/version.go
+++ b/components/datadog/agentparams/version.go
@@ -1,9 +1,16 @@
 package agentparams
 
+type channel string
+
+const (
+	StableChannel  channel = "stable"
+	BetaChannel    channel = "beta"
+	NightlyChannel channel = "nightly"
+)
+
 type PackageVersion struct {
-	Major          string
-	Minor          string // Empty means latest
-	BetaChannel    bool
-	NightlyChannel bool
-	PipelineID     string
+	Major      string
+	Minor      string // Empty means latest
+	Channel    channel
+	PipelineID string
 }

--- a/components/datadog/agentparams/version.go
+++ b/components/datadog/agentparams/version.go
@@ -1,8 +1,9 @@
 package agentparams
 
 type PackageVersion struct {
-	Major       string
-	Minor       string // Empty means latest
-	BetaChannel bool
-	PipelineID  string
+	Major          string
+	Minor          string // Empty means latest
+	BetaChannel    bool
+	NightlyChannel bool
+	PipelineID     string
 }


### PR DESCRIPTION
What does this PR do?
---------------------

Change the default version of the datadog-agent package used from latest stable to latest nightly.

Users running e2e tests locally prefer to have a version of the agent closer to their changes. Latest stable can be quite different from the latest main version of the agent. Latest nightly is closer to the current main state

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
