### PR TITLE
Add the ability to transfer files to system folders

### DIFF
--- a/components/command/filemanager.go
+++ b/components/command/filemanager.go
@@ -169,10 +169,6 @@ func (fm *FileManager) CopyFSFolder(
 	return fileResources, nil
 }
 
-func (fm *FileManager) CopyRemoteFile(source string, destination string, sudo bool, opts ...pulumi.ResourceOption) (*remote.Command, error) {
-	return fm.command.CopyRemoteFile(fm.runner, source, destination, sudo, opts...)
-}
-
 // When copying foo/bar to /tmp the result folder is /tmp/bar
 // This function remove the root prefix from the path (`foo` in this case)
 func getDestinationPath(folder string, rootFolder string) (string, error) {

--- a/components/command/filemanager.go
+++ b/components/command/filemanager.go
@@ -36,7 +36,7 @@ func (fm *FileManager) CreateDirectoryFromPulumiString(name string, remotePath p
 }
 
 // CreateDirectoryForFile if the directory does not exist
-// To avoid pulumi.URN colisions if multiple files use the same directory, use the full filePath as URN and path.Split out the folderPath for creation
+// To avoid pulumi.URN collisions if multiple files use the same directory, use the full filePath as URN and path.Split out the folderPath for creation
 func (fm *FileManager) CreateDirectoryForFile(remotePath string, useSudo bool, opts ...pulumi.ResourceOption) (*remote.Command, error) {
 	// if given just a directory path, path.Split returns "" as file
 	//  eg. path.Split("/a/b/c/") -> "/a/b/c/", ""
@@ -167,6 +167,10 @@ func (fm *FileManager) CopyFSFolder(
 	}
 
 	return fileResources, nil
+}
+
+func (fm *FileManager) CopyRemoteFile(source string, destination string, sudo bool, opts ...pulumi.ResourceOption) (*remote.Command, error) {
+	return fm.command.CopyRemoteFile(fm.runner, source, destination, sudo, opts...)
 }
 
 // When copying foo/bar to /tmp the result folder is /tmp/bar

--- a/components/command/osCommand.go
+++ b/components/command/osCommand.go
@@ -34,6 +34,15 @@ type OSCommand interface {
 		user string) pulumi.StringInput
 
 	IsPathAbsolute(path string) bool
+
+	CopyRemoteFile(
+		runner *Runner,
+		source string,
+		destination string,
+		sudo bool,
+		opts ...pulumi.ResourceOption) (*remote.Command, error)
+
+	NewCopyFile(runner *Runner, localPath, remotePath string, opts ...pulumi.ResourceOption) (*remote.CopyFile, error)
 }
 
 // ------------------------------
@@ -94,4 +103,21 @@ func buildCommandString(
 	}).(pulumi.StringOutput)
 
 	return fct(envVarsStr)
+}
+
+func copyRemoteFile(
+	runner *Runner,
+	name string,
+	createCommand string,
+	deleteCommand string,
+	useSudo bool,
+	opts ...pulumi.ResourceOption,
+) (*remote.Command, error) {
+	return runner.Command(name,
+		&Args{
+			Create:   pulumi.String(createCommand),
+			Delete:   pulumi.String(deleteCommand),
+			Sudo:     useSudo,
+			Triggers: pulumi.Array{pulumi.String(createCommand), pulumi.String(deleteCommand), pulumi.BoolPtr(useSudo)},
+		}, opts...)
 }

--- a/components/command/osCommand.go
+++ b/components/command/osCommand.go
@@ -35,13 +35,6 @@ type OSCommand interface {
 
 	IsPathAbsolute(path string) bool
 
-	CopyRemoteFile(
-		runner *Runner,
-		source string,
-		destination string,
-		sudo bool,
-		opts ...pulumi.ResourceOption) (*remote.Command, error)
-
 	NewCopyFile(runner *Runner, localPath, remotePath string, opts ...pulumi.ResourceOption) (*remote.CopyFile, error)
 }
 

