### PR TITLE
[fakeintake] set the profile

### DIFF
--- a/resources/aws/ecs/client.go
+++ b/resources/aws/ecs/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/DataDog/test-infra-definitions/resources/aws"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
 	awsECS "github.com/aws/aws-sdk-go-v2/service/ecs"
 )
@@ -15,10 +16,12 @@ type Client struct {
 	ctx context.Context
 }
 
-func NewECSClient(ctx context.Context, region string) (*Client, error) {
+func NewECSClient(ctx context.Context, e aws.Environment) (*Client, error) {
 	cfg, err := awsConfig.LoadDefaultConfig(ctx,
-		awsConfig.WithRegion(region),
+		awsConfig.WithRegion(e.Region()),
+		awsConfig.WithSharedConfigProfile(e.Profile()),
 	)
+
 	if err != nil {
 		return nil, err
 	}

--- a/scenarios/aws/fakeintake/fakeintake.go
+++ b/scenarios/aws/fakeintake/fakeintake.go
@@ -103,7 +103,7 @@ func fargateSvcNoLB(e aws.Environment, namer namer.Namer, taskDef *awsxEcs.Farga
 		var ipAddress string
 		err := backoff.Retry(func() error {
 			e.Ctx().Log.Debug("waiting for fakeintake task private ip", nil)
-			ecsClient, err := ecs.NewECSClient(e.Ctx().Context(), e.Region())
+			ecsClient, err := ecs.NewECSClient(e.Ctx().Context(), e)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
What does this PR do?
---------------------

Pass the aws profile to the AWS ECS Client we use to get the fakeintake lb-less URL

Which scenarios this will impact?
-------------------

All scenarios using fakeintake without LB, locally

Motivation
----------

As we introduced the profile in the pulumi aws provider, we don't need anymore to wrap our local calls to invoke tasks with `aws-vault exec ...`. We missed passing the profile to the AWS ECS Client.

Additional Notes
----------------
