### PR TITLE
Use CopyFile in the CopyInlineFile to avoid encoding issues

### DIFF
--- a/components/command/osCommand.go
+++ b/components/command/osCommand.go
@@ -19,13 +19,6 @@ type OSCommand interface {
 		useSudo bool,
 		opts ...pulumi.ResourceOption) (*remote.Command, error)
 
-	CopyInlineFile(
-		runner *Runner,
-		fileContent pulumi.StringInput,
-		remotePath string,
-		useSudo bool,
-		opts ...pulumi.ResourceOption) (*remote.Command, error)
-
 	BuildCommandString(
 		command pulumi.StringInput,
 		env pulumi.StringMap,
@@ -35,7 +28,7 @@ type OSCommand interface {
 
 	IsPathAbsolute(path string) bool
 
-	NewCopyFile(runner *Runner, localPath, remotePath string, opts ...pulumi.ResourceOption) (*remote.CopyFile, error)
+	NewCopyFile(runner *Runner, name string, localPath, remotePath pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error)
 }
 
 // ------------------------------
@@ -63,25 +56,6 @@ func createDirectory(
 		}, opts...)
 }
 
-func copyInlineFile(
-	name string,
-	runner *Runner,
-	fileContent pulumi.StringInput,
-	useSudo bool,
-	createCmd string,
-	deleteCmd string,
-	opts ...pulumi.ResourceOption,
-) (*remote.Command, error) {
-	return runner.Command(runner.namer.ResourceName("copy-file", name),
-		&Args{
-			Create:   pulumi.String(createCmd),
-			Delete:   pulumi.String(deleteCmd),
-			Stdin:    fileContent,
-			Sudo:     useSudo,
-			Triggers: pulumi.Array{pulumi.String(createCmd), fileContent, pulumi.BoolPtr(useSudo)},
-		}, opts...)
-}
-
 func buildCommandString(
 	command pulumi.StringInput,
 	envVars pulumi.StringArray,
@@ -101,16 +75,16 @@ func buildCommandString(
 func copyRemoteFile(
 	runner *Runner,
 	name string,
-	createCommand string,
-	deleteCommand string,
+	createCommand pulumi.StringInput,
+	deleteCommand pulumi.StringInput,
 	useSudo bool,
 	opts ...pulumi.ResourceOption,
 ) (*remote.Command, error) {
 	return runner.Command(name,
 		&Args{
-			Create:   pulumi.String(createCommand),
-			Delete:   pulumi.String(deleteCommand),
+			Create:   createCommand,
+			Delete:   deleteCommand,
 			Sudo:     useSudo,
-			Triggers: pulumi.Array{pulumi.String(createCommand), pulumi.String(deleteCommand), pulumi.BoolPtr(useSudo)},
+			Triggers: pulumi.Array{createCommand, deleteCommand, pulumi.BoolPtr(useSudo)},
 		}, opts...)
 }

--- a/components/command/runner.go
+++ b/components/command/runner.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+
 	"github.com/pulumi/pulumi-command/sdk/go/command/local"
 	"github.com/pulumi/pulumi-command/sdk/go/command/remote"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -108,8 +109,8 @@ func (r *Runner) Command(name string, args *Args, opts ...pulumi.ResourceOption)
 	return remote.NewCommand(r.e.Ctx(), r.namer.ResourceName("cmd", name), args.toRemoteCommandArgs(r.config, r.osCommand), utils.MergeOptions(r.options, opts...)...)
 }
 
-func (r *Runner) NewCopyFile(localPath, remotePath string, opts ...pulumi.ResourceOption) (*remote.CopyFile, error) {
-	return r.osCommand.NewCopyFile(r, localPath, remotePath, opts...)
+func (r *Runner) NewCopyFile(name string, localPath, remotePath pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error) {
+	return r.osCommand.NewCopyFile(r, name, localPath, remotePath, opts...)
 }
 
 type LocalRunner struct {

--- a/components/command/unixOSCommand.go
+++ b/components/command/unixOSCommand.go
@@ -2,9 +2,10 @@ package command
 
 import (
 	"fmt"
-	"github.com/DataDog/test-infra-definitions/common/utils"
 	"path/filepath"
 	"strings"
+
+	"github.com/DataDog/test-infra-definitions/common/utils"
 
 	"github.com/alessio/shellescape"
 	"github.com/pulumi/pulumi-command/sdk/go/command/remote"
@@ -44,21 +45,6 @@ func (unixOSCommand) CreateDirectory(
 		opts...)
 }
 
-func (unixOSCommand) CopyInlineFile(
-	runner *Runner,
-	fileContent pulumi.StringInput,
-	remotePath string,
-	useSudo bool,
-	opts ...pulumi.ResourceOption,
-) (*remote.Command, error) {
-	backupPath := remotePath + "." + backupExtension
-	backupCmd := fmt.Sprintf("if [ -f '%v' ]; then mv -f '%v' '%v'; fi", remotePath, remotePath, backupPath)
-	createCmd := fmt.Sprintf("bash -c '(%v) && cat - | tee %v > /dev/null'", backupCmd, remotePath)
-	deleteCmd := fmt.Sprintf("bash -c 'if [ -f '%v' ]; then mv -f '%v' '%v'; else rm -f '%v'; fi'", backupPath, backupPath, remotePath, remotePath)
-	opts = append(opts, pulumi.ReplaceOnChanges([]string{"*"}), pulumi.DeleteBeforeReplace(true))
-	return copyInlineFile(remotePath, runner, fileContent, useSudo, createCmd, deleteCmd, opts...)
-}
-
 func (fs unixOSCommand) GetTemporaryDirectory() string {
 	return linuxTempDir
 }
@@ -86,26 +72,28 @@ func (fs unixOSCommand) IsPathAbsolute(path string) bool {
 	return strings.HasPrefix(path, "/")
 }
 
-func (fs unixOSCommand) NewCopyFile(runner *Runner, localPath, remotePath string, opts ...pulumi.ResourceOption) (*remote.CopyFile, error) {
-	tempRemotePath := filepath.Join(runner.osCommand.GetTemporaryDirectory(), filepath.Base(localPath))
+func (fs unixOSCommand) NewCopyFile(runner *Runner, name string, localPath, remotePath pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error) {
+	tempRemotePath := localPath.ToStringOutput().ApplyT(func(path string) string {
+		return filepath.Join(runner.osCommand.GetTemporaryDirectory(), filepath.Base(path))
+	}).(pulumi.StringOutput)
 
-	tempCopyFile, err := remote.NewCopyFile(runner.e.Ctx(), runner.namer.ResourceName("copy-", remotePath), &remote.CopyFileArgs{
+	tempCopyFile, err := remote.NewCopyFile(runner.e.Ctx(), runner.namer.ResourceName("copy", name), &remote.CopyFileArgs{
 		Connection: runner.config.connection,
-		LocalPath:  pulumi.String(localPath),
-		RemotePath: pulumi.String(tempRemotePath),
-		Triggers:   pulumi.Array{pulumi.String(localPath), pulumi.String(tempRemotePath)},
+		LocalPath:  localPath,
+		RemotePath: tempRemotePath,
+		Triggers:   pulumi.Array{localPath, tempRemotePath},
 	}, utils.MergeOptions(runner.options, opts...)...)
 
 	if err != nil {
 		return nil, err
 	}
 
-	_, err = fs.copyRemoteFile(runner, tempRemotePath, remotePath, true, utils.PulumiDependsOn(tempCopyFile))
+	moveCommand, err := fs.moveRemoteFile(runner, name, tempRemotePath, remotePath, true, utils.PulumiDependsOn(tempCopyFile))
 	if err != nil {
 		return nil, err
 	}
 
-	return tempCopyFile, err
+	return moveCommand, err
 }
 
 func formatCommandIfNeeded(command pulumi.StringInput, sudo bool, password bool, user string) pulumi.StringInput {
@@ -129,10 +117,10 @@ func formatCommandIfNeeded(command pulumi.StringInput, sudo bool, password bool,
 	return formattedCommand
 }
 
-func (fs unixOSCommand) copyRemoteFile(runner *Runner, source string, destination string, sudo bool, opts ...pulumi.ResourceOption) (*remote.Command, error) {
-	backupPath := destination + "." + backupExtension
-	copyCommand := fmt.Sprintf(`cp '%v' '%v'`, source, destination)
-	createCommand := fmt.Sprintf(`bash -c 'if [ -f '%v' ]; then mv -f '%v' '%v'; fi; %v'`, destination, destination, backupPath, copyCommand)
-	deleteCommand := fmt.Sprintf(`bash -c 'if [ -f '%v' ]; then mv -f '%v' '%v'; else rm -f '%v'; fi'`, backupPath, backupPath, destination, destination)
-	return copyRemoteFile(runner, fmt.Sprintf("copy-file-%s", filepath.Base(source)), createCommand, deleteCommand, sudo, opts...)
+func (fs unixOSCommand) moveRemoteFile(runner *Runner, name string, source, destination pulumi.StringInput, sudo bool, opts ...pulumi.ResourceOption) (*remote.Command, error) {
+	backupPath := pulumi.Sprintf("%v.%s", destination, backupExtension)
+	copyCommand := pulumi.Sprintf(`cp '%v' '%v'`, source, destination)
+	createCommand := pulumi.Sprintf(`bash -c 'if [ -f '%v' ]; then mv -f '%v' '%v'; fi; %v'`, destination, destination, backupPath, copyCommand)
+	deleteCommand := pulumi.Sprintf(`bash -c 'if [ -f '%v' ]; then mv -f '%v' '%v'; else rm -f '%v'; fi'`, backupPath, backupPath, destination, destination)
+	return copyRemoteFile(runner, fmt.Sprintf("move-file-%s", name), createCommand, deleteCommand, sudo, opts...)
 }

--- a/components/command/windowsOSCommand.go
+++ b/components/command/windowsOSCommand.go
@@ -2,8 +2,9 @@ package command
 
 import (
 	"fmt"
-	"github.com/DataDog/test-infra-definitions/common/utils"
 	"strings"
+
+	"github.com/DataDog/test-infra-definitions/common/utils"
 
 	"github.com/pulumi/pulumi-command/sdk/go/command/remote"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -33,25 +34,6 @@ func (fs windowsOSCommand) CreateDirectory(
 		fmt.Sprintf("if (-not (Test-Path -Path %v/*)) { Remove-Item -Path %v -ErrorAction SilentlyContinue }", remotePath, remotePath),
 		useSudo,
 		opts...)
-}
-
-func (fs windowsOSCommand) CopyInlineFile(
-	runner *Runner,
-	fileContent pulumi.StringInput,
-	remotePath string,
-	useSudo bool,
-	opts ...pulumi.ResourceOption,
-) (*remote.Command, error) {
-	backupPath := remotePath + "." + backupExtension
-	backupCmd := fmt.Sprintf("if (Test-Path -Path '%v') { Move-Item -Force -Path '%v' -Destination '%v'}", remotePath, remotePath, backupPath)
-	createCmd := fmt.Sprintf(`%v; [System.Console]::In.ReadToEnd() | Out-File -FilePath '%v'`, backupCmd, remotePath)
-
-	deleteMoveCmd := fmt.Sprintf(`Move-Item -Force -Path '%v' -Destination '%v'`, backupPath, remotePath)
-	deleteRemoveCmd := fmt.Sprintf(`Remove-Item -Force -Path '%v'`, remotePath)
-	deleteCmd := fmt.Sprintf("if (Test-Path -Path '%v') { %v } else { %v }", backupPath, deleteMoveCmd, deleteRemoveCmd)
-	// If the file was previously created, make sure to delete it before creating it.
-	opts = append(opts, pulumi.ReplaceOnChanges([]string{"*"}), pulumi.DeleteBeforeReplace(true))
-	return copyInlineFile(remotePath, runner, fileContent, useSudo, createCmd, deleteCmd, opts...)
 }
 
 func (fs windowsOSCommand) GetTemporaryDirectory() string {
@@ -96,11 +78,11 @@ func (fs windowsOSCommand) IsPathAbsolute(path string) bool {
 	return false
 }
 
-func (fs windowsOSCommand) NewCopyFile(runner *Runner, localPath, remotePath string, opts ...pulumi.ResourceOption) (*remote.CopyFile, error) {
-	return remote.NewCopyFile(runner.e.Ctx(), runner.namer.ResourceName("copy", remotePath), &remote.CopyFileArgs{
+func (fs windowsOSCommand) NewCopyFile(runner *Runner, name string, localPath, remotePath pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error) {
+	return remote.NewCopyFile(runner.e.Ctx(), runner.namer.ResourceName("copy", name), &remote.CopyFileArgs{
 		Connection: runner.config.connection,
-		LocalPath:  pulumi.String(localPath),
-		RemotePath: pulumi.String(remotePath),
-		Triggers:   pulumi.Array{pulumi.String(localPath), pulumi.String(remotePath)},
+		LocalPath:  localPath,
+		RemotePath: remotePath,
+		Triggers:   pulumi.Array{localPath, remotePath},
 	}, utils.MergeOptions(runner.options, opts...)...)
 }

--- a/components/docker/component.go
+++ b/components/docker/component.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"fmt"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/DataDog/test-infra-definitions/common/config"
@@ -77,7 +78,7 @@ func (d *Manager) ComposeFileUp(composeFilePath string, opts ...pulumi.ResourceO
 	}
 	remoteComposePath := path.Join(tempDirPath, path.Base(composeFilePath))
 
-	copyCmd, err := d.Host.OS.FileManager().CopyFile(composeFilePath, remoteComposePath, utils.MergeOptions(opts, utils.PulumiDependsOn(tempCmd))...)
+	copyCmd, err := d.Host.OS.FileManager().CopyFile(filepath.Base(composeFilePath), pulumi.String(composeFilePath), pulumi.String(remoteComposePath), utils.MergeOptions(opts, utils.PulumiDependsOn(tempCmd))...)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +110,6 @@ func (d *Manager) ComposeStrUp(name string, composeManifests []ComposeInlineMani
 		writeCommand, err := d.Host.OS.FileManager().CopyInlineFile(
 			manifest.Content,
 			remoteComposePath,
-			false,
 			utils.MergeOptions(d.opts, utils.PulumiDependsOn(homeCmd))...,
 		)
 		if err != nil {

--- a/components/kubernetes/kind.go
+++ b/components/kubernetes/kind.go
@@ -68,7 +68,7 @@ func NewKindCluster(env config.Env, vm *remote.Host, resourceName, kindClusterNa
 		clusterConfigFilePath := fmt.Sprintf("/tmp/kind-cluster-%s.yaml", kindClusterName)
 		clusterConfig, err := vm.OS.FileManager().CopyInlineFile(
 			pulumi.String(kindClusterConfig),
-			clusterConfigFilePath, false, opts...)
+			clusterConfigFilePath, opts...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
What does this PR do?
---------------------

Adds back https://github.com/DataDog/test-infra-definitions/pull/876 but fixed (hopefully)

Which scenarios this will impact?
-------------------

Motivation
----------

The `NewCopyFile` function on Linux should return the `moveCommand` and not the file, otherwise we can have dependency issue because the move might not be performed at the right time. Problem comes from [here](https://github.com/DataDog/test-infra-definitions/pull/830/files#diff-a2991ec5fe72aebc0781d75f5795f6dc572224ceeed0250a1ec809ab3ca9e1b6R103)

Additional Notes
----------------
