### PR TITLE
installer: fix suse repo url

### DIFF
--- a/components/datadog/updater/install_script.sh
+++ b/components/datadog/updater/install_script.sh
@@ -54,7 +54,11 @@ apt_repo_version="${DD_PIPELINE_ID}-i7-${ARCH} 7"
 apt_usr_share_keyring="/usr/share/keyrings/datadog-archive-keyring.gpg"
 apt_trusted_d_keyring="/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg"
 
-yum_url="yumtesting.datad0g.com/testing"
+if [ "${OS}" = "SUSE" ]; then
+    yum_url="yumtesting.datad0g.com/suse/testing"
+else
+    yum_url="yumtesting.datad0g.com/testing"
+fi
 yum_repo_version="${DD_PIPELINE_ID}-i7/7"
 
 DD_APT_INSTALL_ERROR_MSG=/tmp/ddog_install_error_msg


### PR DESCRIPTION
What does this PR do?
---------------------

Handles the SUSE specific repo URL

Which scenarios this will impact?
-------------------

All installer tests running on SUSE

Motivation
----------

Additional Notes
----------------
