### PR TITLE
Use `DeleteBeforeReplace` when moving files in `CopyFile`

### DIFF
--- a/components/command/unixOSCommand.go
+++ b/components/command/unixOSCommand.go
@@ -122,5 +122,5 @@ func (fs unixOSCommand) moveRemoteFile(runner *Runner, name string, source, dest
 	copyCommand := pulumi.Sprintf(`cp '%v' '%v'`, source, destination)
 	createCommand := pulumi.Sprintf(`bash -c 'if [ -f '%v' ]; then mv -f '%v' '%v'; fi; %v'`, destination, destination, backupPath, copyCommand)
 	deleteCommand := pulumi.Sprintf(`bash -c 'if [ -f '%v' ]; then mv -f '%v' '%v'; else rm -f '%v'; fi'`, backupPath, backupPath, destination, destination)
-	return copyRemoteFile(runner, fmt.Sprintf("move-file-%s", name), createCommand, deleteCommand, sudo, opts...)
+	return copyRemoteFile(runner, fmt.Sprintf("move-file-%s", name), createCommand, deleteCommand, sudo, utils.MergeOptions(opts, pulumi.DeleteBeforeReplace(true))...)
 }


### PR DESCRIPTION
What does this PR do?
---------------------

Use `DeleteBeforeReplace` when moving files

Which scenarios this will impact?
-------------------

Motivation
----------

Currently when we create a file that does not exist remotely, we:
1. Backup the file existing file (if any), 
2. Move the file

When we try to replace a file that already exists we use a `replace`, which runs the `deleteCommand`, which brings back the backup file after moving the new file to the location. So in the end we get the exact same content for this file.

Additional Notes
----------------
