### PR TITLE
Restart the Agent after the config files are replaced

### DIFF
--- a/components/command/unixOSCommand.go
+++ b/components/command/unixOSCommand.go
@@ -122,5 +122,5 @@ func (fs unixOSCommand) moveRemoteFile(runner *Runner, name string, source, dest
 	copyCommand := pulumi.Sprintf(`cp '%v' '%v'`, source, destination)
 	createCommand := pulumi.Sprintf(`bash -c 'if [ -f '%v' ]; then mv -f '%v' '%v'; fi; %v'`, destination, destination, backupPath, copyCommand)
 	deleteCommand := pulumi.Sprintf(`bash -c 'if [ -f '%v' ]; then mv -f '%v' '%v'; else rm -f '%v'; fi'`, backupPath, backupPath, destination, destination)
-	return copyRemoteFile(runner, fmt.Sprintf("move-file-%s", name), createCommand, deleteCommand, sudo, utils.MergeOptions(opts, pulumi.DeleteBeforeReplace(true))...)
+	return copyRemoteFile(runner, fmt.Sprintf("move-file-%s", name), createCommand, deleteCommand, sudo, utils.MergeOptions(opts, pulumi.ReplaceOnChanges([]string{"*"}), pulumi.DeleteBeforeReplace(true))...)
 }

--- a/components/command/unixOSCommand.go
+++ b/components/command/unixOSCommand.go
@@ -88,7 +88,7 @@ func (fs unixOSCommand) NewCopyFile(runner *Runner, name string, localPath, remo
 		return nil, err
 	}
 
-	moveCommand, err := fs.moveRemoteFile(runner, name, tempRemotePath, remotePath, true, utils.PulumiDependsOn(tempCopyFile))
+	moveCommand, err := fs.moveRemoteFile(runner, name, tempRemotePath, remotePath, true, utils.MergeOptions(opts, utils.PulumiDependsOn(tempCopyFile))...)
 	if err != nil {
 		return nil, err
 	}
@@ -122,5 +122,5 @@ func (fs unixOSCommand) moveRemoteFile(runner *Runner, name string, source, dest
 	copyCommand := pulumi.Sprintf(`cp '%v' '%v'`, source, destination)
 	createCommand := pulumi.Sprintf(`bash -c 'if [ -f '%v' ]; then mv -f '%v' '%v'; fi; %v'`, destination, destination, backupPath, copyCommand)
 	deleteCommand := pulumi.Sprintf(`bash -c 'if [ -f '%v' ]; then mv -f '%v' '%v'; else rm -f '%v'; fi'`, backupPath, backupPath, destination, destination)
-	return copyRemoteFile(runner, fmt.Sprintf("move-file-%s", name), createCommand, deleteCommand, sudo, utils.MergeOptions(opts, pulumi.DeleteBeforeReplace(true))...)
+	return copyRemoteFile(runner, fmt.Sprintf("move-file-%s", name), createCommand, deleteCommand, sudo, utils.MergeOptions(opts, pulumi.ReplaceOnChanges([]string{"*"}), pulumi.DeleteBeforeReplace(true))...)
 }

--- a/components/command/unixOSCommand.go
+++ b/components/command/unixOSCommand.go
@@ -122,5 +122,5 @@ func (fs unixOSCommand) moveRemoteFile(runner *Runner, name string, source, dest
 	copyCommand := pulumi.Sprintf(`cp '%v' '%v'`, source, destination)
 	createCommand := pulumi.Sprintf(`bash -c 'if [ -f '%v' ]; then mv -f '%v' '%v'; fi; %v'`, destination, destination, backupPath, copyCommand)
 	deleteCommand := pulumi.Sprintf(`bash -c 'if [ -f '%v' ]; then mv -f '%v' '%v'; else rm -f '%v'; fi'`, backupPath, backupPath, destination, destination)
-	return copyRemoteFile(runner, fmt.Sprintf("move-file-%s", name), createCommand, deleteCommand, sudo, utils.MergeOptions(opts, pulumi.ReplaceOnChanges([]string{"*"}), pulumi.DeleteBeforeReplace(true))...)
+	return copyRemoteFile(runner, fmt.Sprintf("move-file-%s", name), createCommand, deleteCommand, sudo, utils.MergeOptions(opts, pulumi.DeleteBeforeReplace(true))...)
 }

