### PR TITLE
upgrade(VMs): Add AmazonLinux2018 types

### DIFF
--- a/components/os/linux.go
+++ b/components/os/linux.go
@@ -18,24 +18,26 @@ func newLinuxOS(e config.Env, desc Descriptor, runner *command.Runner) OS {
 	case AmazonLinux, AmazonLinuxECS, CentOS:
 		// AL2 is YUM, AL2023 is DNF (but with yum compatibility)
 		os.packageManager = newYumManager(runner)
-		os.serviceManager = newSystemdServiceManager(e, runner)
 
 	case Fedora, RedHat, RockyLinux:
 		os.packageManager = newDnfManager(runner)
-		os.serviceManager = newSystemdServiceManager(e, runner)
 
 	case Debian, Ubuntu:
 		os.packageManager = newAptManager(runner)
-		os.serviceManager = newSystemdServiceManager(e, runner)
 
 	case Suse:
 		os.packageManager = newZypperManager(runner)
-		os.serviceManager = newSystemdServiceManager(e, runner)
 
 	case Unknown, WindowsServer, MacosOS:
 		fallthrough
 	default:
 		panic(fmt.Sprintf("unsupported linux flavor from desc: %+v", desc))
+	}
+
+	if desc.Flavor == AmazonLinux2018.Flavor && desc.Version == AmazonLinux2018.Version {
+		os.serviceManager = newSysvinitServiceManager(e, runner)
+	} else {
+		os.serviceManager = newSystemdServiceManager(e, runner)
 	}
 
 	return os

--- a/components/os/linux_descriptors.go
+++ b/components/os/linux_descriptors.go
@@ -11,6 +11,7 @@ var (
 	AmazonLinuxDefault = AmazonLinux2023
 	AmazonLinux2023    = NewDescriptor(AmazonLinux, "2023")
 	AmazonLinux2       = NewDescriptor(AmazonLinux, "2")
+	AmazonLinux2018    = NewDescriptor(AmazonLinux, "2018")
 
 	AmazonLinuxECSDefault = AmazonLinuxECS2023
 	AmazonLinuxECS2023    = NewDescriptor(AmazonLinuxECS, "2023")

--- a/components/os/linux_servicemanagers.go
+++ b/components/os/linux_servicemanagers.go
@@ -1,6 +1,8 @@
 package os
 
 import (
+	"fmt"
+
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/components/command"
 	"github.com/pulumi/pulumi-command/sdk/go/command/remote"
@@ -21,6 +23,32 @@ func (s *systemdServiceManager) EnsureRestarted(serviceName string, transform co
 	cmdArgs := command.Args{
 		Sudo:   true,
 		Create: pulumi.String("systemctl restart " + serviceName),
+	}
+
+	// If a transform is provided, use it to modify the command name and args
+	if transform != nil {
+		cmdName, cmdArgs = transform(cmdName, cmdArgs)
+	}
+
+	return s.runner.Command(cmdName, &cmdArgs, opts...)
+}
+
+type sysvinitServiceManager struct {
+	e      config.Env
+	runner *command.Runner
+}
+
+func newSysvinitServiceManager(e config.Env, runner *command.Runner) ServiceManager {
+	return &sysvinitServiceManager{e: e, runner: runner}
+}
+
+func (s *sysvinitServiceManager) EnsureRestarted(serviceName string, transform command.Transformer, opts ...pulumi.ResourceOption) (*remote.Command, error) {
+	cmdName := s.e.CommonNamer().ResourceName("running", serviceName)
+	// To the difference of systemctl the restart doesn't work if the service isn't already running
+	// so instead we run a stop command that we allow to fail and then a start command
+	cmdArgs := command.Args{
+		Sudo:   false,
+		Create: pulumi.String(fmt.Sprintf("sudo stop %[1]s; sudo start %[1]s", serviceName)),
 	}
 
 	// If a transform is provided, use it to modify the command name and args

--- a/scenarios/aws/ec2/os_resolver.go
+++ b/scenarios/aws/ec2/os_resolver.go
@@ -97,10 +97,10 @@ func resolveAmazonLinuxAMI(e aws.Environment, osInfo *os.Descriptor) (string, er
 	case os.AmazonLinuxECS2023.Version:
 		paramName = fmt.Sprintf("al2023-ami-kernel-default-%s", osInfo.Architecture)
 	case os.AmazonLinux2018.Version:
-		if osInfo.Architecture == os.ARM64Arch {
-			return "", errors.New("ARM64 is not supported for Amazon Linux 2018")
+		if osInfo.Architecture != os.AMD64Arch {
+			return "", fmt.Errorf("arch %s is not supported for Amazon Linux 2018", osInfo.Architecture)
 		}
-		return "ami-051394ccb12210d6e", nil // Image name: amzn-ami-2018.03.20240131-amazon-ecs-optimized
+		return ec2.SearchAMI(e, "591542846629", "amzn-ami-2018.03.*-amazon-ecs-optimized", string(osInfo.Architecture)) // Community AMI owned by Amazon
 	default:
 		return "", fmt.Errorf("unsupported Amazon Linux version %s", osInfo.Version)
 	}

--- a/scenarios/aws/ec2/os_resolver.go
+++ b/scenarios/aws/ec2/os_resolver.go
@@ -100,7 +100,7 @@ func resolveAmazonLinuxAMI(e aws.Environment, osInfo *os.Descriptor) (string, er
 		if osInfo.Architecture != os.AMD64Arch {
 			return "", fmt.Errorf("arch %s is not supported for Amazon Linux 2018", osInfo.Architecture)
 		}
-		return ec2.SearchAMI(e, "591542846629", "amzn-ami-2018.03.*-amazon-ecs-optimized", string(osInfo.Architecture)) // Community AMI owned by Amazon
+		return ec2.SearchAMI(e, "669783387624", "amzn-ami-2018.03.*-amazon-ecs-optimized", string(osInfo.Architecture))
 	default:
 		return "", fmt.Errorf("unsupported Amazon Linux version %s", osInfo.Version)
 	}


### PR DESCRIPTION
What does this PR do?
---------------------
Adds AmazonLinux2018 VM. That VM runs on SysVInit and not systemd, which is useful to test in E2Es as we are supposed to test it.

Which scenarios this will impact?
-------------------
Installer tests for now, maybe more if users chose to use that VM :)

Motivation
----------
Testing installer + injector on SysVInit scenarii in E2Es

Additional Notes
----------------
Image: https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#ImageDetails:imageId=ami-07541a4f680f1ba8e
