### PR TITLE
Increase `ec2_metadata_timeout` to avoid timeouts causing flakiness

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -254,6 +254,12 @@ func buildLinuxHelmValues(installName, agentImagePath, agentImageTag, clusterAge
 					},
 				})),
 			},
+			"env": pulumi.MapArray{
+				pulumi.Map{
+					"name":  pulumi.String("DD_EC2_METADATA_TIMEOUT"),
+					"value": pulumi.String("5000"), // Unit is ms
+				},
+			},
 		},
 		"agents": pulumi.Map{
 			"image": pulumi.Map{


### PR DESCRIPTION
What does this PR do?
---------------------

Increase the `ec2_metadata_timeout` agents setting.

Which scenarios this will impact?
-------------------

* `aws/eks`
* `aws/kindvm`

Motivation
----------

[Some flaky tests are still failing because of missing `kube_cluster_name` tag](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/479757337).
This is follow-up of #741 which attempted to fix the issue for the cluster-agent.
But it seems that [the node agents experience the same issue](https://dddev.datadoghq.com/logs?query=host%3Ai-06bc4e6e7a15a1247%20service%3Aagent%20container_id%3A8017478f98eb20da7ffdbc5dd3285c72f5f1146b60790e11c38f16decf0fd733%20filename%3A0.log%20&agg_q=host&agg_q_source=base&cols=matches%2Cvolume%2Ccontainer_name%2Cmessage&context_event=AY6v2j-MAACBcC4e9nUYQgAN&event=AgAAAY6v2fpQcTT7jQAAAAAAAAAYAAAAAEFZNnYyai1NQUFDQmNDNGU5blVZUWdBTAAAACQAAAAAMDE4ZWFmZTMtMzIxNi00ZmVkLTg3NjctMTY5MDlmMGYzMGJk&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=paused&sort_m=&sort_m_source=&sort_t=&storage=hot&stream_sort=time%2Cdesc&to_event=AgAAAY6v2fpQcTT7lwAAAAAAAAAYAAAAAEFZNnYyai1NQUFDQmNDNGU5blVZUWdBVgAAACQAAAAAMDE4ZWFmZTMtMzIxNi00ZmVkLTg3NjctMTY5MDlmMGYzMGJk&top_n=10&top_o=top&viz=&x_missing=true&from_ts=1712346982000&to_ts=1712347282001&live=false):
```
2024-04-05 20:01:22 UTC | CORE | WARN | (pkg/util/ec2/ec2_tags.go:104 in fetchEc2TagsFromAPI) | unable to get tags using default credentials (falling back to instance role): operation error EC2: DescribeTags, https response error StatusCode: 0, RequestID: , canceled, context deadline exceeded
```


Additional Notes
----------------
