### PR TITLE
rename installer repos pattern from u7 to i7

### DIFF
--- a/components/datadog/updater/install_script.sh
+++ b/components/datadog/updater/install_script.sh
@@ -50,12 +50,12 @@ if [ "${ARCH}" = "aarch64" ]; then
 fi
 
 apt_url="apttesting.datad0g.com"
-apt_repo_version="${DD_PIPELINE_ID}-u7-${ARCH} 7"
+apt_repo_version="${DD_PIPELINE_ID}-i7-${ARCH} 7"
 apt_usr_share_keyring="/usr/share/keyrings/datadog-archive-keyring.gpg"
 apt_trusted_d_keyring="/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg"
 
 yum_url="yumtesting.datad0g.com/testing"
-yum_repo_version="${DD_PIPELINE_ID}-u7/7"
+yum_repo_version="${DD_PIPELINE_ID}-i7/7"
 
 DD_APT_INSTALL_ERROR_MSG=/tmp/ddog_install_error_msg
 MAX_RETRY_NB=10


### PR DESCRIPTION
What does this PR do?
---------------------

Renames the `u7` pattern from updater repo to `i7` since we're renaming to tool `installer`

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
