### PR TITLE
Fix the collection of agent telemetry

### DIFF
--- a/components/datadog/agent/ecs.go
+++ b/components/datadog/agent/ecs.go
@@ -136,6 +136,14 @@ func ecsLinuxAgentSingleContainerDefinition(e config.CommonEnvironment, apiKeySS
 				Name:  pulumi.StringPtr("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED"),
 				Value: pulumi.StringPtr("true"),
 			},
+			ecs.TaskDefinitionKeyValuePairArgs{
+				Name:  pulumi.StringPtr("DD_TELEMETRY_ENABLED"),
+				Value: pulumi.StringPtr("true"),
+			},
+			ecs.TaskDefinitionKeyValuePairArgs{
+				Name:  pulumi.StringPtr("DD_TELEMETRY_CHECKS"),
+				Value: pulumi.StringPtr("*"),
+			},
 		}, ecsAgentAdditionalEndpointsEnv(params)...), ecsFakeintakeAdditionalEndpointsEnv(fakeintake)...),
 		Secrets: ecs.TaskDefinitionSecretArray{
 			ecs.TaskDefinitionSecretArgs{
@@ -198,7 +206,7 @@ func ecsLinuxAgentSingleContainerDefinition(e config.CommonEnvironment, apiKeySS
 			"com.datadoghq.ad.checks": pulumi.String(utils.JSONMustMarshal(
 				map[string]interface{}{
 					"openmetrics": map[string]interface{}{
-						"init_configs": []map[string]interface{}{},
+						"init_config": map[string]interface{}{},
 						"instances": []map[string]interface{}{
 							{
 								"openmetrics_endpoint": "http://localhost:5000/telemetry",

--- a/components/datadog/agent/ecsFargate.go
+++ b/components/datadog/agent/ecsFargate.go
@@ -32,6 +32,14 @@ func ECSFargateLinuxContainerDefinition(e config.CommonEnvironment, image string
 				Name:  pulumi.StringPtr("DD_CHECKS_TAG_CARDINALITY"),
 				Value: pulumi.StringPtr("high"),
 			},
+			ecs.TaskDefinitionKeyValuePairArgs{
+				Name:  pulumi.StringPtr("DD_TELEMETRY_ENABLED"),
+				Value: pulumi.StringPtr("true"),
+			},
+			ecs.TaskDefinitionKeyValuePairArgs{
+				Name:  pulumi.StringPtr("DD_TELEMETRY_CHECKS"),
+				Value: pulumi.StringPtr("*"),
+			},
 		}, ecsFakeintakeAdditionalEndpointsEnv(fakeintake)...),
 		Secrets: ecs.TaskDefinitionSecretArray{
 			ecs.TaskDefinitionSecretArgs{
@@ -59,7 +67,7 @@ func ECSFargateLinuxContainerDefinition(e config.CommonEnvironment, image string
 			"com.datadoghq.ad.checks": pulumi.String(utils.JSONMustMarshal(
 				map[string]interface{}{
 					"openmetrics": map[string]interface{}{
-						"init_configs": []map[string]interface{}{},
+						"init_config": map[string]interface{}{},
 						"instances": []map[string]interface{}{
 							{
 								"openmetrics_endpoint": "http://localhost:5000/telemetry",

--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -261,6 +261,14 @@ func buildLinuxHelmValues(installName, agentImagePath, agentImageTag, clusterAge
 					"name":  pulumi.String("DD_EC2_METADATA_TIMEOUT"),
 					"value": pulumi.String("5000"), // Unit is ms
 				},
+				pulumi.StringMap{
+					"name":  pulumi.String("DD_TELEMETRY_ENABLED"),
+					"value": pulumi.String("true"),
+				},
+				pulumi.StringMap{
+					"name":  pulumi.String("DD_TELEMETRY_CHECKS"),
+					"value": pulumi.String("*"),
+				},
 			},
 		},
 		"agents": pulumi.Map{
@@ -274,7 +282,7 @@ func buildLinuxHelmValues(installName, agentImagePath, agentImageTag, clusterAge
 				"ad.datadoghq.com/agent.checks": pulumi.String(utils.JSONMustMarshal(
 					map[string]interface{}{
 						"openmetrics": map[string]interface{}{
-							"init_config": []map[string]interface{}{},
+							"init_config": map[string]interface{}{},
 							"instances": []map[string]interface{}{
 								{
 									"openmetrics_endpoint": "http://localhost:6000/telemetry",


### PR DESCRIPTION
What does this PR do?
---------------------

Fix the collection of agent telemetry data (metrics under `datadog.agent`)

Which scenarios this will impact?
-------------------

* `aws/ecs`
* `aws/eks`
* `aws/kind`

Motivation
----------

Agent telemetry is currently not working.
We would need it to diagnose some cases of test failure.

Additional Notes
----------------
