### PR TITLE
Increase the Burst and Qps in the KubeClientSettings param

### DIFF
--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -125,6 +125,7 @@ func Run(ctx *pulumi.Context) error {
 			Kubeconfig:            cluster.KubeconfigJson,
 			EnableServerSideApply: pulumi.BoolPtr(true),
 			DeleteUnreachable:     pulumi.BoolPtr(true),
+			KubeClientSettings:    kubernetes.KubeClientSettingsPtrInput(kubernetes.KubeClientSettingsArgs{Burst: pulumi.IntPtr(20), Qps: pulumi.Float64Ptr(10)}),
 		}, awsEnv.WithProviders(config.ProviderAWS))
 		if err != nil {
 			return err


### PR DESCRIPTION
What does this PR do?
---------------------

Increase the Burst and Qps options in the KubeClientSettings param

Which scenarios this will impact?
-------------------

Motivation
----------

Attempt to solve https://datadoghq.atlassian.net/browse/ADXT-266

The default values are 10 and 5 respectively https://github.com/pulumi/pulumi-kubernetes/blob/0b393b10d06fe630d4ab8a719e10e31958c13a29/sdk/go/kubernetes/pulumiTypes.go#L304C1-L312C2

Additional Notes
----------------
