### PR TITLE
Add WithFileWithPermissions to create files with predefined permissions

### DIFF
--- a/components/datadog/agent/host.go
+++ b/components/datadog/agent/host.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/DataDog/datadog-agent/pkg/util/optional"
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/namer"
 	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/components"
 	"github.com/DataDog/test-infra-definitions/components/command"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
+	perms "github.com/DataDog/test-infra-definitions/components/datadog/agentparams/filepermissions"
 	remoteComp "github.com/DataDog/test-infra-definitions/components/remote"
 
 	"github.com/pulumi/pulumi-command/sdk/go/command/remote"
@@ -200,7 +202,7 @@ func (h *HostAgent) installIntegrationConfigsAndFiles(
 		configFolder := h.manager.getAgentConfigFolder()
 		fullPath := path.Join(configFolder, filePath)
 
-		cmd, err := h.writeFileDefinition(fullPath, fileDef.Content, fileDef.UseSudo, opts...)
+		cmd, err := h.writeFileDefinition(fullPath, fileDef.Content, fileDef.UseSudo, fileDef.Permissions, opts...)
 		if err != nil {
 			return nil, "", err
 		}
@@ -212,7 +214,7 @@ func (h *HostAgent) installIntegrationConfigsAndFiles(
 			return nil, "", fmt.Errorf("failed to write file: \"%s\" is not an absolute filepath", fullPath)
 		}
 
-		cmd, err := h.writeFileDefinition(fullPath, fileDef.Content, fileDef.UseSudo, opts...)
+		cmd, err := h.writeFileDefinition(fullPath, fileDef.Content, fileDef.UseSudo, fileDef.Permissions, opts...)
 		if err != nil {
 			return nil, "", err
 		}
@@ -226,6 +228,7 @@ func (h *HostAgent) writeFileDefinition(
 	fullPath string,
 	content string,
 	useSudo bool,
+	perms optional.Option[perms.FilePermissions],
 	opts ...pulumi.ResourceOption,
 ) (*remote.Command, error) {
 	// create directory, if it does not exist
@@ -238,5 +241,20 @@ func (h *HostAgent) writeFileDefinition(
 	if err != nil {
 		return nil, err
 	}
+
+	// Set permissions if any
+	if value, found := perms.Get(); found {
+		if cmd := value.SetupPermissionsCommand(fullPath); cmd != "" {
+			return h.host.OS.Runner().Command(
+				h.namer.ResourceName("set-permissions-"+fullPath, utils.StrHash(cmd)),
+				&command.Args{
+					Create: pulumi.String(cmd),
+					Delete: pulumi.String(value.ResetPermissionsCommand(fullPath)),
+					Update: pulumi.String(value.ResetPermissionsCommand(fullPath)),
+				},
+				utils.PulumiDependsOn(copyCmd))
+		}
+	}
+
 	return copyCmd, nil
 }

--- a/components/datadog/agentparams/filepermissions/permissions.go
+++ b/components/datadog/agentparams/filepermissions/permissions.go
@@ -1,0 +1,8 @@
+package filepermissions
+
+// FilePermissions interface defines all commands that can be used to set and reset file permissions.
+// These functions are used to create args.Command that will be run by pulumi.
+type FilePermissions interface {
+	SetupPermissionsCommand(path string) string
+	ResetPermissionsCommand(path string) string
+}

--- a/components/datadog/agentparams/filepermissions/permissions_nix.go
+++ b/components/datadog/agentparams/filepermissions/permissions_nix.go
@@ -1,0 +1,82 @@
+package filepermissions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/util/optional"
+	"github.com/DataDog/test-infra-definitions/common"
+)
+
+type UnixPermissionsOption = func(*UnixPermissions) error
+
+// UnixPermissions represents the owner, group, and permissions of a file.
+// Permissions are represented by a string (should be an octal). There is no check on the octal format.
+type UnixPermissions struct {
+	Owner       string
+	Group       string
+	Permissions string
+}
+
+var _ FilePermissions = (*UnixPermissions)(nil)
+
+// NewUnixPermissions creates a new UnixPermissions object and applies the given options.
+func NewUnixPermissions(options ...UnixPermissionsOption) optional.Option[FilePermissions] {
+	p, err := common.ApplyOption(&UnixPermissions{}, options)
+
+	if err != nil {
+		return optional.NewNoneOption[FilePermissions]()
+	}
+	return optional.NewOption[FilePermissions](p)
+}
+
+// SetupPermissionsCommand returns a command that sets the owner, group, and permissions of a file.
+func (p *UnixPermissions) SetupPermissionsCommand(path string) string {
+	var commands []string
+
+	if p.Owner != "" {
+		commands = append(commands, fmt.Sprintf("chown %s %s", p.Owner, path))
+	}
+
+	if p.Group != "" {
+		commands = append(commands, fmt.Sprintf("chgrp %s %s", p.Group, path))
+	}
+
+	if p.Permissions != "" {
+		commands = append(commands, fmt.Sprintf("chmod %s %s", p.Permissions, path))
+	}
+
+	if len(commands) == 0 {
+		return ""
+	}
+	return fmt.Sprintf(`sudo sh -c "%v"`, strings.Join(commands, " && "))
+}
+
+// ResetPermissionsCommand returns a command that resets the owner, group, and permissions of a file to default.
+func (p *UnixPermissions) ResetPermissionsCommand(path string) string {
+	return fmt.Sprintf("sudo chown ubuntu:ubuntu %s && sudo chmod 644 %s", path, path)
+}
+
+// WithOwner sets the owner of the file.
+func WithOwner(owner string) UnixPermissionsOption {
+	return func(p *UnixPermissions) error {
+		p.Owner = owner
+		return nil
+	}
+}
+
+// WithGroup sets the group of the file.
+func WithGroup(group string) UnixPermissionsOption {
+	return func(p *UnixPermissions) error {
+		p.Group = group
+		return nil
+	}
+}
+
+// WithPermissions sets the permissions of the file.
+func WithPermissions(permissions string) UnixPermissionsOption {
+	return func(p *UnixPermissions) error {
+		p.Permissions = permissions
+		return nil
+	}
+}

--- a/components/datadog/agentparams/filepermissions/permissions_nix.go
+++ b/components/datadog/agentparams/filepermissions/permissions_nix.go
@@ -25,7 +25,7 @@ func NewUnixPermissions(options ...UnixPermissionsOption) optional.Option[FilePe
 	p, err := common.ApplyOption(&UnixPermissions{}, options)
 
 	if err != nil {
-		return optional.NewNoneOption[FilePermissions]()
+		panic("Could not create UnixPermissions: " + err.Error())
 	}
 	return optional.NewOption[FilePermissions](p)
 }

--- a/components/datadog/agentparams/filepermissions/permissions_nix.go
+++ b/components/datadog/agentparams/filepermissions/permissions_nix.go
@@ -49,7 +49,7 @@ func (p *UnixPermissions) SetupPermissionsCommand(path string) string {
 	if len(commands) == 0 {
 		return ""
 	}
-	return fmt.Sprintf(`sudo sh -c "%v"`, strings.Join(commands, " && "))
+	return strings.Join(commands, " && ")
 }
 
 // ResetPermissionsCommand returns a command that resets the owner, group, and permissions of a file to default.

--- a/components/datadog/agentparams/filepermissions/permissions_nix.go
+++ b/components/datadog/agentparams/filepermissions/permissions_nix.go
@@ -35,15 +35,15 @@ func (p *UnixPermissions) SetupPermissionsCommand(path string) string {
 	var commands []string
 
 	if p.Owner != "" {
-		commands = append(commands, fmt.Sprintf("chown %s %s", p.Owner, path))
+		commands = append(commands, fmt.Sprintf("sudo chown %s %s", p.Owner, path))
 	}
 
 	if p.Group != "" {
-		commands = append(commands, fmt.Sprintf("chgrp %s %s", p.Group, path))
+		commands = append(commands, fmt.Sprintf("sudo chgrp %s %s", p.Group, path))
 	}
 
 	if p.Permissions != "" {
-		commands = append(commands, fmt.Sprintf("chmod %s %s", p.Permissions, path))
+		commands = append(commands, fmt.Sprintf("sudo chmod %s %s", p.Permissions, path))
 	}
 
 	if len(commands) == 0 {
@@ -54,7 +54,7 @@ func (p *UnixPermissions) SetupPermissionsCommand(path string) string {
 
 // ResetPermissionsCommand returns a command that resets the owner, group, and permissions of a file to default.
 func (p *UnixPermissions) ResetPermissionsCommand(path string) string {
-	return fmt.Sprintf("sudo chown ubuntu:ubuntu %s && sudo chmod 644 %s", path, path)
+	return fmt.Sprintf("sudo chown $USER %s && sudo chmod 644 %s", path, path)
 }
 
 // WithOwner sets the owner of the file.

--- a/components/datadog/agentparams/filepermissions/permissions_nix.go
+++ b/components/datadog/agentparams/filepermissions/permissions_nix.go
@@ -54,7 +54,7 @@ func (p *UnixPermissions) SetupPermissionsCommand(path string) string {
 
 // ResetPermissionsCommand returns a command that resets the owner, group, and permissions of a file to default.
 func (p *UnixPermissions) ResetPermissionsCommand(path string) string {
-	return fmt.Sprintf("sudo chown $USER %s && sudo chmod 644 %s", path, path)
+	return fmt.Sprintf("sudo chown $USER:$(id -gn) %s && sudo chmod 644 %s", path, path)
 }
 
 // WithOwner sets the owner of the file.

--- a/components/datadog/agentparams/filepermissions/permissions_nix.go
+++ b/components/datadog/agentparams/filepermissions/permissions_nix.go
@@ -35,15 +35,15 @@ func (p *UnixPermissions) SetupPermissionsCommand(path string) string {
 	var commands []string
 
 	if p.Owner != "" {
-		commands = append(commands, fmt.Sprintf("sudo chown %s %s", p.Owner, path))
+		commands = append(commands, fmt.Sprintf(`sudo chown "%s" "%s"`, p.Owner, path))
 	}
 
 	if p.Group != "" {
-		commands = append(commands, fmt.Sprintf("sudo chgrp %s %s", p.Group, path))
+		commands = append(commands, fmt.Sprintf(`sudo chgrp "%s" "%s"`, p.Group, path))
 	}
 
 	if p.Permissions != "" {
-		commands = append(commands, fmt.Sprintf("sudo chmod %s %s", p.Permissions, path))
+		commands = append(commands, fmt.Sprintf(`sudo chmod "%s" "%s"`, p.Permissions, path))
 	}
 
 	if len(commands) == 0 {
@@ -54,7 +54,7 @@ func (p *UnixPermissions) SetupPermissionsCommand(path string) string {
 
 // ResetPermissionsCommand returns a command that resets the owner, group, and permissions of a file to default.
 func (p *UnixPermissions) ResetPermissionsCommand(path string) string {
-	return fmt.Sprintf("sudo chown $USER:$(id -gn) %s && sudo chmod 644 %s", path, path)
+	return fmt.Sprintf(`sudo chown "$USER:$(id -gn)" "%s" && sudo chmod 644 "%s"`, path, path)
 }
 
 // WithOwner sets the owner of the file.

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -5,9 +5,11 @@ import (
 	"path"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/util/optional"
 	"github.com/DataDog/test-infra-definitions/common"
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	perms "github.com/DataDog/test-infra-definitions/components/datadog/agentparams/filepermissions"
 	"github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -36,8 +38,9 @@ import (
 // [Functional options pattern]: https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
 
 type FileDefinition struct {
-	Content string
-	UseSudo bool
+	Content     string
+	UseSudo     bool
+	Permissions optional.Option[perms.FilePermissions]
 }
 
 type Params struct {
@@ -175,10 +178,16 @@ func WithIntegration(folderName string, content string) func(*Params) error {
 
 // WithFile adds a file with contents to the install at the given path. This should only be used when the agent needs to be restarted after writing the file.
 func WithFile(absolutePath string, content string, useSudo bool) func(*Params) error {
+	return WithFileWithPermissions(absolutePath, content, useSudo, optional.NewNoneOption[perms.FilePermissions]())
+}
+
+// WithFileWithPermissions adds a file like WithFile but we can predefine the permissions of the file.
+func WithFileWithPermissions(absolutePath string, content string, useSudo bool, perms optional.Option[perms.FilePermissions]) func(*Params) error {
 	return func(p *Params) error {
 		p.Files[absolutePath] = &FileDefinition{
-			Content: content,
-			UseSudo: useSudo,
+			Content:     content,
+			UseSudo:     useSudo,
+			Permissions: perms,
 		}
 		return nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 
 require (
 	dario.cat/mergo v1.0.0 // indirect
+	github.com/DataDog/datadog-agent/pkg/util/optional v0.52.1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/DataDog/test-infra-definitions
 go 1.21
 
 require (
+	github.com/DataDog/datadog-agent/pkg/util/optional v0.52.1
 	github.com/Masterminds/semver v1.5.0
 	github.com/alessio/shellescape v1.4.2
 	github.com/aws/aws-sdk-go-v2 v1.25.2
@@ -34,7 +35,6 @@ require (
 
 require (
 	dario.cat/mergo v1.0.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/util/optional v0.52.1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
 	github.com/aead/chacha20 v0.0.0-20180709150244-8b13a72661da // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+github.com/DataDog/datadog-agent/pkg/util/optional v0.52.1 h1:mQQ54mKj9E3hVFppFFedxo9UTZcSzxqvpiphU3Nvwa8=
+github.com/DataDog/datadog-agent/pkg/util/optional v0.52.1/go.mod h1:th8Bo5fv4Kxe+GVS5LvPT4J5p/y0asz4WysHK2G+lRM=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=


### PR DESCRIPTION
What does this PR do?
---------------------

Add a way to specify permissions when creating a file. Only on Unix for now but will follow up for Windows permissions 

Example PR: https://github.com/DataDog/datadog-agent/pull/24723

Which scenarios this will impact?
-------------------

Any scenarios that needs to set specific permissions to a file. 

Motivation
----------

Currently to test secret feature, we need to do the following:

1. UpdateEnv without the Agent config
2. Give permissions to the secret script
3. UpdateEnv with the Agent config

In the first UpdateEnv, we can add the secret script file but we cannot give it the right permissions. So if we set `secret_backend_command` directly the Agent won't be able to start and the first UpdateEnv will fail.

Additional Notes
----------------