--- a/components/command/runner.go
+++ b/components/command/runner.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"fmt"
-
 	"github.com/pulumi/pulumi-command/sdk/go/command/local"
 	"github.com/pulumi/pulumi-command/sdk/go/command/remote"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -110,12 +109,7 @@ func (r *Runner) Command(name string, args *Args, opts ...pulumi.ResourceOption)
 }
 
 func (r *Runner) NewCopyFile(localPath, remotePath string, opts ...pulumi.ResourceOption) (*remote.CopyFile, error) {
-	return remote.NewCopyFile(r.e.Ctx(), r.namer.ResourceName("copy", remotePath), &remote.CopyFileArgs{
-		Connection: r.config.connection,
-		LocalPath:  pulumi.String(localPath),
-		RemotePath: pulumi.String(remotePath),
-		Triggers:   pulumi.Array{pulumi.String(localPath), pulumi.String(remotePath)},
-	}, utils.MergeOptions(r.options, opts...)...)
+	return r.osCommand.NewCopyFile(r, localPath, remotePath, opts...)
 }
 
 type LocalRunner struct {

--- a/components/command/unixOSCommand.go
+++ b/components/command/unixOSCommand.go
@@ -2,6 +2,8 @@ package command
 
 import (
 	"fmt"
+	"github.com/DataDog/test-infra-definitions/common/utils"
+	"path/filepath"
 	"strings"
 
 	"github.com/alessio/shellescape"
@@ -82,6 +84,36 @@ func (fs unixOSCommand) BuildCommandString(command pulumi.StringInput, env pulum
 
 func (fs unixOSCommand) IsPathAbsolute(path string) bool {
 	return strings.HasPrefix(path, "/")
+}
+
+func (fs unixOSCommand) CopyRemoteFile(runner *Runner, source string, destination string, sudo bool, opts ...pulumi.ResourceOption) (*remote.Command, error) {
+	backupPath := destination + "." + backupExtension
+	copyCommand := fmt.Sprintf(`cp '%v' '%v'`, source, destination)
+	createCommand := fmt.Sprintf(`bash -c 'if [ -f '%v' ]; then mv -f '%v' '%v'; fi; %v'`, destination, destination, backupPath, copyCommand)
+	deleteCommand := fmt.Sprintf(`bash -c 'if [ -f '%v' ]; then mv -f '%v' '%v'; else rm -f '%v'; fi'`, backupPath, backupPath, destination, destination)
+	return copyRemoteFile(runner, fmt.Sprintf("copy-file-%s", filepath.Base(source)), createCommand, deleteCommand, sudo, opts...)
+}
+
+func (fs unixOSCommand) NewCopyFile(runner *Runner, localPath, remotePath string, opts ...pulumi.ResourceOption) (*remote.CopyFile, error) {
+	tempRemotePath := filepath.Join(runner.osCommand.GetTemporaryDirectory(), filepath.Base(localPath))
+
+	tempCopyFile, err := remote.NewCopyFile(runner.e.Ctx(), runner.namer.ResourceName("copy-", remotePath), &remote.CopyFileArgs{
+		Connection: runner.config.connection,
+		LocalPath:  pulumi.String(localPath),
+		RemotePath: pulumi.String(tempRemotePath),
+		Triggers:   pulumi.Array{pulumi.String(localPath), pulumi.String(tempRemotePath)},
+	}, utils.MergeOptions(runner.options, opts...)...)
+
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = runner.osCommand.CopyRemoteFile(runner, tempRemotePath, remotePath, true, pulumi.DependsOn([]pulumi.Resource{tempCopyFile}))
+	if err != nil {
+		return nil, err
+	}
+
+	return tempCopyFile, err
 }
 
 func formatCommandIfNeeded(command pulumi.StringInput, sudo bool, password bool, user string) pulumi.StringInput {

--- a/components/command/windowsOSCommand.go
+++ b/components/command/windowsOSCommand.go
@@ -2,6 +2,8 @@ package command
 
 import (
 	"fmt"
+	"github.com/DataDog/test-infra-definitions/common/utils"
+	"path/filepath"
 	"strings"
 
 	"github.com/pulumi/pulumi-command/sdk/go/command/remote"
@@ -11,6 +13,15 @@ import (
 var _ OSCommand = (*windowsOSCommand)(nil)
 
 type windowsOSCommand struct{}
+
+func (fs windowsOSCommand) NewCopyFile(runner *Runner, localPath, remotePath string, opts ...pulumi.ResourceOption) (*remote.CopyFile, error) {
+	return remote.NewCopyFile(runner.e.Ctx(), runner.namer.ResourceName("copy", remotePath), &remote.CopyFileArgs{
+		Connection: runner.config.connection,
+		LocalPath:  pulumi.String(localPath),
+		RemotePath: pulumi.String(remotePath),
+		Triggers:   pulumi.Array{pulumi.String(localPath), pulumi.String(remotePath)},
+	}, utils.MergeOptions(runner.options, opts...)...)
+}
 
 func NewWindowsOSCommand() OSCommand {
 	return windowsOSCommand{}
@@ -93,4 +104,16 @@ func (fs windowsOSCommand) IsPathAbsolute(path string) bool {
 		return true
 	}
 	return false
+}
+
+func (fs windowsOSCommand) CopyRemoteFile(runner *Runner, source string, destination string, sudo bool, opts ...pulumi.ResourceOption) (*remote.Command, error) {
+	backupPath := destination + "." + backupExtension
+	backupCommand := fmt.Sprintf("if (Test-Path -Path '%v') { Move-Item -Force -Path '%v' -Destination '%v'}", destination, destination, backupPath)
+	createCommand := fmt.Sprintf(`%v; Copy-Item -Path '%v' -Destination '%v'`, backupCommand, source, destination)
+
+	deleteMoveCommand := fmt.Sprintf(`Move-Item -Force -Path '%v' -Destination '%v'`, backupPath, destination)
+	deleteRemoveCommand := fmt.Sprintf(`Remove-Item -Force -Path '%v'`, destination)
+	deleteCommand := fmt.Sprintf("if (Test-Path -Path '%v') { %v } else { %v }", backupPath, deleteMoveCommand, deleteRemoveCommand)
+
+	return copyRemoteFile(runner, fmt.Sprintf("copy-file-%s", filepath.Base(source)), createCommand, deleteCommand, sudo, opts...)
 }


### PR DESCRIPTION
What does this PR do?
---------------------

Add the ability to transfer files to system folders copying it to `/tmp` and then copying it to the right destination using `sudo`. 

Note that this is a bit less efficient, it's not great but it works

Which scenarios this will impact?
-------------------

All linux ones that copy files.

Motivation
----------

- Address https://datadoghq.atlassian.net/wiki/spaces/AW/pages/3659661423/Known+E2E+issues+idiosyncrasy#Permission-denied-during-SFTP-operations

Additional Notes
----------------

- Part 1 of https://datadoghq.atlassian.net/browse/ADXT-228
- In a follow-up PR I'll address the encoding issue by creating a local file and using scp to send it instead of using `stdin`
