### PR TITLE
Fix HPA settings to make them more reactive

### DIFF
--- a/components/datadog/apps/nginx/k8s.go
+++ b/components/datadog/apps/nginx/k8s.go
@@ -231,10 +231,15 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 									Name: pulumi.String("datadogmetric@" + namespace + ":nginx"),
 								},
 								Target: &autoscalingv2beta2.MetricTargetArgs{
-									Type:         pulumi.String("AverageValue"),
-									AverageValue: pulumi.String("10"),
+									Type:  pulumi.String("Value"),
+									Value: pulumi.StringPtr("10"),
 								},
 							},
+						},
+					},
+					Behavior: &autoscalingv2beta2.HorizontalPodAutoscalerBehaviorArgs{
+						ScaleDown: &autoscalingv2beta2.HPAScalingRulesArgs{
+							StabilizationWindowSeconds: pulumi.IntPtr(0),
 						},
 					},
 				},
@@ -266,10 +271,15 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 									Name: pulumi.String("datadogmetric@" + namespace + ":nginx"),
 								},
 								Target: &autoscalingv2.MetricTargetArgs{
-									Type:         pulumi.String("AverageValue"),
-									AverageValue: pulumi.String("10"),
+									Type:  pulumi.String("Value"),
+									Value: pulumi.StringPtr("10"),
 								},
 							},
+						},
+					},
+					Behavior: &autoscalingv2.HorizontalPodAutoscalerBehaviorArgs{
+						ScaleDown: &autoscalingv2.HPAScalingRulesArgs{
+							StabilizationWindowSeconds: pulumi.IntPtr(0),
 						},
 					},
 				},


### PR DESCRIPTION
What does this PR do?
---------------------

* In the `spec` of `HorizontalPodAutoscaler`, use `Value` instead of `AverageValue` because the query in the `DatadogMetric` is already computing an average (`avg:` operator at the beginning of the query).
  As a result, the total number of TPS was wrongly divided twice by the number of pods (once by datadog because of the `avg` operator in the query and once [by the HPA](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#algorithm-details) itself)
* Reduce the [stabilization windows](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#stabilization-window) because:
  * We want the HPA to be as reactive as possible in the context of e2e to detect scale up and scale down events as fast as possible [here](https://github.com/DataDog/datadog-agent/blob/b2384042b144a5f880a4d22b22018895101eceea/test/new-e2e/tests/containers/k8s_test.go#L939).
  * The [doc](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#stabilization-window) says:
    > The stabilization window is used to restrict the flapping of replica count when the metrics used for scaling keep fluctuating.

    We don’t need it because [the query in the DatadogMetric already smoothes the values with the `.rollup(60)`](https://github.com/DataDog/test-infra-definitions/blob/37aac06e056635fe3dc3e90e56930e4a80ad4cb3/components/datadog/apps/nginx/k8s.go#L199).

Which scenarios this will impact?
-------------------

* `aws/eks`
* `aws/kindvm`

Motivation
----------

We noticed some flaky failures of the [testHPA](https://github.com/DataDog/datadog-agent/blob/b2384042b144a5f880a4d22b22018895101eceea/test/new-e2e/tests/containers/k8s_test.go#L356) in the past.

Additional Notes
----------------

This graph shows the behavior of the HPA before and after this change.
![image](https://github.com/DataDog/test-infra-definitions/assets/1437785/a9a79627-b4de-4b39-a3f8-65c21dc78a41)