### PR TITLE
Enable oom_kill integration in microVMs agent

### DIFF
--- a/scenarios/aws/microVMs/microvms/files/oom_kill.yaml
+++ b/scenarios/aws/microVMs/microvms/files/oom_kill.yaml
@@ -1,0 +1,4 @@
+init_config: {}
+
+instances:
+  - collect_oom_kill: true

--- a/scenarios/aws/microVMs/microvms/files/system-probe.yaml
+++ b/scenarios/aws/microVMs/microvms/files/system-probe.yaml
@@ -2,5 +2,7 @@ system_probe_config:
   enabled: true
   debug_port: 6666
   telemetry_enabled: true
+  enable_oom_kill: true
+
 network_config:
   enabled: true

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -59,6 +59,9 @@ var datadogAgentConfig string
 //go:embed files/system-probe.yaml
 var systemProbeConfig string
 
+//go:embed files/oom_kill.yaml
+var oomKillConfig string
+
 var SSHKeyFileNames = map[string]string{
 	ec2.AMD64Arch: libvirtSSHPrivateKeyX86,
 	ec2.ARM64Arch: libvirtSSHPrivateKeyArm,
@@ -134,7 +137,7 @@ func newMetalInstance(instanceEnv *InstanceEnvironment, name, arch string, m con
 	// In the context of KMT, this agent runs on the host environment. As such,
 	// it has no knowledge of the individual test VMs, other than as processes in the host machine.
 	if awsEnv.AgentDeploy() {
-		_, err := agent.NewHostAgent(awsEnv, awsInstance, agentparams.WithAgentConfig(datadogAgentConfig), agentparams.WithSystemProbeConfig(systemProbeConfig))
+		_, err := agent.NewHostAgent(awsEnv, awsInstance, agentparams.WithAgentConfig(datadogAgentConfig), agentparams.WithSystemProbeConfig(systemProbeConfig), agentparams.WithIntegration("oom_kill", oomKillConfig))
 		if err != nil {
 			awsEnv.Ctx().Log.Warn(fmt.Sprintf("failed to deploy datadog agent on host instance: %v", err), nil)
 		}


### PR DESCRIPTION
What does this PR do?
---------------------

This PR enables the OOM killer integration in the KMT microVMs, so that we can monitor OOM kills due to memory pressure in CI.

Which scenarios this will impact?
-------------------

microVMs

Motivation
----------

Improved visibility into the instances used for CI

Additional Notes
----------------

Validated in https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/38356928
