### PR TITLE
updater: fix zypper non-interactive mode arguments

### DIFF
--- a/components/datadog/updater/install_script.sh
+++ b/components/datadog/updater/install_script.sh
@@ -104,7 +104,7 @@ elif [ "${OS}" = "SUSE" ]; then
         gpgkeys="${gpgkeys:+"${gpgkeys}${separator}"}https://${keys_url}/${key_path}"
     done
     $sudo_cmd sh -c "echo -e '[datadog]\nname = Datadog, Inc.\nbaseurl = https://${yum_url}/${yum_repo_version}/${ARCH}/\nenabled=1\ngpgcheck=1\nrepo_gpgcheck=1\npriority=1\ngpgkey=${gpgkeys}' > /etc/zypp/repos.d/datadog.repo"
-    $sudo_cmd zypper -y refresh
-    $sudo_cmd zypper -y install datadog-installer
+    $sudo_cmd zypper -n refresh
+    $sudo_cmd zypper -n install datadog-installer
 fi
 


### PR DESCRIPTION
-y is only available in rug compatibility mode, which we don't enable. Switch to '-n' for '--non-interactive' which is always available

What does this PR do?
---------------------

Fix an incorrect change introduced in #765 

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
