### PR TITLE
Increase the CPU limit of the agents to avoid starvation at startup

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -308,7 +308,7 @@ func buildLinuxHelmValues(installName, agentImagePath, agentImageTag, clusterAge
 							"memory": pulumi.String("130Mi"),
 						},
 						"limits": pulumi.StringMap{
-							"cpu":    pulumi.String("50m"),
+							"cpu":    pulumi.String("100m"),
 							"memory": pulumi.String("150Mi"),
 						},
 					},
@@ -320,7 +320,7 @@ func buildLinuxHelmValues(installName, agentImagePath, agentImageTag, clusterAge
 							"memory": pulumi.String("100Mi"),
 						},
 						"limits": pulumi.StringMap{
-							"cpu":    pulumi.String("50m"),
+							"cpu":    pulumi.String("100m"),
 							"memory": pulumi.String("130Mi"),
 						},
 					},
@@ -345,7 +345,7 @@ func buildLinuxHelmValues(installName, agentImagePath, agentImageTag, clusterAge
 					"memory": pulumi.String("70Mi"),
 				},
 				"limits": pulumi.StringMap{
-					"cpu":    pulumi.String("50m"),
+					"cpu":    pulumi.String("100m"),
 					"memory": pulumi.String("100Mi"),
 				},
 			},
@@ -371,11 +371,11 @@ func buildLinuxHelmValues(installName, agentImagePath, agentImageTag, clusterAge
 			},
 			"resources": pulumi.StringMapMap{
 				"requests": pulumi.StringMap{
-					"cpu":    pulumi.String("10m"),
+					"cpu":    pulumi.String("20m"),
 					"memory": pulumi.String("100Mi"),
 				},
 				"limits": pulumi.StringMap{
-					"cpu":    pulumi.String("50m"),
+					"cpu":    pulumi.String("200m"),
 					"memory": pulumi.String("130Mi"),
 				},
 			},


### PR DESCRIPTION
What does this PR do?
---------------------

Increase the CPU limit of the agents.

Which scenarios this will impact?
-------------------

* `aws/eks`
* `aws/kind`

Motivation
----------

#791 Introduced CPU and memory resources requests and limits for the agent based on their nominal resource consumption.
Since then, we observe some restarts of the cluster checks runners from time to time.
This is because they are consuming much more CPU at their startup than in average.
So, let’s increase the CPU requests and limits of all the agents so that they are not starved at startup.

Additional Notes
----------------
