### PR TITLE
Increase `ec2_metadata_timeout` to avoid timeouts causing flakiness

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -294,6 +294,10 @@ func buildLinuxHelmValues(installName, agentImagePath, agentImageTag, clusterAge
 			},
 			"token": clusterAgentToken,
 			"env": pulumi.MapArray{
+				pulumi.Map{
+					"name":  pulumi.String("DD_EC2_METADATA_TIMEOUT"),
+					"value": pulumi.String("5000"),
+				},
 				// This option is disabled by default and not exposed in the
 				// Helm chart yet, so we need to set the env.
 				pulumi.Map{


### PR DESCRIPTION
What does this PR do?
---------------------

Increase `ec2_metadata_timeout` cluster-agent setting.

Which scenarios this will impact?
-------------------

* `aws/eks`
* `aws/kindvm`

Motivation
----------

[Some flaky tests are failing because of missing `kube_cluster_name` tag](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/478339793):
```
=== FAIL: tests/containers TestEKSSuite/TestNginx/metric___network.http.response_time{} (120.01s)
    base_test.go:143: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/base_test.go:179
        	            				/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.8.linux-amd64/src/runtime/asm_amd64.s:1650
        	Error:      	Received unexpected error:
        	            	missing tags: ^cluster_name:, ^kube_cluster_name:
        	Messages:   	Tags mismatch on `network.http.response_time{}`
    base_test.go:143: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/base_test.go:143
        	            				/go/pkg/mod/github.com/stretchr/testify@v1.9.0/suite/suite.go:115
        	Error:      	Condition never satisfied
        	Test:       	TestEKSSuite/TestNginx/metric___network.http.response_time{}
        	Messages:   	Failed finding `network.http.response_time{}` with proper tags and value
        --- FAIL: TestEKSSuite/TestNginx/metric___network.http.response_time{} (120.01s)
=== FAIL: tests/containers TestEKSSuite/TestNginx/metric___kubernetes_state.deployment.replicas_available{^kube_deployment:nginx$,^kube_namespace:workload-nginx$} (120.01s)
    base_test.go:143: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/base_test.go:179
        	            				/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.8.linux-amd64/src/runtime/asm_amd64.s:1650
        	Error:      	Received unexpected error:
        	            	missing tags: ^kube_cluster_name:
        	Messages:   	Tags mismatch on `kubernetes_state.deployment.replicas_available{^kube_deployment:nginx$,^kube_namespace:workload-nginx$}`
    base_test.go:143: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/base_test.go:143
        	            				/go/pkg/mod/github.com/stretchr/testify@v1.9.0/suite/suite.go:115
        	Error:      	Condition never satisfied
        	Test:       	TestEKSSuite/TestNginx/metric___kubernetes_state.deployment.replicas_available{^kube_deployment:nginx$,^kube_namespace:workload-nginx$}
        	Messages:   	Failed finding `kubernetes_state.deployment.replicas_available{^kube_deployment:nginx$,^kube_namespace:workload-nginx$}` with proper tags and value
        --- FAIL: TestEKSSuite/TestNginx/metric___kubernetes_state.deployment.replicas_available{^kube_deployment:nginx$,^kube_namespace:workload-nginx$} (120.01s)
=== FAIL: tests/containers TestEKSSuite/TestNginx/hpa___kubernetes_state.deployment.replicas_available{kube_namespace:workload-nginx,kube_deployment:nginx} (1500.04s)
    k8s_test.go:970: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:1016
        	            				/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.8.linux-amd64/src/runtime/asm_amd64.s:1650
        	Error:      	Should be true
        	Messages:   	No scale up detected
    k8s_test.go:970: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:1017
        	            				/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.8.linux-amd64/src/runtime/asm_amd64.s:1650
        	Error:      	Should be true
        	Messages:   	No scale down detected
    k8s_test.go:970: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:970
        	            				/go/pkg/mod/github.com/stretchr/testify@v1.9.0/suite/suite.go:115
        	Error:      	Condition never satisfied
        	Test:       	TestEKSSuite/TestNginx/hpa___kubernetes_state.deployment.replicas_available{kube_namespace:workload-nginx,kube_deployment:nginx}
        	Messages:   	Failed to witness scale up and scale down of workload-nginx.nginx
        --- FAIL: TestEKSSuite/TestNginx/hpa___kubernetes_state.deployment.replicas_available{kube_namespace:workload-nginx,kube_deployment:nginx} (1500.04s)
=== FAIL: tests/containers TestEKSSuite/TestNginx (1812.01s)
    --- FAIL: TestEKSSuite/TestNginx (1812.01s)
=== FAIL: tests/containers TestEKSSuite/TestRedis/metric___kubernetes_state.deployment.replicas_available{^kube_deployment:redis$,^kube_namespace:workload-redis$} (120.01s)
    base_test.go:143: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/base_test.go:179
        	            				/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.8.linux-amd64/src/runtime/asm_amd64.s:1650
        	Error:      	Received unexpected error:
        	            	missing tags: ^kube_cluster_name:
        	Messages:   	Tags mismatch on `kubernetes_state.deployment.replicas_available{^kube_deployment:redis$,^kube_namespace:workload-redis$}`
    base_test.go:143: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/base_test.go:143
        	            				/go/pkg/mod/github.com/stretchr/testify@v1.9.0/suite/suite.go:115
        	Error:      	Condition never satisfied
        	Test:       	TestEKSSuite/TestRedis/metric___kubernetes_state.deployment.replicas_available{^kube_deployment:redis$,^kube_namespace:workload-redis$}
        	Messages:   	Failed finding `kubernetes_state.deployment.replicas_available{^kube_deployment:redis$,^kube_namespace:workload-redis$}` with proper tags and value
        --- FAIL: TestEKSSuite/TestRedis/metric___kubernetes_state.deployment.replicas_available{^kube_deployment:redis$,^kube_namespace:workload-redis$} (120.01s)
=== FAIL: tests/containers TestEKSSuite/TestRedis/hpa___kubernetes_state.deployment.replicas_available{kube_namespace:workload-redis,kube_deployment:redis} (1500.04s)
    k8s_test.go:970: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:1016
        	            				/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.8.linux-amd64/src/runtime/asm_amd64.s:1650
        	Error:      	Should be true
        	Messages:   	No scale up detected
    k8s_test.go:970: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:1017
        	            				/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.21.8.linux-amd64/src/runtime/asm_amd64.s:1650
        	Error:      	Should be true
        	Messages:   	No scale down detected
    k8s_test.go:970: 
        	Error Trace:	/go/src/github.com/DataDog/datadog-agent/test/new-e2e/tests/containers/k8s_test.go:970
        	            				/go/pkg/mod/github.com/stretchr/testify@v1.9.0/suite/suite.go:115
        	Error:      	Condition never satisfied
        	Test:       	TestEKSSuite/TestRedis/hpa___kubernetes_state.deployment.replicas_available{kube_namespace:workload-redis,kube_deployment:redis}
        	Messages:   	Failed to witness scale up and scale down of workload-redis.redis
        --- FAIL: TestEKSSuite/TestRedis/hpa___kubernetes_state.deployment.replicas_available{kube_namespace:workload-redis,kube_deployment:redis} (1500.04s)
```

What we see is that all those tests are failing for the same reason: missing `kube_cluster_name`.
Moreover, it is missing only on the metrics managed by the cluster-agent:
* `network.http.response_time` comes from a [service check managed by the cluster-agent](https://github.com/DataDog/test-infra-definitions/blob/798c711b2ed61998f5843014004633c952ef731e/components/datadog/apps/nginx/k8s.go#L301-L314).
* `kubernetes_state.deployment.replicas_available` is a KSM metric. KSM is a cluster check.

The issue is that the [cluster-agent failed to get the cluster name](https://dddev.datadoghq.com/logs?query=host%3Ai-0f8e6a5e67b0497a6%20service%3Acluster-agent%20container_id%3A1f085d5663526041923f04dacfca9db779ce15126599a2d3f157366c8c98c51f%20filename%3A0.log%20&cols=host%2Cservice&context_event=AY6qBZoiAADhidT-O3rDUgDz&event=AgAAAY6qA3iQAbK3tQAAAAAAAAAYAAAAAEFZNnFCWm9pQUFEaGlkVC1PM3JEVWdEegAAACQAAAAAMDE4ZWFhMDYtOWQ0MC00MDY0LWE3MjQtNDg0YWZlMDdhYTYw&index=%2A&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&to_event=AgAAAY6qA3iQAbK3vQAAAAAAAAAYAAAAAEFZNnFCWm9pQUFEaGlkVC1PM3JEVWdENwAAACQAAAAAMDE4ZWFhMDYtOWQ0MC00MDY0LWE3MjQtNDg0YWZlMDdhYTYw&viz=&from_ts=1712249038000&to_ts=1712249338001&live=false):
```
2024-04-04 16:48:58 UTC | CLUSTER | WARN | (subcommands/start/command.go:333 in start) | Failed to auto-detect a Kubernetes cluster name. We recommend you set it manually via the cluster_name config option
```

Because [it timed-out while fetching the EC2 tags](https://dddev.datadoghq.com/logs?query=host%3Ai-0f8e6a5e67b0497a6%20service%3Acluster-agent%20container_id%3A1f085d5663526041923f04dacfca9db779ce15126599a2d3f157366c8c98c51f%20filename%3A0.log%20&cols=host%2Cservice&context_event=AY6qBZoiAADhidT-O3rDUgDz&event=AgAAAY6qA2zYAbK3nAAAAAAAAAAYAAAAAEFZNnFCWm9pQUFEaGlkVC1PM3JEVWdEYQAAACQAAAAAMDE4ZWFhMDYtOWQ0MC00MDY0LWE3MjQtNDg0YWZlMDdhYTYw&index=%2A&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&to_event=AgAAAY6qA3iQAbK3vQAAAAAAAAAYAAAAAEFZNnFCWm9pQUFEaGlkVC1PM3JEVWdENwAAACQAAAAAMDE4ZWFhMDYtOWQ0MC00MDY0LWE3MjQtNDg0YWZlMDdhYTYw&viz=&from_ts=1712249038000&to_ts=1712249338001&live=false):
```
2024-04-04 16:48:55 UTC | CLUSTER | WARN | (pkg/util/ec2/ec2_tags.go:104 in fetchEc2TagsFromAPI) | unable to get tags using default credentials (falling back to instance role): operation error EC2: DescribeTags, https response error StatusCode: 0, RequestID: , canceled, context deadline exceeded
```

This time-out comes from https://github.com/DataDog/datadog-agent/blob/2b23f6f95253912e3338f325f831990b71f07577/pkg/util/ec2/ec2_tags.go#L126

Additional Notes
----------------
