### PR TITLE
[updater] Add default config

### DIFF
--- a/components/datadog/updater/install_script.sh
+++ b/components/datadog/updater/install_script.sh
@@ -21,6 +21,10 @@ if [ "$UID" == "0" ]; then
 else
     sudo_cmd="sudo"
 fi
+$sudo_cmd mkdir -p /etc/datadog-agent
+$sudo_cmd touch $config_file
+$sudo_cmd chmod 644 $config_file
+$sudo_cmd sh -c "echo 'api_key: $apikey' > $config_file"
 
 agent_major_version=7
 


### PR DESCRIPTION
Add default config to avoid permanent crashes of datadog-agent and datadog-updater units

E2E that use agent configuration + real api keys are left to the datadog installer