### PR TITLE
Improve handling of RSA keys in setup.debug

### DIFF
--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -262,10 +262,14 @@ def _pulumi_version(ctx: Context) -> Tuple[str, bool]:
 
 
 def ssh_fingerprint_to_bytes(fingerprint: str) -> bytes:
-    # EXAMPLE: 256 SHA1:41jsg4Z9lgylj6/zmhGxtZ6/qZs testname (ED25519)
-    out = fingerprint.strip().split(' ')[1].split(':')[1]
-    # ssh leaves out padding but python will ignore extra padding so add the missing padding
-    return base64.b64decode(out + '==')
+    out = fingerprint.strip().split(' ')[1].split(':', 1)
+    if ':' in out[1]:
+        # EXAMPLE: 2048 MD5:19:b3:a8:5f:13:7e:b9:d3:6c:75:20:d6:18:7f:e2:1d no comment (RSA)
+        return bytes.fromhex(out[1].replace(':', ''))
+    else:
+        # EXAMPLE: 256 SHA1:41jsg4Z9lgylj6/zmhGxtZ6/qZs testname (ED25519)
+        # ssh leaves out padding but python will ignore extra padding so add the missing padding
+        return base64.b64decode(out[1] + '==')
 
 
 # noqa: because vulture thinks this is unused


### PR DESCRIPTION
What does this PR do?
---------------------
Improve handling of RSA keys in `inv setup.debug` 

Fix `ssh-keygen` output parsing, loop over each line, add additional format.

Add check to ensure `privateKeyPath` and `publicKeyPath` match.

Which scenarios this will impact?
-------------------
N/A

Motivation
----------
RSA keys are required to decrypt Windows/RDP credentials, so the output from `inv setup.debug` should make sense for them.

In `setup.debug` helper, the `in_ssh_agent` method was not looping over the output from `ssh-add -l`, so it was only comparing the fingerprint to the first key in the ssh agent.

Additional Notes
----------------
It doesn't seem possible to match RSA public keys to their AWS counterparts. The SHA1 fingerprint output by `ssh-keygen` does not match the fingerprint provided by AWS for these keys. So I removed the `WARNING` about these keys not being found in aws.