### PR TITLE
increase integration-tests job resources to run it in parallel

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,9 +55,9 @@ integration-testing:
     E2E_PUBLIC_KEY_PATH: /tmp/agent-integration-test-ssh-key.pub
     E2E_PRIVATE_KEY_PATH: /tmp/agent-integration-test-ssh-key
     E2E_KEY_PAIR_NAME: e2e-integration-test-ssh-key
-    KUBERNETES_MEMORY_REQUEST: 12Gi
-    KUBERNETES_MEMORY_LIMIT: 16Gi
-    KUBERNETES_CPU_REQUEST: 6
+    KUBERNETES_MEMORY_REQUEST: 24Gi
+    KUBERNETES_MEMORY_LIMIT: 30Gi
+    KUBERNETES_CPU_REQUEST: 12
 
 release-runner-image:
   stage: release

--- a/integration-tests/config.go
+++ b/integration-tests/config.go
@@ -1,0 +1,64 @@
+package tests
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config instance contains ConfigParams and StackParams
+type Config struct {
+	ConfigParams ConfigParams                 `yaml:"configParams"`
+	StackParams  map[string]map[string]string `yaml:"stackParams"`
+}
+
+// ConfigParams instance contains config relayed parameters
+type ConfigParams struct {
+	AWS       AWS    `yaml:"aws"`
+	Agent     Agent  `yaml:"agent"`
+	OutputDir string `yaml:"outputDir"`
+	Pulumi    Pulumi `yaml:"pulumi"`
+	DevMode   string `yaml:"devMode"`
+}
+
+// AWS instance contains AWS related parameters
+type AWS struct {
+	Account            string `yaml:"account"`
+	KeyPairName        string `yaml:"keyPairName"`
+	PublicKeyPath      string `yaml:"publicKeyPath"`
+	PrivateKeyPath     string `yaml:"privateKeyPath"`
+	PrivateKeyPassword string `yaml:"privateKeyPassword"`
+	TeamTag            string `yaml:"teamTag"`
+}
+
+// Agent instance contains agent related parameters
+type Agent struct {
+	APIKey              string `yaml:"apiKey"`
+	APPKey              string `yaml:"appKey"`
+	VerifyCodeSignature string `yaml:"verifyCodeSignature"`
+}
+
+// Pulumi instance contains pulumi related parameters
+type Pulumi struct {
+	// Sets the log level for Pulumi operations
+	// Be careful setting this value, as it can expose sensitive information in the logs.
+	// https://www.pulumi.com/docs/support/troubleshooting/#verbose-logging
+	LogLevel string `yaml:"logLevel"`
+	// By default pulumi logs to /tmp, and creates symlinks to the most recent log, e.g. /tmp/pulumi.INFO
+	// Set this option to true to log to stderr instead.
+	// https://www.pulumi.com/docs/support/troubleshooting/#verbose-logging
+	LogToStdErr string `yaml:"logToStdErr"`
+	// To reduce logs noise in the CI, by default we display only the Pulumi error progress steam.
+	// Set this option to true to display all the progress streams.
+	VerboseProgressStreams string `yaml:"verboseProgressStreams"`
+}
+
+func LoadConfig(path string) (Config, error) {
+	config := Config{}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, err
+	}
+	err = yaml.Unmarshal(content, &config)
+	return config, err
+}

--- a/integration-tests/invoke_test.go
+++ b/integration-tests/invoke_test.go
@@ -28,12 +28,15 @@ func TestInvokes(t *testing.T) {
 
 	// Subtests
 	t.Run("invoke-vm", func(t *testing.T) {
+		t.Parallel()
 		testInvokeVM(t, tmpConfigFile)
 	})
 	t.Run("invoke-docker-vm", func(t *testing.T) {
+		t.Parallel()
 		testInvokeDockerVM(t, tmpConfigFile)
 	})
 	t.Run("invoke-kind", func(t *testing.T) {
+		t.Parallel()
 		testInvokeKind(t, tmpConfigFile)
 	})
 }

--- a/integration-tests/invoke_test.go
+++ b/integration-tests/invoke_test.go
@@ -20,7 +20,10 @@ func TestInvokes(t *testing.T) {
 	t.Log("Creating temporary configuration file")
 	tmpConfigFile, err := createTemporaryConfigurationFile()
 	require.NoError(t, err, "Error writing temporary configuration")
-	defer os.Remove(tmpConfigFile)
+	t.Cleanup(func() {
+		t.Log("Cleaning up temporary configuration file")
+		os.Remove(tmpConfigFile)
+	})
 
 	t.Log("setup test infra")
 	err = setupTestInfra(tmpConfigFile)
@@ -33,12 +36,15 @@ func TestInvokes(t *testing.T) {
 
 	// Subtests
 	t.Run("invoke-vm", func(t *testing.T) {
+		t.Parallel()
 		testInvokeVM(t, tmpConfigFile)
 	})
 	t.Run("invoke-docker-vm", func(t *testing.T) {
+		t.Parallel()
 		testInvokeDockerVM(t, tmpConfigFile)
 	})
 	t.Run("invoke-kind", func(t *testing.T) {
+		t.Parallel()
 		testInvokeKind(t, tmpConfigFile)
 	})
 }

--- a/integration-tests/testfixture/config.yaml
+++ b/integration-tests/testfixture/config.yaml
@@ -7,5 +7,9 @@ configParams:
     keyPairName: KEY_PAIR_NAME
     publicKeyPath: PUBLIC_KEY_PATH
     teamTag: test-ci
+  pulumi:
+    logLevel: 1
+    logToStdErr: true
+    verboseProgressStreams: false
 options:
   checkKeyPair: false


### PR DESCRIPTION
What does this PR do?
---------------------

This PR refactors the integration test to allow running it locally and in parallel. It increases the CI resources to avoid OOM during the test. 

Which scenarios this will impact?
-------------------

None

Motivation
----------

This allows to reduce the `test-infra-definitions` pipeline time by half, from ~40 min to ~20 min

Additional Notes
----------------
