### PR TITLE
Updating CODEOWNERS with AML owned apps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,6 @@
 *                                       @DataDog/agent-e2e-testing
 /scenarios/aws/microVMs/                @DataDog/ebpf-platform
 /scenarios/aws/installer/               @DataDog/fleet
+/components/datadog/apps/jmxfetch       @DataDog/agent-metrics-logs
+/components/datadog/apps/logger         @DataDog/agent-metrics-logs
 /components/datadog/apps/tracegen       @DataDog/agent-apm


### PR DESCRIPTION
What does this PR do?
---------------------

Updated `.github/CODEOWNERS` file chaning the ownership of test apps owned by @DataDog/agent-metrics-logs 

Which scenarios this will impact?
-------------------

None.

Motivation
----------

Speed up development.

Additional Notes
----------------

None.
