### PR TITLE
Remove the overrides to grant more resources to the fake intake

### DIFF
--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -258,8 +258,7 @@ func Run(ctx *pulumi.Context) error {
 		var fakeIntake *fakeintakeComp.Fakeintake
 		if awsEnv.GetCommonEnvironment().AgentUseFakeintake() {
 			fakeIntakeOptions := []fakeintake.Option{
-				fakeintake.WithCPU(1024),
-				fakeintake.WithMemory(6144),
+				fakeintake.WithMemory(2048),
 			}
 			if awsEnv.GetCommonEnvironment().InfraShouldDeployFakeintakeWithLB() {
 				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithLoadBalancer())

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -69,8 +69,7 @@ func Run(ctx *pulumi.Context) error {
 	var fakeIntake *fakeintakeComp.Fakeintake
 	if awsEnv.GetCommonEnvironment().AgentUseFakeintake() {
 		fakeIntakeOptions := []fakeintake.Option{
-			fakeintake.WithCPU(1024),
-			fakeintake.WithMemory(6144),
+			fakeintake.WithMemory(2048),
 		}
 		if awsEnv.GetCommonEnvironment().InfraShouldDeployFakeintakeWithLB() {
 			fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithLoadBalancer())


### PR DESCRIPTION
What does this PR do?
---------------------

Removes the overrides to grant more resources to the fake intake.

Which scenarios this will impact?
-------------------

* `aws/eks`
* `aws/kind`

In the past, it has been necessary to bump the amount of memory granted to the fake intake because of the huge volume of data generated on the EKS and kind scenarios.
Since DataDog/datadog-agent#24064, the data are now kept on disk instead of memory.

Motivation
----------

Save money.

Additional Notes
----------------

![image](https://github.com/DataDog/test-infra-definitions/assets/1437785/0738ba2d-2447-4d0d-ad34-f825d8469100)