### PR TITLE
[CWS] migrate `cws-centos7` image

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,3 +15,4 @@
 /components/datadog/apps/jmxfetch       @DataDog/agent-metrics-logs
 /components/datadog/apps/logger         @DataDog/agent-metrics-logs
 /components/datadog/apps/tracegen       @DataDog/agent-apm
+/components/datadog/apps/cws            @DataDog/agent-security

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -81,3 +81,7 @@ updates:
     schedule:
       interval: daily
 
+  - package-ecosystem: docker
+    directory: /components/datadog/apps/cws/images/cws-centos7
+    schedule:
+      interval: daily

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,6 +62,8 @@ jobs:
             image: go-httpbin
           - app: npm-tools
             image: npm-tools
+          - app: cws
+            image: cws-centos7
           - app: logger
             image: logger
           - app: jmxfetch

--- a/components/datadog/apps/cws/images/cws-centos7/Dockerfile
+++ b/components/datadog/apps/cws/images/cws-centos7/Dockerfile
@@ -1,0 +1,6 @@
+FROM centos:7
+
+ENV DOCKER_DD_AGENT=yes
+
+RUN mkdir -p /opt/datadog-agent/embedded/bin
+RUN yum -y install xfsprogs e2fsprogs iproute perl


### PR DESCRIPTION
What does this PR do?
---------------------

This PR migrates this image used in the CI of the agent from https://github.com/paulcacheux/cws-buildimages/blob/main/Dockerfile.cws-centos7 to a datadog owned repository.

Which scenarios this will impact?
-------------------

Motivation
----------

The end goal is to use this image in KMT CWS tests.

Additional Notes
----------------
