### PR TITLE
Fix varying VMs over vcpu and memory

### DIFF
--- a/scenarios/aws/microVMs/microvms/domain.go
+++ b/scenarios/aws/microVMs/microvms/domain.go
@@ -241,7 +241,9 @@ func GenerateDomainConfigurationsForVMSet(e *config.CommonEnvironment, providerF
 						depends,
 						vol.Key(),
 						vol.Pool().Name(),
-						vol.FullResourceName("final-overlay", kernel.Tag),
+						// adding the full domain ID causes the length of the resource name
+						// to go beyond the maximum size allowed by pulumi.
+						vol.FullResourceName("overlay", kernel.Tag, vcpu, memory),
 					)
 					if err != nil {
 						return []*Domain{}, 0, err

--- a/scenarios/aws/microVMs/microvms/domain.go
+++ b/scenarios/aws/microVMs/microvms/domain.go
@@ -243,7 +243,7 @@ func GenerateDomainConfigurationsForVMSet(e *config.CommonEnvironment, providerF
 						vol.Pool().Name(),
 						// adding the full domain ID causes the length of the resource name
 						// to go beyond the maximum size allowed by pulumi.
-						vol.FullResourceName("overlay", kernel.Tag, vcpu, memory),
+						vol.FullResourceName("overlay", kernel.Tag, fmt.Sprintf("%d-%d", vcpu, memory)),
 					)
 					if err != nil {
 						return []*Domain{}, 0, err


### PR DESCRIPTION
What does this PR do?
---------------------
This PR adds vcpu and memory configured for a VM to the resource generating its volume overlay. This allows us to create multiple versions of the same VM varying either the vcpu or memory.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
