### PR TITLE
Stop silencing restart-service errors

### DIFF
--- a/components/datadog/agent/host_windowsos.go
+++ b/components/datadog/agent/host_windowsos.go
@@ -80,8 +80,13 @@ func (am *agentWindowsManager) getAgentConfigFolder() string {
 func (am *agentWindowsManager) restartAgentServices(transform command.Transformer, opts ...pulumi.ResourceOption) (*remote.Command, error) {
 	// TODO: When we introduce Namer in components, we should use it here.
 	cmdName := am.host.Name() + "-" + "restart-agent"
+	restartCmd := `
+$exitCode = (Start-Process "$($env:ProgramFiles)\Datadog\Datadog Agent\bin\agent.exe" -Wait -PassThru -RedirectStandardError stderr.txt -ArgumentList restart-service)
+Get-Content stderr.txt
+Exit $exitCode
+`
 	cmdArgs := command.Args{
-		Create: pulumi.String(`Start-Process "$($env:ProgramFiles)\Datadog\Datadog Agent\bin\agent.exe" -Wait -ArgumentList restart-service`),
+		Create: pulumi.String(restartCmd),
 	}
 
 	// If a transform is provided, use it to modify the command name and args

--- a/components/datadog/agent/host_windowsos.go
+++ b/components/datadog/agent/host_windowsos.go
@@ -81,9 +81,8 @@ func (am *agentWindowsManager) restartAgentServices(transform command.Transforme
 	// TODO: When we introduce Namer in components, we should use it here.
 	cmdName := am.host.Name() + "-" + "restart-agent"
 	restartCmd := `
-$exitCode = (Start-Process "$($env:ProgramFiles)\Datadog\Datadog Agent\bin\agent.exe" -Wait -PassThru -RedirectStandardError stderr.txt -ArgumentList restart-service)
+$exitCode = (Start-Process "$($env:ProgramFiles)\Datadog\Datadog Agent\bin\agent.exe" -Wait -PassThru -RedirectStandardError stderr.txt -ArgumentList restart-service).ExitCode
 Get-Content stderr.txt
-Exit $exitCode
 `
 	cmdArgs := command.Args{
 		Create: pulumi.String(restartCmd),


### PR DESCRIPTION
What does this PR do?
---------------------

Catch failure on `agent.exe restart-service` command. Without that `Start-Process` will always exit with a 0 code. And pulumi will never fail, even if it failed to restart the services

Note: It may create new failures in tests while previously the test would succeed even if the restart-service did not. But I think we want to make sure the agent is properly restarted when it should

Which scenarios this will impact?
-------------------

Windows scenarios

Motivation
----------

Additional Notes
----------------
