### PR TITLE
Enable host sbom collection in k8s

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -206,6 +206,9 @@ func buildLinuxHelmValues(installName, agentImagePath, agentImageTag, clusterAge
 				"enabled": pulumi.Bool(true),
 			},
 			"sbom": pulumi.Map{
+				"host": pulumi.Map{
+					"enabled": pulumi.Bool(true),
+				},
 				"containerImage": pulumi.Map{
 					"enabled":                   pulumi.Bool(true),
 					"uncompressedLayersSupport": pulumi.Bool(true),


### PR DESCRIPTION
What does this PR do?
---------------------
This PR enables host sbom collection in k8s

Which scenarios this will impact?
-------------------
aws/eks aws/kind

Motivation
----------
We recently discovered agent panics following a dependency bump when host sbom was enabled.

Additional Notes
----------------
