### PR TITLE
Use the main requirements file to run the Python linters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install lint python requirements
-        run: pip3 install -r https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/requirements/circleci.txt
+        run: pip3 install -r https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/requirements.txt
       - name: Run linters
         run: |
           ruff format --check tasks


### PR DESCRIPTION
What does this PR do?
---------------------

Use the main requirements file to run the Python linters

Which scenarios this will impact?
-------------------

Motivation
----------

We moved the dependencies to the main file https://github.com/DataDog/datadog-agent-buildimages/pull/585

Additional Notes
----------------
