### PR TITLE
[KMT] Ensure docker config folder exists

### DIFF
--- a/scenarios/aws/microVMs/microvms/provision.go
+++ b/scenarios/aws/microVMs/microvms/provision.go
@@ -126,7 +126,7 @@ func setDockerDataRoot(runner *Runner, disks []resources.DomainDisk, namer namer
 		}
 
 		args := command.Args{
-			Create: pulumi.Sprintf("echo -e '{\n\t\"data-root\":\"%s\"\n}' > /etc/docker/daemon.json && sudo systemctl restart docker", d.Mountpoint),
+			Create: pulumi.Sprintf("mkdir -p /etc/docker && echo -e '{\n\t\"data-root\":\"%s\"\n}' > /etc/docker/daemon.json && sudo systemctl restart docker", d.Mountpoint),
 			Sudo:   true,
 		}
 		done, err := runner.Command(namer.ResourceName("set-docker-data-root"), &args, pulumi.DependsOn(depends))


### PR DESCRIPTION
What does this PR do?
---------------------

Ensures that the `/etc/docker` folder exists before trying to write the config file.

Which scenarios this will impact?
-------------------

Only microvms.

Motivation
----------

Fixing errors where the folder not existing caused setup to fail.

Additional Notes
----------------

Validated in pipeline https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/31535952
