### PR TITLE
Let docker-compose up handle the diff instead of forcing down on each change

### DIFF
--- a/components/docker/docker.go
+++ b/components/docker/docker.go
@@ -116,7 +116,7 @@ func (d *Manager) ComposeStrUp(name string, composeManifests []ComposeInlineMani
 			Environment: envVars,
 			Triggers:    runCommandTriggers,
 		},
-		utils.MergeOptions(d.opts, pulumi.DependsOn(runCommandDeps), pulumi.DeleteBeforeReplace(true))...,
+		utils.MergeOptions(d.opts, pulumi.DependsOn(runCommandDeps))...,
 	)
 }
 


### PR DESCRIPTION

What does this PR do?
---------------------

Remove `DeleteBeforeReplace` that should not be needed, as `docker-compose up` must handle updates. This is a try to fix APM test that run `UpdateEnv` to update environment variables between two tests.
cf ADXT-226

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
