### PR TITLE
Move EKS Windows nodes to managed nodegroups

### DIFF
--- a/components/datadog/apps/nginx/k8s.go
+++ b/components/datadog/apps/nginx/k8s.go
@@ -31,7 +31,7 @@ func runtimeClassToPulumi(runtimeClass string) pulumi.StringInput {
 
 // K8sAppDefinition defines a Kubernetes application, with a deployment, a service, a pod disruption budget and an HPA.
 // It also creates a DatadogMetric and an HPA if dependsOnCrd is not nil.
-func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace string, runtimeClass string, dependsOnCrd pulumi.ResourceOption, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
+func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace string, runtimeClass string, withDatadogAutoscaling bool, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &componentskube.Workload{}
@@ -201,7 +201,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 		}
 	}
 
-	if dependsOnCrd != nil {
+	if withDatadogAutoscaling {
 		ddm, err := yaml.NewConfigGroup(e.Ctx(), namespace+"/nginx", &yaml.ConfigGroupArgs{
 			Objs: []map[string]any{
 				{
@@ -219,7 +219,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 					},
 				},
 			},
-		}, append(opts, dependsOnCrd)...)
+		}, opts...)
 		if err != nil {
 			return nil, err
 		}

--- a/components/datadog/apps/redis/k8s.go
+++ b/components/datadog/apps/redis/k8s.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace string, dependsOnCrd pulumi.ResourceOption, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
+func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace string, withDatadogAutoscaling bool, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &componentskube.Workload{}
@@ -156,7 +156,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 		}
 	}
 
-	if dependsOnCrd != nil {
+	if withDatadogAutoscaling {
 		ddm, err := yaml.NewConfigGroup(e.Ctx(), "redis", &yaml.ConfigGroupArgs{
 			Objs: []map[string]any{
 				{
@@ -174,7 +174,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 					},
 				},
 			},
-		}, append(opts, dependsOnCrd)...)
+		}, opts...)
 		if err != nil {
 			return nil, err
 		}

--- a/resources/aws/eks/eniConfig.go
+++ b/resources/aws/eks/eniConfig.go
@@ -3,10 +3,8 @@ package eks
 import (
 	"fmt"
 
-	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 
-	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/yaml"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -14,7 +12,7 @@ import (
 // NewENIConfigs creates ENIConfig CRDs to allow usage of custom networkwing for EKS pods when using AWS VPC CNI Plugin (default).
 // https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html
 // ENI = Elastic Network Interface (basically, a virtual network card)
-func NewENIConfigs(e aws.Environment, provider *kubernetes.Provider, subnets []aws.DDInfraEKSPodSubnets, securityGroups []string, opts ...pulumi.ResourceOption) (*yaml.ConfigGroup, error) {
+func NewENIConfigs(e aws.Environment, subnets []aws.DDInfraEKSPodSubnets, securityGroups []string, opts ...pulumi.ResourceOption) (*yaml.ConfigGroup, error) {
 	if len(subnets) == 0 {
 		return nil, fmt.Errorf("subnets must not be empty")
 	}
@@ -34,7 +32,5 @@ func NewENIConfigs(e aws.Environment, provider *kubernetes.Provider, subnets []a
 		})
 	}
 
-	return yaml.NewConfigGroup(e.Ctx(), e.Namer.ResourceName("eks-eni-configs"), &yaml.ConfigGroupArgs{
-		Objs: objects,
-	}, utils.MergeOptions(opts, pulumi.Providers(provider))...)
+	return yaml.NewConfigGroup(e.Ctx(), e.Namer.ResourceName("eks-eni-configs"), &yaml.ConfigGroupArgs{Objs: objects}, opts...)
 }

