### PR TITLE
Use restart-service powershell command to restart the agent

### DIFF
--- a/components/datadog/agent/host_windowsos.go
+++ b/components/datadog/agent/host_windowsos.go
@@ -81,7 +81,7 @@ func (am *agentWindowsManager) restartAgentServices(transform command.Transforme
 	// TODO: When we introduce Namer in components, we should use it here.
 	cmdName := am.host.Name() + "-" + "restart-agent"
 	cmdArgs := command.Args{
-		Create: pulumi.String(`Start-Process "$($env:ProgramFiles)\Datadog\Datadog Agent\bin\agent.exe" -Wait -ArgumentList restart-service`),
+		Create: pulumi.String(`Restart-Service datadogagent -Force`),
 	}
 
 	// If a transform is provided, use it to modify the command name and args


### PR DESCRIPTION
What does this PR do?
---------------------
Use `Restart-Service` from powershell instead of `restart-services` from agent.exe
The `restart-services` is known to be impacted by race conditions

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
