### PR TITLE
fix(installer): Add default config

### DIFF
--- a/components/datadog/updater/install_script.sh
+++ b/components/datadog/updater/install_script.sh
@@ -14,7 +14,7 @@ config_file="/etc/datadog-agent/datadog.yaml"
 $sudo_cmd mkdir -p /etc/datadog-agent
 $sudo_cmd touch $config_file
 $sudo_cmd chmod 644 $config_file
-$sudo_cmd sh -c "echo '${AGENT_CONFIG}' > $config_file"
+$sudo_cmd sh -c "echo '${AGENT_CONFIG:-api_key: 000000000}' > $config_file" # We at least need the api_key field in the config
 
 INSTALLER_BIN="/opt/datadog-installer/bin/installer/installer"
 OCI_URL_PREFIX="oci://docker.io/datadog/"


### PR DESCRIPTION
What does this PR do?
---------------------
Adds default installer config when none is set

Which scenarios this will impact?
-------------------
new-e2e-installer

Motivation
----------
Trace agent can't start without the `api_key` field set

Additional Notes
----------------
