### PR TITLE
Fix container collect all assignment

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -129,7 +129,7 @@ func NewHelmInstallation(e config.CommonEnvironment, args HelmInstallationArgs, 
 		linuxInstallName += "-linux"
 	}
 
-	values := buildLinuxHelmValues(installName, agentImagePath, agentImageTag, clusterAgentImagePath, clusterAgentImageTag, randomClusterAgentToken.Result, !args.DisableLogsContainerCollectAll)
+	values := buildLinuxHelmValues(installName, agentImagePath, agentImageTag, clusterAgentImagePath, clusterAgentImageTag, randomClusterAgentToken.Result, args.DisableLogsContainerCollectAll)
 	values.configureImagePullSecret(imgPullSecret)
 	values.configureFakeintake(e, args.Fakeintake)
 


### PR DESCRIPTION
What does this PR do?
---------------------

Fixes disabling `container_collect_all` in the agent running in Kubernetes.

Which scenarios this will impact?
-------------------
E2E tests in Kubernetes where the agent is orchestrated with `WithoutLogsContainerCollectAll()`.

Motivation
----------
Needed to be fixed for my E2E test to work.

Additional Notes
----------------
