### PR TITLE
[github] bump cosign to 2.2.3

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -77,7 +77,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 #3.4.0
         with:
-          cosign-release: 'v1.13.1'
+          cosign-release: 'v2.2.3'
 
 
       # Workaround: https://github.com/docker/build-push-action/issues/461


### PR DESCRIPTION
What does this PR do?
---------------------

Bump cosign to 2.2.3

Which scenarios this will impact?
-------------------

None

Motivation
----------

A recent change in cosign caused our signature action to fail on main, we bump to v2.2.3 as suggested by https://blog.sigstore.dev/tuf-root-update/

Additional Notes
----------------
