### PR TITLE
Add a local environment that implements config.Env interface

### DIFF
--- a/components/kubernetes/kind.go
+++ b/components/kubernetes/kind.go
@@ -135,7 +135,7 @@ func NewLocalKindCluster(env config.Env, resourceName, kindClusterName string, k
 			return err
 		}
 
-		nodeImage := fmt.Sprintf("%s/%s:%s", env.InfraOSDescriptor(), kindNodeImageName, kindVersionConfig.nodeImageVersion)
+		nodeImage := fmt.Sprintf("%s/%s:%s", env.InternalDockerhubMirror(), kindNodeImageName, kindVersionConfig.nodeImageVersion)
 		createCluster, err := runner.Command(
 			commonEnvironment.CommonNamer().ResourceName("kind-create-cluster", resourceName),
 			&command.Args{

--- a/resources/local/environment.go
+++ b/resources/local/environment.go
@@ -1,0 +1,38 @@
+package local
+
+import (
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+type Environment struct {
+	// CommonEnvironment is the common environment for all the components
+	// in the test-infra-definitions.
+	*config.CommonEnvironment
+}
+
+var _ config.Env = (*Environment)(nil)
+
+// NewEnvironment creates a new local environment.
+func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
+	env := Environment{}
+
+	commonEnv, err := config.NewCommonEnvironment(ctx)
+	if err != nil {
+		return Environment{}, err
+	}
+
+	env.CommonEnvironment = &commonEnv
+
+	return env, nil
+}
+
+// InternalRegistry returns the internal registry.
+func (e *Environment) InternalRegistry() string {
+	return "none"
+}
+
+// InternalDockerhubMirror returns the internal Dockerhub mirror.
+func (e *Environment) InternalDockerhubMirror() string {
+	return "registry-1.docker.io"
+}


### PR DESCRIPTION
What does this PR do?
---------------------

Create a new `local` environment that implements `config.Env`.
It can be useful to create provider that are made to be used locally

Which scenarios this will impact?
-------------------

Local scenarios

Motivation
----------

Additional Notes
----------------
