### PR TITLE
[docker] pass dependencies to docker compose command

### DIFF
--- a/components/datadog/agent/docker.go
+++ b/components/datadog/agent/docker.go
@@ -50,7 +50,10 @@ func NewDockerAgent(e config.Env, vm *remoteComp.Host, manager *docker.Manager, 
 		composeContents := []docker.ComposeInlineManifest{dockerAgentComposeManifest(params.FullImagePath, e.AgentAPIKey(), params.AgentServiceEnvironment)}
 		composeContents = append(composeContents, params.ExtraComposeManifests...)
 
-		_, err = manager.ComposeStrUp("agent", composeContents, params.EnvironmentVariables, pulumi.Parent(comp))
+		opts := make([]pulumi.ResourceOption, 0, len(params.PulumiDependsOn)+1)
+		opts = append(opts, params.PulumiDependsOn...)
+		opts = append(opts, pulumi.Parent(comp))
+		_, err = manager.ComposeStrUp("agent", composeContents, params.EnvironmentVariables, opts...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
What does this PR do?
---------------------

Pass dependencies to the agent docker compose command

Which scenarios this will impact?
-------------------

docker

Motivation
----------

updateEnv on docker compose is currently broken by this

Additional Notes
----------------
