### PR TITLE
Remove triggers to not force a replace on manifest change

### DIFF
--- a/components/docker/compose.go
+++ b/components/docker/compose.go
@@ -5,7 +5,6 @@ import "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 type ComposeInlineManifest struct {
 	Name    string
 	Content pulumi.StringInput
-	Hash    pulumi.StringInput
 }
 
 type ComposeManifest struct {

--- a/components/docker/compose.go
+++ b/components/docker/compose.go
@@ -5,6 +5,7 @@ import "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 type ComposeInlineManifest struct {
 	Name    string
 	Content pulumi.StringInput
+	Hash    pulumi.StringInput
 }
 
 type ComposeManifest struct {

--- a/components/docker/docker.go
+++ b/components/docker/docker.go
@@ -118,8 +118,8 @@ func (d *Manager) ComposeStrUp(name string, composeManifests []ComposeInlineMani
 	// We include the file hashes in the environment variables to trigger an update when the manifest changes
 	// This is a workaround to avoid a force replace with Triggers when the content of the manifest changes
 	for k, v := range manifestHashes {
-		formatted_name := strings.ReplaceAll(strings.ToUpper(k), "-", "_")
-		mergedEnvVars[formatted_name] = v
+		formattedName := strings.ReplaceAll(strings.ToUpper(k), "-", "_")
+		mergedEnvVars[formattedName] = v
 	}
 
 	composeFileArgs := "-f " + strings.Join(remoteComposePaths, " -f ")

--- a/components/docker/docker.go
+++ b/components/docker/docker.go
@@ -118,7 +118,8 @@ func (d *Manager) ComposeStrUp(name string, composeManifests []ComposeInlineMani
 	// We include the file hashes in the environment variables to trigger an update when the manifest changes
 	// This is a workaround to avoid a force replace with Triggers when the content of the manifest changes
 	for k, v := range manifestHashes {
-		mergedEnvVars[k] = v
+		formatted_name := strings.ReplaceAll(strings.ToUpper(k), "-", "_")
+		mergedEnvVars[formatted_name] = v
 	}
 
 	composeFileArgs := "-f " + strings.Join(remoteComposePaths, " -f ")

--- a/components/docker/docker.go
+++ b/components/docker/docker.go
@@ -115,7 +115,7 @@ func (d *Manager) ComposeStrUp(name string, composeManifests []ComposeInlineMani
 		mergedEnvVars[k] = v
 	}
 
-	// We include the file hashs in the environment variables to trigger a new run when the manifest changes
+	// We include the file hashes in the environment variables to trigger an update when the manifest changes
 	// This is a workaround to avoid a force replace with Triggers when the content of the manifest changes
 	for k, v := range manifestHashes {
 		mergedEnvVars[k] = v

--- a/components/docker/docker.go
+++ b/components/docker/docker.go
@@ -110,7 +110,7 @@ func (d *Manager) ComposeStrUp(name string, composeManifests []ComposeInlineMani
 		return utils.StrHash(mergedContent)
 	}).(pulumi.StringOutput)
 
-	// We include a hash of the manifest contents in the environment variables to trigger an update when a manifest changes
+	// We include a hash of the manifests content in the environment variables to trigger an update when a manifest changes
 	// This is a workaround to avoid a force replace with Triggers when the content of the manifest changes
 	envVars["CONTENT_HASH"] = contentHash
 


### PR DESCRIPTION
What does this PR do?
---------------------

Modify the `docker-compose` command to include a hash of the content manifest as an environment variable.
This is a workaround to stop using `Triggers` that will create a replacement (`docker-compose down` + `docker-compose up`) to avoid some flakiness we have when this happen. We now let `docker-compose` handle the update.

Which scenarios this will impact?
-------------------

docker

Motivation
----------

Fix flakiness

Additional Notes
----------------
