### PR TITLE
fix utils.MergeYaml function unmarshalling yaml data into the wrong variable 

### DIFF
--- a/common/utils/yaml.go
+++ b/common/utils/yaml.go
@@ -14,13 +14,12 @@ func MergeYAML(oldValuesYamlContent string, newValuesYamlContent string) (string
 	var oldValuesYAML map[string]interface{}
 	var newValuesYAML map[string]interface{}
 
-	err := yaml.Unmarshal([]byte(oldValuesYamlContent), &oldValuesYamlContent)
+	err := yaml.Unmarshal([]byte(oldValuesYamlContent), &oldValuesYAML)
 	if err != nil {
 		return "", err
 	}
 
 	err = yaml.Unmarshal([]byte(newValuesYamlContent), &newValuesYAML)
-
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
What does this PR do?
---------------------

Fixes the `utils.MergeYAML` function which was unmarshalling `oldValuesYamlContent` into the wrong variable.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
