### PR TITLE
Add WindowsPermissions structure that can be used with WithFileWithPermissions

### DIFF
--- a/components/datadog/agentparams/filepermissions/permissions_win.go
+++ b/components/datadog/agentparams/filepermissions/permissions_win.go
@@ -11,7 +11,10 @@ type WindowsPermissionsOption = func(*WindowsPermissions) error
 
 // WindowsPermissions contains the information to configure the permissions of a file on Windows.
 type WindowsPermissions struct {
-	// If you are familiar with the icacls command, you can provide a custom command directly. This has precedence over any other option.
+	// RemoveDefaultPermissions removes the default permissions from the file. This is useful when you want to set permissions for secrets management.
+	RemoveDefaultPermissions bool
+
+	// If you are familiar with the icacls command, you can provide a custom command directly.
 	IcaclsCommand string
 }
 
@@ -29,10 +32,14 @@ func NewWindowsPermissions(options ...WindowsPermissionsOption) optional.Option[
 
 // SetupPermissionsCommand returns a command that sets the permissions of a file. It relies on the icacls command.
 func (p *WindowsPermissions) SetupPermissionsCommand(path string) string {
-	if p.IcaclsCommand != "" {
-		return fmt.Sprintf("icacls “%v” %v", path, p.IcaclsCommand)
+	cmd := ""
+	if p.RemoveDefaultPermissions {
+		cmd = fmt.Sprintf(`icacls "%v" /remove (Get-LocalUser) "Everyone" "Users" "Administrators" "SYSTEM" "Authenticated Users" "CREATOR OWNER" /inheritance:r /t /c /l;`, path)
 	}
-	return ""
+	if p.IcaclsCommand != "" {
+		return fmt.Sprintf(`%v icacls "%v" %v`, cmd, path, p.IcaclsCommand)
+	}
+	return cmd
 }
 
 // ResetPermissionsCommand returns a command that resets the owner, group, and permissions of a file to default.
@@ -40,10 +47,18 @@ func (p *WindowsPermissions) ResetPermissionsCommand(path string) string {
 	return fmt.Sprintf("icacls “%v” /reset /t /c /l", path)
 }
 
-// WithIcaclsCommand sets the icacls command to use. This has precedence over any other option.
+// WithIcaclsCommand sets the icacls command to use.
 func WithIcaclsCommand(command string) WindowsPermissionsOption {
 	return func(p *WindowsPermissions) error {
 		p.IcaclsCommand = command
+		return nil
+	}
+}
+
+// WithRemoveDefaultPermissions removes the default permissions from the file.
+func WithRemoveDefaultPermissions() WindowsPermissionsOption {
+	return func(p *WindowsPermissions) error {
+		p.RemoveDefaultPermissions = true
 		return nil
 	}
 }

--- a/components/datadog/agentparams/filepermissions/permissions_win.go
+++ b/components/datadog/agentparams/filepermissions/permissions_win.go
@@ -1,0 +1,49 @@
+package filepermissions
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/util/optional"
+	"github.com/DataDog/test-infra-definitions/common"
+)
+
+type WindowsPermissionsOption = func(*WindowsPermissions) error
+
+// WindowsPermissions contains the information to configure the permissions of a file on Windows.
+type WindowsPermissions struct {
+	// If you are familiar with the icacls command, you can provide a custom command directly. This has precedence over any other option.
+	IcaclsCommand string
+}
+
+var _ FilePermissions = (*WindowsPermissions)(nil)
+
+// NewWindowsPermissions creates a new WindowsPermissions object and applies the given options.
+func NewWindowsPermissions(options ...WindowsPermissionsOption) optional.Option[FilePermissions] {
+	p, err := common.ApplyOption(&WindowsPermissions{}, options)
+
+	if err != nil {
+		panic("Could not create WindowsPermissions: " + err.Error())
+	}
+	return optional.NewOption[FilePermissions](p)
+}
+
+// SetupPermissionsCommand returns a command that sets the permissions of a file. It relies on the icacls command.
+func (p *WindowsPermissions) SetupPermissionsCommand(path string) string {
+	if p.IcaclsCommand != "" {
+		return fmt.Sprintf("icacls “%v” %v", path, p.IcaclsCommand)
+	}
+	return ""
+}
+
+// ResetPermissionsCommand returns a command that resets the owner, group, and permissions of a file to default.
+func (p *WindowsPermissions) ResetPermissionsCommand(path string) string {
+	return fmt.Sprintf("icacls “%v” /reset /t /c /l", path)
+}
+
+// WithIcaclsCommand sets the icacls command to use. This has precedence over any other option.
+func WithIcaclsCommand(command string) WindowsPermissionsOption {
+	return func(p *WindowsPermissions) error {
+		p.IcaclsCommand = command
+		return nil
+	}
+}

--- a/components/datadog/agentparams/filepermissions/permissions_win.go
+++ b/components/datadog/agentparams/filepermissions/permissions_win.go
@@ -44,7 +44,7 @@ func (p *WindowsPermissions) SetupPermissionsCommand(path string) string {
 
 // ResetPermissionsCommand returns a command that resets the owner, group, and permissions of a file to default.
 func (p *WindowsPermissions) ResetPermissionsCommand(path string) string {
-	return fmt.Sprintf("icacls “%[1]v” /inheritance:e /t /c /l; icacls “%[1]v” /reset /t /c /l;", path)
+	return fmt.Sprintf("icacls “%v” /reset /t /c /l;", path)
 }
 
 // WithIcaclsCommand sets the icacls command to use.


### PR DESCRIPTION
Equivalent of https://github.com/DataDog/test-infra-definitions/pull/762 for Windows

Which scenarios this will impact?
-------------------

Any scenarios that needs to set specific permissions to a file. See [usage example](https://github.com/DataDog/datadog-agent/pull/24829/files)

Motivation
----------
ASCII-1491
Currently to test secret feature, we need to do the following:

1. UpdateEnv without the Agent config
2. Give permissions to the secret script
3. UpdateEnv with the Agent config

In the first UpdateEnv, we can add the secret script file but we cannot give it the right permissions. So if we set secret_backend_command directly the Agent won't be able to start and the first UpdateEnv will fail.

Additional Notes
----------------

I started to work on structures containing ACE information, which would contain identifier like explained in [icacls documentation](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/icacls#remarks).
 
```
const (
       Allow ACEType = iota
       Deny
)

type WindowsACE struct {
       SID        string
       AceType    ACEType  // Allow or Deny
       AccessMask []string // FullControl, Modify, ReadAndExecute, Read, Write
       AceFlags   []string // ObjectInherit, ContainerInherit, NoPropagateInherit, InheritOnly, Inherited
}
```

For instance AccessMask could contain ["RX", "M", WDAC"] and then we would be able to transform it into `(RX,M,WDAC)` to use it with `icacls`


I'm doing this PR to have a first version for Windows and make sure I can do wrapper around secrets management. I'll try to follow up later to add a more friendly API (e.g. having function like `WithFullControl()`, `WithReadExec()`, etc ...)