### PR TITLE
Give an option to disable dual shipping

### DIFF
--- a/components/datadog/agent/kubernetes.go
+++ b/components/datadog/agent/kubernetes.go
@@ -45,6 +45,7 @@ func NewKubernetesAgent(e config.Env, resourceName string, kubeProvider *kuberne
 			AgentFullImagePath:             params.AgentFullImagePath,
 			ClusterAgentFullImagePath:      params.ClusterAgentFullImagePath,
 			DisableLogsContainerCollectAll: params.DisableLogsContainerCollectAll,
+			DualShipping:                   params.DualShipping,
 		}, params.PulumiResourceOptions...)
 		if err != nil {
 			return err

--- a/components/datadog/agent/kubernetes.go
+++ b/components/datadog/agent/kubernetes.go
@@ -45,7 +45,7 @@ func NewKubernetesAgent(e config.Env, resourceName string, kubeProvider *kuberne
 			AgentFullImagePath:             params.AgentFullImagePath,
 			ClusterAgentFullImagePath:      params.ClusterAgentFullImagePath,
 			DisableLogsContainerCollectAll: params.DisableLogsContainerCollectAll,
-			DualShipping:                   params.DualShipping,
+			DisableDualShipping:            params.DisableDualShipping,
 		}, params.PulumiResourceOptions...)
 		if err != nil {
 			return err

--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -551,7 +551,7 @@ func (values HelmValues) configureFakeintake(e config.Env, fakeintake *fakeintak
 		if _, found := values[section].(pulumi.Map)["env"]; !found {
 			values[section].(pulumi.Map)["env"] = endpointsEnvVar
 		} else {
-			values[section].(pulumi.Map)["env"] = append(values[section].(pulumi.Map)["env"].(pulumi.StringMapArray), additionalEndpointsEnvVar...)
+			values[section].(pulumi.Map)["env"] = append(values[section].(pulumi.Map)["env"].(pulumi.StringMapArray), endpointsEnvVar...)
 		}
 	}
 }

