### PR TITLE
[host] retry cloud-init on failure

### DIFF
--- a/components/command/utils.go
+++ b/components/command/utils.go
@@ -12,7 +12,8 @@ func WaitForCloudInit(runner *Runner) (*remote.Command, error) {
 		"wait-cloud-init",
 		&Args{
 			// `sudo` is required for amazon linux
-			Create: pulumi.String("cloud-init status --wait"),
+			// retry 5 times with exponential backoff as cloud-init may take some time to initialize
+			Create: pulumi.String("for i in 1 2 3 4 5; do cloud-init status --wait && break || sleep $((2**$i)); done"),
 			Sudo:   true,
 		})
 }


### PR DESCRIPTION
What does this PR do?
---------------------

Wrap `cloud-init status --wait` in 5 retries loop

Which scenarios this will impact?
-------------------

linux host

Motivation
----------

`cloud-init` is failing transiently, [here are failures over the past month](https://app.datadoghq.com/logs?query=%22FileNotFoundError%3A%20%5BErrno%202%5D%20No%20such%20file%20or%20directory%3A%20%27%2Frun%2Fcloud-init%2Fstatus.json%27%22%20service%3A%28gitlab-runner%29%20&cols=host%2Cservice&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=timeseries&from_ts=1710673578745&to_ts=1713265578745&live=true):
 
![image](https://github.com/DataDog/test-infra-definitions/assets/45568537/df76c8db-142d-4104-8433-07e297b1987f)
It should wait for init to complete, adding retries to see if it is enough. 

What is weird is that we correctly ssh into the host, so the cloud init is supposedly successful 

Additional Notes
----------------
