### PR TITLE
[components/datadog] Add deployments with APM instrumentation

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -203,6 +203,15 @@ func buildLinuxHelmValues(installName, agentImagePath, agentImageTag, clusterAge
 			},
 			"apm": pulumi.Map{
 				"portEnabled": pulumi.Bool(true),
+				"instrumentation": pulumi.Map{
+					"enabled": pulumi.Bool(true),
+					"enabledNamespaces": pulumi.Array{
+						pulumi.String("workload-mutated-lib-injection"),
+					},
+					"language_detection": pulumi.Map{
+						"enabled": pulumi.Bool(true),
+					},
+				},
 			},
 			"processAgent": pulumi.Map{
 				"processCollection": pulumi.Bool(true),
@@ -284,6 +293,14 @@ func buildLinuxHelmValues(installName, agentImagePath, agentImageTag, clusterAge
 				"useDatadogMetrics": pulumi.Bool(true),
 			},
 			"token": clusterAgentToken,
+			"env": pulumi.MapArray{
+				// This option is disabled by default and not exposed in the
+				// Helm chart yet, so we need to set the env.
+				pulumi.Map{
+					"name":  pulumi.String("DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INJECT_AUTO_DETECTED_LIBRARIES"),
+					"value": pulumi.String("true"),
+				},
+			},
 		},
 		"clusterChecksRunner": pulumi.Map{
 			"enabled": pulumi.Bool(true),

--- a/components/datadog/apps/mutatedbyadmissioncontroller/k8s.go
+++ b/components/datadog/apps/mutatedbyadmissioncontroller/k8s.go
@@ -12,7 +12,16 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
+// K8sAppDefinition creates 3 different deployments:
+// - to be mutated but without lib injection
+// - to be mutated with lib injection specifying the library in an annotation.
+// - to be mutated with lib injection without specifying the library in an
+// annotation. The language will be auto-detected.
+//
+// Lib injection can be enabled or disabled by namespace. We use 2 separate
+// namespaces so that we can test mutation with and without lib injection
+// separately.
+func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provider, namespaceWithoutLibInjection string, namespaceWithLibInjection string, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &componentskube.Workload{}
@@ -22,51 +31,118 @@ func K8sAppDefinition(e config.CommonEnvironment, kubeProvider *kubernetes.Provi
 
 	opts = append(opts, pulumi.Parent(k8sComponent))
 
-	ns, err := corev1.NewNamespace(e.Ctx, namespace, &corev1.NamespaceArgs{
+	nsWithoutLibInjection, err := corev1.NewNamespace(e.Ctx, namespaceWithoutLibInjection, &corev1.NamespaceArgs{
 		Metadata: &metav1.ObjectMetaArgs{
-			Name: pulumi.String(namespace),
+			Name: pulumi.String(namespaceWithoutLibInjection),
 		},
 	}, opts...)
 	if err != nil {
 		return nil, err
 	}
 
-	opts = append(opts, pulumi.Parent(ns))
-
-	if _, err := appsv1.NewDeployment(e.Ctx, "mutated", &appsv1.DeploymentArgs{
+	nsWithLibInjection, err := corev1.NewNamespace(e.Ctx, namespaceWithLibInjection, &corev1.NamespaceArgs{
 		Metadata: &metav1.ObjectMetaArgs{
-			Name:      pulumi.String("mutated"),
+			Name: pulumi.String(namespaceWithLibInjection),
+		},
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = k8sDeploymentWithoutLibInjection(e, namespaceWithoutLibInjection, "mutated", append(opts, pulumi.Parent(nsWithoutLibInjection))...); err != nil {
+		return nil, err
+	}
+	if err = k8sDeploymentWithLibInjection(e, namespaceWithLibInjection, "mutated-with-lib-annotation", true, append(opts, pulumi.Parent(nsWithLibInjection))...); err != nil {
+		return nil, err
+	}
+	if err = k8sDeploymentWithLibInjection(e, namespaceWithLibInjection, "mutated-with-auto-detected-language", false, append(opts, pulumi.Parent(nsWithLibInjection))...); err != nil {
+		return nil, err
+	}
+
+	return k8sComponent, nil
+}
+func k8sDeploymentWithoutLibInjection(e config.CommonEnvironment, namespace string, name string, opts ...pulumi.ResourceOption) error {
+	_, err := appsv1.NewDeployment(e.Ctx, name, &appsv1.DeploymentArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.String(name),
 			Namespace: pulumi.String(namespace),
-			Labels:    pulumi.StringMap{"app": pulumi.String("mutated")},
+			Labels:    pulumi.StringMap{"app": pulumi.String(name)},
 		},
 		Spec: &appsv1.DeploymentSpecArgs{
 			Replicas: pulumi.Int(1),
 			Selector: &metav1.LabelSelectorArgs{
-				MatchLabels: pulumi.StringMap{"app": pulumi.String("mutated")},
+				MatchLabels: pulumi.StringMap{"app": pulumi.String(name)},
 			},
 			Template: &corev1.PodTemplateSpecArgs{
 				Metadata: &metav1.ObjectMetaArgs{
 					Labels: pulumi.StringMap{
-						"app":                             pulumi.String("mutated"),
+						"app":                             pulumi.String(name),
 						"admission.datadoghq.com/enabled": pulumi.String("true"),
 						"tags.datadoghq.com/env":          pulumi.String("e2e"),
-						"tags.datadoghq.com/service":      pulumi.String("mutated"),
+						"tags.datadoghq.com/service":      pulumi.String(name),
 						"tags.datadoghq.com/version":      pulumi.String("v0.0.1"),
 					},
 				},
 				Spec: &corev1.PodSpecArgs{
 					Containers: corev1.ContainerArray{
 						corev1.ContainerArgs{
-							Name:  pulumi.String("mutated"),
+							Name:  pulumi.String(name),
 							Image: pulumi.String("ghcr.io/datadog/apps-mutated:main"),
 						},
 					},
 				},
 			},
 		},
-	}, opts...); err != nil {
-		return nil, err
+	}, opts...)
+
+	return err
+}
+
+func k8sDeploymentWithLibInjection(e config.CommonEnvironment, namespace string, name string, withLibAnnotation bool, opts ...pulumi.ResourceOption) error {
+	annotations := pulumi.StringMap{}
+	if withLibAnnotation {
+		annotations["admission.datadoghq.com/python-lib.version"] = pulumi.String("v2.7.3")
 	}
 
-	return k8sComponent, nil
+	if _, err := appsv1.NewDeployment(e.Ctx, name, &appsv1.DeploymentArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.String(name),
+			Namespace: pulumi.String(namespace),
+			Labels:    pulumi.StringMap{"app": pulumi.String(name)},
+		},
+		Spec: &appsv1.DeploymentSpecArgs{
+			Replicas: pulumi.Int(1),
+			Selector: &metav1.LabelSelectorArgs{
+				MatchLabels: pulumi.StringMap{"app": pulumi.String(name)},
+			},
+			Template: &corev1.PodTemplateSpecArgs{
+				Metadata: &metav1.ObjectMetaArgs{
+					Labels: pulumi.StringMap{
+						"app":                             pulumi.String(name),
+						"admission.datadoghq.com/enabled": pulumi.String("true"),
+						"tags.datadoghq.com/env":          pulumi.String("e2e"),
+						"tags.datadoghq.com/service":      pulumi.String(name),
+						"tags.datadoghq.com/version":      pulumi.String("v0.0.1"),
+					},
+					Annotations: annotations,
+				},
+				Spec: &corev1.PodSpecArgs{
+					Containers: corev1.ContainerArray{
+						corev1.ContainerArgs{
+							Name: pulumi.String(name),
+							// Python is one of the languages supported by APM lib injection
+							Image: pulumi.String("python:3.12-slim"),
+							Command: pulumi.ToStringArray([]string{
+								"python", "-c", "while True: import time; time.sleep(60)",
+							}),
+						},
+					},
+				},
+			},
+		},
+	}, opts...); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -275,7 +275,7 @@ func Run(ctx *pulumi.Context) error {
 				return err
 			}
 
-			if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-mutated"); err != nil {
+			if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(*awsEnv.CommonEnvironment, eksKubeProvider, "workload-mutated", "workload-mutated-lib-injection"); err != nil {
 				return err
 			}
 		}

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -147,7 +147,7 @@ agents:
 			return err
 		}
 
-		if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(*awsEnv.CommonEnvironment, kindKubeProvider, "workload-mutated"); err != nil {
+		if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(*awsEnv.CommonEnvironment, kindKubeProvider, "workload-mutated", "workload-mutated-lib-injection"); err != nil {
 			return err
 		}
 	}

--- a/scenarios/azure/aks/run.go
+++ b/scenarios/azure/aks/run.go
@@ -114,7 +114,7 @@ providers:
 				return err
 			}
 
-			if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(*env.CommonEnvironment, aksKubeProvider, "workload-mutated"); err != nil {
+			if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(*env.CommonEnvironment, aksKubeProvider, "workload-mutated", "workload-mutated-lib-injection"); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
What does this PR do?
---------------------
This PR configures APM lib injection in a specific namespace. It also creates a couple of deployments in that namespace. One specifies the library in an annotation and the other one doesn't and relies on language detection instead.

