### PR TITLE
[Auto-bump PR] Use commit range with list rather than just changes

### DIFF
--- a/tasks/ci.py
+++ b/tasks/ci.py
@@ -21,7 +21,7 @@ def create_bump_pr_and_close_stale_ones_on_datadog_agent(ctx, branch: str, new_c
 This PR was automatically created by the test-infra-definitions bump task.
 
 This PR bumps the test-infra-definitions submodule to {new_commit_sha} from {old_commit_sha}.
-Here is the full changelog between the two commits: https://github.com/DataDog/test-infra-definitions/compare/{old_commit_sha}..{new_commit_sha}
+Here is the full changelog between the two commits: https://github.com/DataDog/test-infra-definitions/compare/{old_commit_sha}...{new_commit_sha}
 
 :warning: This PR is opened with the `qa/no-code-change` and `changelog/no-changelog` labels by default. Please make sure this is appropriate
     """


### PR DESCRIPTION
What does this PR do?
---------------------
Update the workflow opening bump PRs to show PR range with commit list + changes rather than just changes.

| Before | After |
|--------|--------|
| ![image](https://github.com/DataDog/test-infra-definitions/assets/23154723/fa3f35e0-6d17-481f-93b3-e401563cad4f) | ![image](https://github.com/DataDog/test-infra-definitions/assets/23154723/9681f34b-3933-4a20-9672-7ece963fd8d4) |




Which scenarios this will impact?
-------------------

Motivation
----------
It's just better 😄

Additional Notes
----------------
