### PR TITLE
Preserve already authenticated environments

### DIFF
--- a/resources/aws/environment.go
+++ b/resources/aws/environment.go
@@ -151,6 +151,10 @@ func (e *Environment) Region() string {
 }
 
 func (e *Environment) Profile() string {
+	if os.Getenv("AWS_ACCESS_KEY_ID") != "" && os.Getenv("AWS_SECRET_ACCESS_KEY") != "" {
+		return ""
+	}
+
 	if profile := os.Getenv("AWS_PROFILE"); profile != "" {
 		return profile
 	}


### PR DESCRIPTION
What does this PR do?
---------------------

Preserve already authenticated environments, otherwise we get: 

```
          Error: A Profile was specified along with the environment variables "AWS_ACCESS_KEY_ID" and "AWS_SECRET_ACCESS_KEY". The Profile is now used instead of the environment variable credentials.
```

If we wrap the command in an already authenticated session

Which scenarios this will impact?
-------------------

Motivation
----------

https://github.com/DataDog/test-infra-definitions/pull/917#discussion_r1661043033

Additional Notes
----------------
