### PR TITLE
[gitlab] increase k8s runners resources for integration-testing job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,8 +55,9 @@ integration-testing:
     E2E_PUBLIC_KEY_PATH: /tmp/agent-integration-test-ssh-key.pub
     E2E_PRIVATE_KEY_PATH: /tmp/agent-integration-test-ssh-key
     E2E_KEY_PAIR_NAME: e2e-integration-test-ssh-key
-    KUBERNETES_MEMORY_REQUEST: "6Gi"
-    KUBERNETES_MEMORY_LIMIT: "12Gi"
+    KUBERNETES_MEMORY_REQUEST: 12Gi
+    KUBERNETES_MEMORY_LIMIT: 16Gi
+    KUBERNETES_CPU_REQUEST: 6
 
 release-runner-image:
   stage: release


### PR DESCRIPTION
What does this PR do?
---------------------

Increase resources requirements for integration-testing job on Gitlab, using values in pair with [datadog-agent's e2e.yml](https://github.com/DataDog/datadog-agent/blob/main/.gitlab/e2e/e2e.yml#L100-L102)

Which scenarios this will impact?
-------------------

None

Motivation
----------

[Last execution](https://gitlab.ddbuild.io/DataDog/test-infra-definitions/-/jobs/545159821) failed on main as it was killed because of an [out of memory](https://app.datadoghq.com/notebook/8634161/ci-oom-by-runner?range=5400000&tpl_var_pod_name=runner-sz8g9p6z-project-3345-concurrent-0-nudldpbl&start=1718628294000&live=false) 😢 

Additional Notes
----------------
