### PR TITLE
rollback pulumi-aws to v6.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.51.3
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/google/gofuzz v1.2.0
-	github.com/pulumi/pulumi-aws/sdk/v6 v6.42.0
+	github.com/pulumi/pulumi-aws/sdk/v6 v6.25.0
 	github.com/pulumi/pulumi-awsx/sdk/v2 v2.5.0
 	github.com/pulumi/pulumi-azure-native-sdk/compute/v2 v2.30.0
 	github.com/pulumi/pulumi-azure-native-sdk/containerservice/v2 v2.30.0

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231 h1:vkHw5I/plNdTr435
 github.com/pulumi/appdash v0.0.0-20231130102222-75f619a67231/go.mod h1:murToZ2N9hNJzewjHBgfFdXhZKjY3z5cYC1VXk+lbFE=
 github.com/pulumi/esc v0.9.1 h1:HH5eEv8sgyxSpY5a8yePyqFXzA8cvBvapfH8457+mIs=
 github.com/pulumi/esc v0.9.1/go.mod h1:oEJ6bOsjYlQUpjf70GiX+CXn3VBmpwFDxUTlmtUN84c=
-github.com/pulumi/pulumi-aws/sdk/v6 v6.42.0 h1:Ef/inZd5Q17PwrgwnUC9lNBHZPgyRTzzI6mxtcCj0K0=
-github.com/pulumi/pulumi-aws/sdk/v6 v6.42.0/go.mod h1:F7kTFr3hCyMxKGjPSHtbdFnZdRqgXW+t6bIlOBF6Org=
+github.com/pulumi/pulumi-aws/sdk/v6 v6.25.0 h1:KstWR3AnkXD72ow0xxOzsAkihF+KdzddapHUy0CK2mU=
+github.com/pulumi/pulumi-aws/sdk/v6 v6.25.0/go.mod h1:Ar4SJq3jbKLps3879H5ZvwUt/VnFp/GKbWw1mhjeQek=
 github.com/pulumi/pulumi-awsx/sdk/v2 v2.5.0 h1:sCzgswv1p7G8RUkvUjDgDnrdi7vBRxTtA8Hwtoqabsc=
 github.com/pulumi/pulumi-awsx/sdk/v2 v2.5.0/go.mod h1:lv+hzv8kilWjMNOPcJS8cddJa51d3IdCOPY7cNd2NuU=
 github.com/pulumi/pulumi-azure-native-sdk/compute/v2 v2.30.0 h1:Zv5fc3sEUpTJs6CKGgq15p/V+qcpehPyBV0gt/v4Hjk=

--- a/integration-tests/invoke_test.go
+++ b/integration-tests/invoke_test.go
@@ -33,7 +33,6 @@ func TestInvokes(t *testing.T) {
 	t.Run("invoke-docker-vm", func(t *testing.T) {
 		testInvokeDockerVM(t, tmpConfigFile)
 	})
-
 	t.Run("invoke-kind", func(t *testing.T) {
 		testInvokeKind(t, tmpConfigFile)
 	})
@@ -43,7 +42,7 @@ func testInvokeVM(t *testing.T, tmpConfigFile string) {
 	t.Helper()
 	stackName := fmt.Sprintf("invoke-vm-%s", os.Getenv("CI_PIPELINE_ID"))
 	t.Log("creating vm")
-	createCmd := exec.Command("invoke", "create-vm", "--no-interactive", "--stack-name", stackName, "--no-use-aws-vault", "--config-path", tmpConfigFile)
+	createCmd := exec.Command("invoke", "create-vm", "--no-interactive", "--stack-name", stackName, "--no-use-aws-vault", "--config-path", tmpConfigFile, "--use-fakeintake")
 	createOutput, err := createCmd.Output()
 	assert.NoError(t, err, "Error found creating vm: %s", string(createOutput))
 
@@ -59,7 +58,7 @@ func testInvokeDockerVM(t *testing.T, tmpConfigFile string) {
 	t.Log("creating vm with docker")
 	var stdOut, stdErr bytes.Buffer
 
-	createCmd := exec.Command("invoke", "create-docker", "--no-interactive", "--stack-name", stackName, "--no-use-aws-vault", "--config-path", tmpConfigFile)
+	createCmd := exec.Command("invoke", "create-docker", "--no-interactive", "--stack-name", stackName, "--no-use-aws-vault", "--config-path", tmpConfigFile, "--use-fakeintake", "--use-loadBalancer")
 	createCmd.Stdout = &stdOut
 	createCmd.Stderr = &stdErr
 	err := createCmd.Run()
@@ -84,7 +83,7 @@ func testInvokeKind(t *testing.T, tmpConfigFile string) {
 	}
 	stackName := strings.Join(stackParts, "-")
 	t.Log("creating kind cluster")
-	createCmd := exec.Command("invoke", "create-kind", "--no-interactive", "--stack-name", stackName, "--no-use-aws-vault", "--config-path", tmpConfigFile)
+	createCmd := exec.Command("invoke", "create-kind", "--no-interactive", "--stack-name", stackName, "--no-use-aws-vault", "--config-path", tmpConfigFile, "--use-fakeintake", "--use-loadBalancer")
 	createOutput, err := createCmd.Output()
 	assert.NoError(t, err, "Error found creating kind cluster: %s", string(createOutput))
 


### PR DESCRIPTION
What does this PR do?
---------------------

Rollback `pulumi-aws` dependency

Which scenarios this will impact?
-------------------

All

Motivation
----------

The bump is breaking the `fakeintake` deployment on [e2e tests](https://github.com/DataDog/datadog-agent/pull/27159) 

Additional Notes
----------------

Added `fakeintake` deployment to integration tests. They will run longer, but will early catch such issues
