### PR TITLE
Remove `pipeline-` from the `pipelineID` parameter

### DIFF
--- a/components/datadog/agent/host_linuxos.go
+++ b/components/datadog/agent/host_linuxos.go
@@ -27,11 +27,11 @@ func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersio
 		testEnvVars = append(testEnvVars, "TESTING_APT_URL=apttesting.datad0g.com")
 		// apt testing repo
 		// TESTING_APT_REPO_VERSION="pipeline-xxxxx-a7 7"
-		testEnvVars = append(testEnvVars, fmt.Sprintf(`TESTING_APT_REPO_VERSION="%v-a7-%s 7"`, version.PipelineID, am.targetOS.Descriptor().Architecture))
+		testEnvVars = append(testEnvVars, fmt.Sprintf(`TESTING_APT_REPO_VERSION="pipeline-%v-a7-%s 7"`, version.PipelineID, am.targetOS.Descriptor().Architecture))
 		testEnvVars = append(testEnvVars, "TESTING_YUM_URL=yumtesting.datad0g.com")
 		// yum testing repo
 		// TESTING_YUM_VERSION_PATH="testing/pipeline-xxxxx-a7/7"
-		testEnvVars = append(testEnvVars, fmt.Sprintf("TESTING_YUM_VERSION_PATH=testing/%v-a7/7", version.PipelineID))
+		testEnvVars = append(testEnvVars, fmt.Sprintf("TESTING_YUM_VERSION_PATH=testing/pipeline-%v-a7/7", version.PipelineID))
 		commandLine := strings.Join(testEnvVars, " ")
 
 		return fmt.Sprintf(

--- a/components/datadog/agent/host_windowsos.go
+++ b/components/datadog/agent/host_windowsos.go
@@ -150,10 +150,7 @@ func getAgentURL(version agentparams.PackageVersion) (string, error) {
 	return finder.findVersion(fullVersion)
 }
 
-func getAgentURLFromPipelineID(pipeline string) (string, error) {
-	// FIXME: remove pipeline- from the pipelineID we do not want it for Windows
-	pipelineID := strings.TrimPrefix(pipeline, "pipeline-")
-
+func getAgentURLFromPipelineID(pipelineID string) (string, error) {
 	// TODO: Replace context.Background() with a Pulumi context.Context.
 	// dd-agent-mstesting is a public bucket so we can use anonymous credentials
 	config, err := awsConfig.LoadDefaultConfig(context.Background(), awsConfig.WithCredentialsProvider(aws.AnonymousCredentials{}))
@@ -172,7 +169,7 @@ func getAgentURLFromPipelineID(pipeline string) (string, error) {
 	}
 
 	if len(result.Contents) <= 0 {
-		return "", fmt.Errorf("no agent MSI found for pipeline %v", pipeline)
+		return "", fmt.Errorf("no agent MSI found for pipeline %v", pipelineID)
 	}
 
 	return "https://s3.amazonaws.com/dd-agent-mstesting/" + *result.Contents[0].Key, nil

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -106,11 +106,11 @@ func WithVersion(version string) func(*Params) error {
 	}
 }
 
-// WithPipeline use a specific version of the Agent by pipeline id. For example: `16497585` uses the version `pipeline-16497585`
+// WithPipeline use a specific version of the Agent by pipeline id
 func WithPipeline(pipelineID string) func(*Params) error {
 	return func(p *Params) error {
 		p.Version = PackageVersion{
-			PipelineID: "pipeline-" + pipelineID,
+			PipelineID: pipelineID,
 		}
 		return nil
 	}

--- a/components/datadog/agentparams/params_test.go
+++ b/components/datadog/agentparams/params_test.go
@@ -32,7 +32,7 @@ func TestParams(t *testing.T) {
 		result, err := common.ApplyOption(p, options)
 		assert.NoError(t, err)
 		assert.Equal(t, result.Version, PackageVersion{
-			PipelineID: "pipeline-16362517",
+			PipelineID: "16362517",
 		})
 	})
 	t.Run("WithIntegration should correctly add conf.d/integration/conf.yaml to the path", func(t *testing.T) {

--- a/components/datadog/updater/install_script.sh
+++ b/components/datadog/updater/install_script.sh
@@ -43,7 +43,7 @@ elif [ -f /etc/SuSE-release ] || [ "$DISTRIBUTION" == "SUSE" ] || [ "$DISTRIBUTI
 fi
 
 apt_url="apttesting.datad0g.com"
-apt_repo_version="${DD_PIPELINE_ID}-a7-${ARCH} 7"
+apt_repo_version="pipeline-${DD_PIPELINE_ID}-a7-${ARCH} 7"
 apt_usr_share_keyring="/usr/share/keyrings/datadog-archive-keyring.gpg"
 apt_trusted_d_keyring="/etc/apt/trusted.gpg.d/datadog-archive-keyring.gpg"
 
@@ -101,7 +101,7 @@ if [ "${OS}" = "Debian" ]; then
     fi
 elif [ "${OS}" = "RedHat" ]; then
     yum_url="yumtesting.datad0g.com/testing"
-    yum_repo_version="${DD_PIPELINE_ID}-i7/7"
+    yum_repo_version="pipeline-${DD_PIPELINE_ID}-i7/7"
 
     RPM_GPG_KEYS=("DATADOG_RPM_KEY_CURRENT.public" "DATADOG_RPM_KEY_B01082D3.public" "DATADOG_RPM_KEY_FD4BF915.public" "DATADOG_RPM_KEY_E09422B3.public")
     separator='\n       '
@@ -113,7 +113,7 @@ elif [ "${OS}" = "RedHat" ]; then
     $sudo_cmd yum -y install datadog-installer
 elif [ "${OS}" = "SUSE" ]; then
     yum_url="yumtesting.datad0g.com/suse/testing"
-    yum_repo_version="${DD_PIPELINE_ID}-i7/7"
+    yum_repo_version="pipeline-${DD_PIPELINE_ID}-i7/7"
 
     RPM_GPG_KEYS=("DATADOG_RPM_KEY_CURRENT.public" "DATADOG_RPM_KEY_B01082D3.public" "DATADOG_RPM_KEY_FD4BF915.public" "DATADOG_RPM_KEY_E09422B3.public")
     separator='\n       '


### PR DESCRIPTION
What does this PR do?
---------------------

Same as https://github.com/DataDog/test-infra-definitions/pull/845 but without breaking everything this time. 

The `pipeline-` is ONLY in the struct, not everywhere like I originally did.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
