### PR TITLE
fix u00a0

### DIFF
--- a/components/datadog/updater/install_script.sh
+++ b/components/datadog/updater/install_script.sh
@@ -115,6 +115,6 @@ elif [ "${OS}" = "RedHat" ]; then
     done
     $sudo_cmd sh -c "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://${yum_url}/${yum_repo_version}/${ARCH}/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\npriority=1\ngpgkey=${gpgkeys}' > /etc/yum.repos.d/datadog.repo"
     $sudo_cmd yum -y clean metadata
-    $sudo_cmd yum -y install datadog-updater || $sudo_cmd yum -y install datadog-installer
+    $sudo_cmd yum -y install datadog-updater || $sudo_cmd yum -y install datadog-installer
 fi
 


### PR DESCRIPTION
wrote a `\u00a0` instead of a space

When we renamed `datadog-updater` to `datadog-installer` test started failing with this error:
previously installation would fail on:     suite_utils.go:19:     bash: -c: option requires an argument

tested by running
```
invoke create-vm -i -o=centos --install-updater --pipeline-id=31677543 --no-verify
```
