### PR TITLE
Add netflow-generator workload app.

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,6 +64,8 @@ jobs:
             image: npm-tools
           - app: logger
             image: logger
+          - app: netflow-generator
+            image: netflow-generator
 
     steps:
       - name: Checkout repository

--- a/components/datadog/apps/netflow-generator/images/netflow-generator/Dockerfile
+++ b/components/datadog/apps/netflow-generator/images/netflow-generator/Dockerfile
@@ -1,0 +1,1 @@
+FROM networkstatic/nflow-generator


### PR DESCRIPTION
What does this PR do?
---------------------
Add netflow-generator workload app.

Which scenarios this will impact?
-------------------
This is simply a repackaging of networkstatic/nflow-generator so we can pull the image from our own registry to avoid any Docker Hub rate limits.  It will initially only be used in a docker environment by a new ndm/netflow new-e2e test.

Motivation
----------

Additional Notes
----------------
