### PR TITLE
Use the full path in the resource name to avoid conflicts

### DIFF
--- a/components/command/filemanager.go
+++ b/components/command/filemanager.go
@@ -87,7 +87,7 @@ func (fm *FileManager) CopyInlineFile(fileContent pulumi.StringInput, remotePath
 		return tempFilePath, nil
 	}).(pulumi.StringInput)
 
-	return fm.CopyFile(filepath.Base(remotePath), localFilePath, pulumi.String(remotePath), opts...)
+	return fm.CopyFile(remotePath, localFilePath, pulumi.String(remotePath), opts...)
 }
 
 // CopyRelativeFolder copies recursively a relative folder to a remote folder.

--- a/components/command/unixOSCommand.go
+++ b/components/command/unixOSCommand.go
@@ -77,7 +77,7 @@ func (fs unixOSCommand) NewCopyFile(runner *Runner, name string, localPath, remo
 		return filepath.Join(runner.osCommand.GetTemporaryDirectory(), filepath.Base(path))
 	}).(pulumi.StringOutput)
 
-	tempCopyFile, err := remote.NewCopyFile(runner.e.Ctx(), runner.namer.ResourceName("copy-", name), &remote.CopyFileArgs{
+	tempCopyFile, err := remote.NewCopyFile(runner.e.Ctx(), runner.namer.ResourceName("copy", name), &remote.CopyFileArgs{
 		Connection: runner.config.connection,
 		LocalPath:  localPath,
 		RemotePath: tempRemotePath,
@@ -122,5 +122,5 @@ func (fs unixOSCommand) copyRemoteFile(runner *Runner, name string, source, dest
 	var copyCommand pulumi.StringInput = pulumi.Sprintf(`cp '%v' '%v'`, source, destination)
 	var createCommand pulumi.StringInput = pulumi.Sprintf(`bash -c 'if [ -f '%v' ]; then mv -f '%v' '%v'; fi; %v'`, destination, destination, backupPath, copyCommand)
 	var deleteCommand pulumi.StringInput = pulumi.Sprintf(`bash -c 'if [ -f '%v' ]; then mv -f '%v' '%v'; else rm -f '%v'; fi'`, backupPath, backupPath, destination, destination)
-	return copyRemoteFile(runner, fmt.Sprintf("copy-file-%s", filepath.Base(name)), createCommand, deleteCommand, sudo, opts...)
+	return copyRemoteFile(runner, fmt.Sprintf("copy-file-%s", name), createCommand, deleteCommand, sudo, opts...)
 }


### PR DESCRIPTION
What does this PR do?
---------------------

Use the full path in the resource name to avoid conflicts

Which scenarios this will impact?
-------------------

Most of them since they use copy files

Motivation
----------

We currently use the filename, which is a problem since some tests might create several files with the same name but in different folders. For instance [here](https://github.com/DataDog/datadog-agent/blob/main/test/new-e2e/tests/agent-subcommands/flare/flare_nix_test.go#L56)

Additional Notes
----------------

Locally with two files called file but in different folders:
```
 +   │  ├─ command:remote:CopyFile  remote-aws-vm-copy-/tmp/file                                                             created (1s)        
 +   │  ├─ command:remote:CopyFile  remote-aws-vm-copy-/home/ubuntu/file                                                     created (1s)        
 +   │  ├─ command:remote:Command   remote-aws-vm-cmd-copy-file-/home/ubuntu/file                                            created (1s)        
 +   │  ├─ command:remote:Command   remote-aws-vm-cmd-copy-file-/tmp/file                                                    created (1s)    
```