### PR TITLE
[kind] mount host proc into kind node

### DIFF
--- a/components/kubernetes/kind-cluster.yaml
+++ b/components/kubernetes/kind-cluster.yaml
@@ -2,6 +2,9 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
+  extraMounts:
+  - hostPath: /proc
+    containerPath: /host/proc
 containerdConfigPatches:
   - |-
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]


### PR DESCRIPTION
What does this PR do?
---------------------
The system-probe container needs access to the host's `proc` filesystem for some modules to work properly (CWS).
This PR updates the kind node configuration to mount the host `/proc` into the container so that it can be further propagated to the system-probe container.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