--- a/resources/aws/eks/nodeGroups.go
+++ b/resources/aws/eks/nodeGroups.go
@@ -1,15 +1,14 @@
 package eks
 
 import (
-	"encoding/base64"
-	"fmt"
+	"strings"
 
 	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 
 	awsEks "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/eks"
 	awsIam "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/iam"
-	"github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ssm"
 	"github.com/pulumi/pulumi-eks/sdk/v2/go/eks"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -18,27 +17,37 @@ const (
 	amazonLinux2AMD64AmiType = "AL2_x86_64"
 	amazonLinux2ARM64AmiType = "AL2_ARM_64"
 	bottlerocketAmiType      = "BOTTLEROCKET_x86_64"
-
-	windowsInitUserData = `<powershell>
-[string]$EKSBootstrapScriptFile = "$env:ProgramFiles\Amazon\EKS\Start-EKSBootstrap.ps1"
-& $EKSBootstrapScriptFile -EKSClusterName %s -KubeletExtraArgs "--register-with-taints=node.kubernetes.io/os=windows:NoSchedule" 3>&1 4>&1 5>&1 6>&1
-</powershell>
-`
+	windowsAmiType           = "WINDOWS_CORE_2022_x86_64"
 )
 
-func NewLinuxNodeGroup(e aws.Environment, cluster *eks.Cluster, nodeRole *awsIam.Role) (*eks.ManagedNodeGroup, error) {
-	return newManagedNodeGroup(e, "linux", cluster, nodeRole, amazonLinux2AMD64AmiType, e.DefaultInstanceType())
+func NewLinuxNodeGroup(e aws.Environment, cluster *eks.Cluster, nodeRole *awsIam.Role, opts ...pulumi.ResourceOption) (*eks.ManagedNodeGroup, error) {
+	return newManagedNodeGroup(e, "linux", cluster, nodeRole, amazonLinux2AMD64AmiType, e.DefaultInstanceType(), opts...)
 }
 
-func NewLinuxARMNodeGroup(e aws.Environment, cluster *eks.Cluster, nodeRole *awsIam.Role) (*eks.ManagedNodeGroup, error) {
-	return newManagedNodeGroup(e, "linux-arm", cluster, nodeRole, amazonLinux2ARM64AmiType, e.DefaultARMInstanceType())
+func NewLinuxARMNodeGroup(e aws.Environment, cluster *eks.Cluster, nodeRole *awsIam.Role, opts ...pulumi.ResourceOption) (*eks.ManagedNodeGroup, error) {
+	return newManagedNodeGroup(e, "linux-arm", cluster, nodeRole, amazonLinux2ARM64AmiType, e.DefaultARMInstanceType(), opts...)
 }
 
-func NewBottlerocketNodeGroup(e aws.Environment, cluster *eks.Cluster, nodeRole *awsIam.Role) (*eks.ManagedNodeGroup, error) {
-	return newManagedNodeGroup(e, "bottlerocket", cluster, nodeRole, bottlerocketAmiType, e.DefaultInstanceType())
+func NewBottlerocketNodeGroup(e aws.Environment, cluster *eks.Cluster, nodeRole *awsIam.Role, opts ...pulumi.ResourceOption) (*eks.ManagedNodeGroup, error) {
+	return newManagedNodeGroup(e, "bottlerocket", cluster, nodeRole, bottlerocketAmiType, e.DefaultInstanceType(), opts...)
 }
 
-func newManagedNodeGroup(e aws.Environment, name string, cluster *eks.Cluster, nodeRole *awsIam.Role, amiType, instanceType string) (*eks.ManagedNodeGroup, error) {
+func NewWindowsNodeGroup(e aws.Environment, cluster *eks.Cluster, nodeRole *awsIam.Role, opts ...pulumi.ResourceOption) (*eks.ManagedNodeGroup, error) {
+	return newManagedNodeGroup(e, "windows", cluster, nodeRole, windowsAmiType, e.DefaultInstanceType(), opts...)
+}
+
+func newManagedNodeGroup(e aws.Environment, name string, cluster *eks.Cluster, nodeRole *awsIam.Role, amiType, instanceType string, opts ...pulumi.ResourceOption) (*eks.ManagedNodeGroup, error) {
+	taints := awsEks.NodeGroupTaintArray{}
+	if strings.Contains(amiType, "WINDOWS") {
+		taints = append(taints,
+			awsEks.NodeGroupTaintArgs{
+				Key:    pulumi.String("node.kubernetes.io/os"),
+				Value:  pulumi.String("windows"),
+				Effect: pulumi.String("NO_SCHEDULE"),
+			},
+		)
+	}
+
 	return eks.NewManagedNodeGroup(e.Ctx(), e.Namer.ResourceName(name), &eks.ManagedNodeGroupArgs{
 		AmiType:             pulumi.StringPtr(amiType),
 		Cluster:             cluster.Core,
@@ -56,46 +65,6 @@ func newManagedNodeGroup(e aws.Environment, name string, cluster *eks.Cluster, n
 			Ec2SshKey:              pulumi.String(e.DefaultKeyPairName()),
 			SourceSecurityGroupIds: pulumi.ToStringArray(e.EKSAllowedInboundSecurityGroups()),
 		},
-	}, e.WithProviders(config.ProviderAWS, config.ProviderEKS))
-}
-
-func NewWindowsUnmanagedNodeGroup(e aws.Environment, cluster *eks.Cluster, nodeRole *awsIam.Role) (*eks.NodeGroup, error) {
-	windowsAmi, err := ssm.LookupParameter(e.Ctx(), &ssm.LookupParameterArgs{
-		Name: fmt.Sprintf("/aws/service/ami-windows-latest/Windows_Server-2022-English-Core-EKS_Optimized-%s/image_id", e.KubernetesVersion()),
-	}, e.WithProvider(config.ProviderAWS))
-	if err != nil {
-		return nil, err
-	}
-
-	return newUnmanagedNodeGroup(e, "windows-ng", cluster, nodeRole, pulumi.String(windowsAmi.Value), pulumi.String(e.DefaultInstanceType()), getUserData(windowsInitUserData, cluster.EksCluster.Name()))
-}
-
-func newUnmanagedNodeGroup(e aws.Environment, name string, cluster *eks.Cluster, nodeRole *awsIam.Role, ami, instanceType, userData pulumi.StringInput) (*eks.NodeGroup, error) {
-	instanceProfile, err := awsIam.NewInstanceProfile(e.Ctx(), e.Namer.ResourceName(name), &awsIam.InstanceProfileArgs{
-		Name: e.CommonNamer().DisplayName(255, pulumi.String(name)),
-		Role: nodeRole.Name,
-	}, e.WithProviders(config.ProviderAWS))
-	if err != nil {
-		return nil, err
-	}
-
-	return eks.NewNodeGroup(e.Ctx(), e.Namer.ResourceName(name), &eks.NodeGroupArgs{
-		NodeUserDataOverride: userData,
-		Cluster:              cluster.Core,
-		DesiredCapacity:      pulumi.Int(1),
-		// Currently not working
-		// ExtraNodeSecurityGroups: extraSecurityGroups,
-		KeyName:                      pulumi.StringPtr(e.DefaultKeyPairName()),
-		AmiId:                        ami,
-		InstanceType:                 instanceType,
-		NodeRootVolumeSize:           pulumi.Int(80),
-		NodeAssociatePublicIpAddress: pulumi.BoolRef(false),
-		InstanceProfile:              instanceProfile,
-	}, e.WithProviders(config.ProviderAWS, config.ProviderEKS))
-}
-
-func getUserData(userData string, clusterName pulumi.StringInput) pulumi.StringInput {
-	return clusterName.ToStringOutput().ApplyT(func(name string) pulumi.StringInput {
-		return pulumi.String(base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(userData, name))))
-	}).(pulumi.StringInput)
+		Taints: taints,
+	}, utils.MergeOptions(opts, e.WithProviders(config.ProviderAWS, config.ProviderEKS))...)
 }

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -121,11 +121,11 @@ agents:
 
 	// Deploy testing workload
 	if awsEnv.TestingWorkloadDeploy() {
-		if _, err := nginx.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-nginx", "", dependsOnCrd); err != nil {
+		if _, err := nginx.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-nginx", "", true, dependsOnCrd); err != nil {
 			return err
 		}
 
-		if _, err := redis.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-redis", dependsOnCrd); err != nil {
+		if _, err := redis.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-redis", true, dependsOnCrd); err != nil {
 			return err
 		}
 