--- a/components/datadog/agent/host.go
+++ b/components/datadog/agent/host.go
@@ -157,21 +157,6 @@ func (h *HostAgent) updateConfig(
 
 	configFullPath := path.Join(h.manager.getAgentConfigFolder(), configPath)
 
-	// Restart the agent when a config file is replaced
-	// See longer comment in `installAgent` for more details
-	restartCmd, err := h.manager.restartAgentServices(
-		func(name string, args command.Args) (string, command.Args) {
-			args.Triggers = pulumi.Array{configContent}
-			args.Delete = args.Create
-			args.Create = nil
-			return name + "-on-file-replace-" + configPath, args
-		})
-	if err != nil {
-		return nil, err
-	}
-
-	opts = utils.MergeOptions(opts, utils.PulumiDependsOn(restartCmd))
-
 	copyCmd, err := h.Host.OS.FileManager().CopyInlineFile(configContent, configFullPath, opts...)
 	if err != nil {
 		return nil, err

--- a/components/datadog/agent/host.go
+++ b/components/datadog/agent/host.go
@@ -157,6 +157,21 @@ func (h *HostAgent) updateConfig(
 
 	configFullPath := path.Join(h.manager.getAgentConfigFolder(), configPath)
 
+	// Restart the agent when a config file is replaced
+	// See longer comment in `installAgent` for more details
+	restartCmd, err := h.manager.restartAgentServices(
+		func(name string, args command.Args) (string, command.Args) {
+			args.Triggers = pulumi.Array{configContent}
+			args.Delete = args.Create
+			args.Create = nil
+			return name + "-on-file-replace-" + configPath, args
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	opts = utils.MergeOptions(opts, utils.PulumiDependsOn(restartCmd))
+
 	copyCmd, err := h.Host.OS.FileManager().CopyInlineFile(configContent, configFullPath, opts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
What does this PR do?
---------------------

1. Restart the Agent after the config files are replaced, adding the `Host` as a dependency
2. Use `ReplaceOnChanges` when moving files

Which scenarios this will impact?
-------------------

Mostly those using `UpdateEnv`

Motivation
----------

If we do not add the Host as a dependency (coming from the `opts`) so the Host will wait for the file to be moved to be done, and the Agent in turn will wait for the Host to be done


Additional Notes
----------------

Tested locally with: 

- `aws-vault exec sso-agent-sandbox-account-admin -- deva -e new-e2e-tests.run --targets ./tests/process --run TestLinuxTestSuite/TestProcessDiscoveryCheck`
```
--- PASS: TestLinuxTestSuite (373.21s)
    --- PASS: TestLinuxTestSuite/TestProcessDiscoveryCheck (37.73s)
PASS
ok      github.com/DataDog/datadog-agent/test/new-e2e/tests/process     375.384s

DONE 2 tests in 383.704s
```

- `aws-vault exec sso-agent-sandbox-account-admin -- deva -e new-e2e-tests.run --targets ./tests/process`
```
--- PASS: TestLinuxTestSuite (1371.04s)
    --- PASS: TestLinuxTestSuite/TestManualProcessCheck (1.55s)
    --- PASS: TestLinuxTestSuite/TestManualProcessCheckWithIO (62.35s)
    --- PASS: TestLinuxTestSuite/TestManualProcessDiscoveryCheck (213.53s)
    --- PASS: TestLinuxTestSuite/TestProcessCheck (16.06s)
    --- PASS: TestLinuxTestSuite/TestProcessCheckWithIO (46.91s)
    --- PASS: TestLinuxTestSuite/TestProcessChecksInCoreAgent (169.20s)
    --- PASS: TestLinuxTestSuite/TestProcessChecksInCoreAgentWithNPM (107.73s)
    --- PASS: TestLinuxTestSuite/TestProcessChecksWithNPM (287.18s)
    --- PASS: TestLinuxTestSuite/TestProcessDiscoveryCheck (162.81s)
=== RUN   TestWindowsTestSuite
--- PASS: TestWindowsTestSuite (869.80s)
    --- PASS: TestWindowsTestSuite/TestManualProcessCheck (3.86s)
    --- SKIP: TestWindowsTestSuite/TestManualProcessCheckWithIO (0.00s)
    --- PASS: TestWindowsTestSuite/TestManualProcessDiscoveryCheck (3.50s)
    --- PASS: TestWindowsTestSuite/TestProcessCheck (17.61s)
    --- PASS: TestWindowsTestSuite/TestProcessCheckIO (59.92s)
    --- PASS: TestWindowsTestSuite/TestProcessDiscoveryCheck (97.75s)
PASS
ok      github.com/DataDog/datadog-agent/test/new-e2e/tests/process     2243.081s
DONE 17 tests, 1 skipped in 2249.887s
```

- `aws-vault exec sso-agent-sandbox-account-admin -- deva -e new-e2e-tests.run --targets ./tests/agent-shared-components`
```
Using default install path: C:\Program Files\Datadog\Datadog Agent\
    agent_commands.go:176: Waiting for the agent to be ready
--- PASS: TestApiSuite (923.22s)
    --- PASS: TestApiSuite/TestDefaultAgentAPIEndpoints (192.10s)
        --- PASS: TestApiSuite/TestDefaultAgentAPIEndpoints/API_-_version_test (10.19s)
        --- PASS: TestApiSuite/TestDefaultAgentAPIEndpoints/API_-_hostname_test (11.08s)
        --- PASS: TestApiSuite/TestDefaultAgentAPIEndpoints/API_-_health_test (10.20s)
        --- PASS: TestApiSuite/TestDefaultAgentAPIEndpoints/API_-_config_test (10.36s)
        --- PASS: TestApiSuite/TestDefaultAgentAPIEndpoints/API_-_config_list-runtime_test (10.20s)
        --- PASS: TestApiSuite/TestDefaultAgentAPIEndpoints/API_-_jmx_configs_test (10.19s)
        --- PASS: TestApiSuite/TestDefaultAgentAPIEndpoints/API_-_config_check_raw_test (10.22s)
        --- PASS: TestApiSuite/TestDefaultAgentAPIEndpoints/API_-_config_check_test (10.20s)
        --- PASS: TestApiSuite/TestDefaultAgentAPIEndpoints/API_-_flare_test (14.43s)
        --- PASS: TestApiSuite/TestDefaultAgentAPIEndpoints/API_-_secrets_test (10.19s)
        --- PASS: TestApiSuite/TestDefaultAgentAPIEndpoints/API_-_tagger_test (10.20s)
        --- PASS: TestApiSuite/TestDefaultAgentAPIEndpoints/API_-_workloadmeta_test (10.20s)
        --- PASS: TestApiSuite/TestDefaultAgentAPIEndpoints/API_-_metadata_gohai_test (10.26s)
        --- PASS: TestApiSuite/TestDefaultAgentAPIEndpoints/API_-_metadata_v5_test (10.62s)
        --- PASS: TestApiSuite/TestDefaultAgentAPIEndpoints/API_-_metadata_inventory-check_test (10.20s)
        --- PASS: TestApiSuite/TestDefaultAgentAPIEndpoints/API_-_metadata_inventory-agent_test (10.52s)
        --- PASS: TestApiSuite/TestDefaultAgentAPIEndpoints/API_-_metadata_inventory-host_test (10.23s)
        --- PASS: TestApiSuite/TestDefaultAgentAPIEndpoints/API_-_diagnose_test (12.42s)
    --- PASS: TestApiSuite/TestSecretsAgentAPIEndpoints (97.44s)
    --- PASS: TestApiSuite/TestWorkloadMetaAgentAPIEndpoint (278.34s)
PASS
ok      github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-shared-components/api 925.359s
    suite_utils.go:19: Stack up took 42.298843208s
        
Using default install path: C:\Program Files\Datadog\Datadog Agent\
    agent_commands.go:176: Waiting for the agent to be ready
--- PASS: TestWindowsRuntimeSecretSuite (705.29s)
    --- PASS: TestWindowsRuntimeSecretSuite/TestSecretRuntimeAPIKey (110.07s)
--- PASS: TestInventoryAgentSuite (700.37s)
    --- PASS: TestInventoryAgentSuite/TestInventoryAllEnabled (62.96s)
    --- PASS: TestInventoryAgentSuite/TestInventoryDefaultConfig (137.07s)
PASS
ok      github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-shared-components/inventory   708.297s
--- PASS: TestMultiFakeintakeSuite (812.75s)
    --- PASS: TestMultiFakeintakeSuite/TestNSSFailover (375.95s)
PASS
ok      github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-shared-components/forwarder   818.662s
--- PASS: TestConfigRefreshSuite (474.68s)
    --- PASS: TestConfigRefreshSuite/TestConfigRefresh (39.23s)
PASS
ok      github.com/DataDog/datadog-agent/test/new-e2e/tests/agent-shared-components/config-refresh      478.752s
```

After using the local version of test-infra: `go mod edit -replace=github.com/DataDog/test-infra-definitions@v0.0.0-20240613082720-4d4daa6d6bdb=../../../test-infra-definitions`