### PR TITLE
[NDM][NDMII-2815] remove useless image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,8 +64,6 @@ jobs:
             image: npm-tools
           - app: logger
             image: logger
-          - app: netflow-generator
-            image: netflow-generator
           - app: jmxfetch
             image: jmx-test-app
 

--- a/components/datadog/apps/netflow-generator/images/netflow-generator/Dockerfile
+++ b/components/datadog/apps/netflow-generator/images/netflow-generator/Dockerfile
@@ -1,1 +1,0 @@
-FROM networkstatic/nflow-generator


### PR DESCRIPTION
What does this PR do?
---------------------
Following [this PR](https://github.com/DataDog/datadog-agent/pull/26066) this image has became useless, we can remove it

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
