### PR TITLE
fix(installer): Use a7 instead of i7

### DIFF
--- a/components/datadog/updater/install_script.sh
+++ b/components/datadog/updater/install_script.sh
@@ -43,7 +43,7 @@ elif [ -f /etc/SuSE-release ] || [ "$DISTRIBUTION" == "SUSE" ] || [ "$DISTRIBUTI
 fi
 
 apt_url="apttesting.datad0g.com"
-apt_repo_version="${DD_PIPELINE_ID}-i7-${ARCH} 7"
+apt_repo_version="${DD_PIPELINE_ID}-a7-${ARCH} 7"
 apt_usr_share_keyring="/usr/share/keyrings/datadog-archive-keyring.gpg"
 apt_trusted_d_keyring="/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg"
 


### PR DESCRIPTION
What does this PR do?
---------------------
Replaces i7 testing repository by a7
Requires https://github.com/DataDog/datadog-agent/pull/25811

Which scenarios this will impact?
-------------------
Installer ones

Motivation
----------
See https://github.com/DataDog/datadog-agent/pull/25811

Additional Notes
----------------
