### PR TITLE
Make SSH user configurable

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -29,6 +29,7 @@ const (
 	DDInfraOSImageID                        = "osImageID"
 	DDInfraDeployFakeintakeWithLoadBalancer = "deployFakeintakeWithLoadBalancer"
 	DDInfraExtraResourcesTags               = "extraResourcesTags"
+	DDInfraSSHUser                          = "sshUser"
 
 	// Agent Namespace
 	DDAgentDeployParamName               = "deploy"
@@ -139,6 +140,10 @@ func (e *CommonEnvironment) ExtraResourcesTags() map[string]string {
 		e.Ctx.Log.Error(fmt.Sprintf("error in extra resources tags : %v", err), nil)
 	}
 	return tags
+}
+
+func (e *CommonEnvironment) InfraSSHUser() string {
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraSSHUser, "")
 }
 
 func EnvVariableResourceTags() map[string]string {

--- a/tasks/config.py
+++ b/tasks/config.py
@@ -36,7 +36,7 @@ class Config(BaseModel, extra=Extra.forbid):
         class Pulumi(BaseModel, extra=Extra.forbid):
             logLevel: Optional[int] = None
             logToStdErr: Optional[bool] = None
-            verboseProgressStreams: Optional[bool] = None
+            verboseProgressStreams: Optional[bool] = None # noqa
 
         pulumi: Optional[Pulumi] = None
 

--- a/tasks/config.py
+++ b/tasks/config.py
@@ -36,6 +36,7 @@ class Config(BaseModel, extra=Extra.forbid):
         class Pulumi(BaseModel, extra=Extra.forbid):
             logLevel: Optional[int] = None
             logToStdErr: Optional[bool] = None
+            verboseProgressStreams: Optional[bool] = None
 
         pulumi: Optional[Pulumi] = None
 

--- a/tasks/doc.py
+++ b/tasks/doc.py
@@ -32,3 +32,4 @@ instance_type: str = "The instance type to use (default is t3.medium for aws or 
 no_verify: str = "Do not verify deploy jobs before creating vm"
 debug: str = "Check for common errors in your environment setup and configuration (defualt False)"
 site: str = "Datadog site to contact (default 'datad0g.com')"
+ssh_user: str = "The user to use for ssh connection (default will be selected depending on the OS family). Should only be used if you explicitly need to use a different user"

--- a/tasks/vm.py
+++ b/tasks/vm.py
@@ -32,6 +32,7 @@ scenario_name = "aws/vm"
         "use_aws_vault": doc.use_aws_vault,
         "instance_type": doc.instance_type,
         "no_verify": doc.no_verify,
+        "ssh_user": doc.ssh_user,
     }
 )
 def create_vm(
@@ -52,6 +53,7 @@ def create_vm(
     interactive: Optional[bool] = True,
     instance_type: Optional[str] = None,
     no_verify: Optional[bool] = False,
+    ssh_user: Optional[str] = None,
 ) -> None:
     """
     Create a new virtual machine on the cloud.
@@ -75,6 +77,9 @@ def create_vm(
             extra_flags["ddinfra:aws/defaultInstanceType"] = instance_type
         else:
             extra_flags["ddinfra:aws/defaultARMInstanceType"] = instance_type
+
+    if ssh_user is not None:
+        extra_flags["ddinfra:sshUser"] = ssh_user
 
     full_stack_name = deploy(
         ctx,


### PR DESCRIPTION
What does this PR do?
---------------------

Add a flag to create VM to let user configure the SSH user they want to use to connect to an instance. 
This can be useful when working with AMI that are not the ones we provide OOTB.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