--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -39,8 +39,8 @@ type HelmInstallationArgs struct {
 	ClusterAgentFullImagePath string
 	// DisableLogsContainerCollectAll is used to disable the collection of logs from all containers by default
 	DisableLogsContainerCollectAll bool
-	// DualShipping is used to enable dual-shipping
-	DualShipping bool
+	// DisableDualShipping is used to disable dual-shipping
+	DisableDualShipping bool
 }
 
 type HelmComponent struct {
@@ -131,7 +131,7 @@ func NewHelmInstallation(e config.Env, args HelmInstallationArgs, opts ...pulumi
 
 	values := buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentImagePath, clusterAgentImageTag, randomClusterAgentToken.Result, !args.DisableLogsContainerCollectAll)
 	values.configureImagePullSecret(imgPullSecret)
-	values.configureFakeintake(e, args.Fakeintake, args.DualShipping)
+	values.configureFakeintake(e, args.Fakeintake, !args.DisableDualShipping)
 
 	defaultYAMLValues := values.toYAMLPulumiAssetOutput()
 
@@ -161,7 +161,7 @@ func NewHelmInstallation(e config.Env, args HelmInstallationArgs, opts ...pulumi
 	if args.DeployWindows {
 		values := buildWindowsHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentImagePath, clusterAgentImageTag)
 		values.configureImagePullSecret(imgPullSecret)
-		values.configureFakeintake(e, args.Fakeintake, args.DualShipping)
+		values.configureFakeintake(e, args.Fakeintake, !args.DisableDualShipping)
 		defaultYAMLValues := values.toYAMLPulumiAssetOutput()
 
 		var windowsValuesYAML pulumi.AssetOrArchiveArray

--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -145,7 +145,6 @@ func NewHelmInstallation(e config.Env, args HelmInstallationArgs, opts ...pulumi
 		InstallName: linuxInstallName,
 		Namespace:   args.Namespace,
 		ValuesYAML:  valuesYAML,
-		
 	}, opts...)
 	if err != nil {
 		return nil, err
@@ -520,7 +519,7 @@ func (values HelmValues) configureFakeintake(e config.Env, fakeintake *fakeintak
 			},
 		}
 	} else {
-		endpointsEnvVar = pulumi.StringMapArray{	
+		endpointsEnvVar = pulumi.StringMapArray{
 			pulumi.StringMap{
 				"name":  pulumi.String("DD_DD_URL"),
 				"value": pulumi.Sprintf("%s", fakeintake.URL),
@@ -546,6 +545,8 @@ func (values HelmValues) configureFakeintake(e config.Env, fakeintake *fakeintak
 				"value": pulumi.String("true"),
 			},
 		}
+	}
+
 	for _, section := range []string{"datadog", "clusterAgent", "clusterChecksRunner"} {
 		if _, found := values[section].(pulumi.Map)["env"]; !found {
 			values[section].(pulumi.Map)["env"] = endpointsEnvVar

--- a/components/datadog/kubernetesagentparams/params.go
+++ b/components/datadog/kubernetesagentparams/params.go
@@ -48,13 +48,16 @@ type Params struct {
 	DeployWindows bool
 	// DisableLogsContainerCollectAll is a flag to disable collection of logs from all containers by default.
 	DisableLogsContainerCollectAll bool
+	// DualShipping is a flag to enable dual shipping.
+	DualShipping bool
 }
 
 type Option = func(*Params) error
 
 func NewParams(e config.Env, options ...Option) (*Params, error) {
 	version := &Params{
-		Namespace: defaultAgentNamespace,
+		Namespace:    defaultAgentNamespace,
+		DualShipping: true,
 	}
 
 	if e.PipelineID() != "" && e.CommitSHA() != "" {
@@ -127,6 +130,15 @@ func WithFakeintake(fakeintake *fakeintake.Fakeintake) func(*Params) error {
 func WithoutLogsContainerCollectAll() func(*Params) error {
 	return func(p *Params) error {
 		p.DisableLogsContainerCollectAll = true
+		return nil
+	}
+}
+
+// WithoutDualShipping disables dual shipping. By default the agent is configured to send data to ddev and to the fakeintake.
+// With that flag data will be sent only to the fakeintake.
+func WithoutDualShipping() func(*Params) error {
+	return func(p *Params) error {
+		p.DualShipping = false
 		return nil
 	}
 }

--- a/components/datadog/kubernetesagentparams/params.go
+++ b/components/datadog/kubernetesagentparams/params.go
@@ -49,15 +49,14 @@ type Params struct {
 	// DisableLogsContainerCollectAll is a flag to disable collection of logs from all containers by default.
 	DisableLogsContainerCollectAll bool
 	// DualShipping is a flag to enable dual shipping.
-	DualShipping bool
+	DisableDualShipping bool
 }
 
 type Option = func(*Params) error
 
 func NewParams(e config.Env, options ...Option) (*Params, error) {
 	version := &Params{
-		Namespace:    defaultAgentNamespace,
-		DualShipping: true,
+		Namespace: defaultAgentNamespace,
 	}
 
 	if e.PipelineID() != "" && e.CommitSHA() != "" {
@@ -138,7 +137,7 @@ func WithoutLogsContainerCollectAll() func(*Params) error {
 // With that flag data will be sent only to the fakeintake.
 func WithoutDualShipping() func(*Params) error {
 	return func(p *Params) error {
-		p.DualShipping = false
+		p.DisableDualShipping = true
 		return nil
 	}
 }


### PR DESCRIPTION
What does this PR do?
---------------------

Add an option to disable dual shipping on Kubernetes tests.
Most of the time using dual shipping is fine but for some specific tests (process ones for example) it can be an issue if the agent take into account the response from the backend

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
