### PR TITLE
Do not break sandbox where we do not have load balancers

### DIFF
--- a/resources/aws/environment.go
+++ b/resources/aws/environment.go
@@ -117,6 +117,10 @@ func NewEnvironment(ctx *pulumi.Context, options ...func(*Environment)) (Environ
 	}
 	env.randomSubnets = shuffle.Results
 
+	if len(env.DefaultFakeintakeLBs()) == 0 {
+		return env, nil
+	}
+
 	shuffleLB, err := random.NewRandomInteger(env.Ctx(), env.Namer.ResourceName("rnd-fakeintake"), &random.RandomIntegerArgs{
 		Min: pulumi.Int(0),
 		Max: pulumi.Int(len(env.DefaultFakeintakeLBs()) - 1),


### PR DESCRIPTION
What does this PR do?
---------------------

We have some user still using `sandbox` to create VMs.
We do not maintain load balancer for fakeintake on sandbox so let's not call the code to randomly select one

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
