### PR TITLE
[centos] use custom CentOS 7 AMI

### DIFF
--- a/scenarios/aws/ec2/os_resolver.go
+++ b/scenarios/aws/ec2/os_resolver.go
@@ -192,7 +192,7 @@ func resolveCentOSAMI(e aws.Environment, osInfo *os.Descriptor) (string, error) 
 	}
 
 	if osInfo.Version == "7" {
-		return "ami-0db0376aef6830be3", nil
+		return "ami-036de472bb001ae9c", nil
 	}
 
 	return ec2.SearchAMI(e, "679593333241", fmt.Sprintf("CentOS-%s-*-*.x86_64*", osInfo.Version), string(osInfo.Architecture))

--- a/scenarios/aws/ec2/os_resolver.go
+++ b/scenarios/aws/ec2/os_resolver.go
@@ -191,6 +191,10 @@ func resolveCentOSAMI(e aws.Environment, osInfo *os.Descriptor) (string, error) 
 		osInfo.Version = os.CentOSDefault.Version
 	}
 
+	if osInfo.Version == "7" {
+		return "ami-0db0376aef6830be3", nil
+	}
+
 	return ec2.SearchAMI(e, "679593333241", fmt.Sprintf("CentOS-%s-*-*.x86_64*", osInfo.Version), string(osInfo.Architecture))
 }
 


### PR DESCRIPTION
What does this PR do?
---------------------

use hardcoded AMI for CentOS 7, using the custom Datadog AMI

Which scenarios this will impact?
-------------------

VM

Motivation
----------

incident-28477

CentOS 7 is EOL, using a custom image with the correct mirrorlist

Additional Notes
----------------