--- a/scenarios/azure/aks/run.go
+++ b/scenarios/azure/aks/run.go
@@ -95,15 +95,15 @@ providers:
 
 		// Deploy testing workload
 		if env.TestingWorkloadDeploy() {
-			if _, err := nginx.K8sAppDefinition(&env, aksKubeProvider, "workload-nginx", "", dependsOnCrd); err != nil {
+			if _, err := nginx.K8sAppDefinition(&env, aksKubeProvider, "workload-nginx", "", true, dependsOnCrd); err != nil {
 				return err
 			}
 
-			if _, err := nginx.K8sAppDefinition(&env, aksKubeProvider, "workload-nginx-kata", kataRuntimeClass, dependsOnCrd); err != nil {
+			if _, err := nginx.K8sAppDefinition(&env, aksKubeProvider, "workload-nginx-kata", kataRuntimeClass, true, dependsOnCrd); err != nil {
 				return err
 			}
 
-			if _, err := redis.K8sAppDefinition(&env, aksKubeProvider, "workload-redis", dependsOnCrd); err != nil {
+			if _, err := redis.K8sAppDefinition(&env, aksKubeProvider, "workload-redis", true, dependsOnCrd); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
What does this PR do?
---------------------

Migrate Windows nodes from unmanaged to managed EKS node groups since it's been supported for some months.
This PR also fixes deployment sequence on EKS:
```
nodes -> agent -> workloads requiring CRDs
      -> workloads not requiring CRDs
```

Which scenarios this will impact?
-------------------

EKS

Motivation
----------

Align Windows nodes on Linux nodes

Additional Notes
----------------

Getting rid of unmanaged node groups as not required anymore.