### PR TITLE
Enable autoballooning in KMT instances

### DIFF
--- a/scenarios/aws/microVMs/microvms/resources/amd64/domain.xsl
+++ b/scenarios/aws/microVMs/microvms/resources/amd64/domain.xsl
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-  <xsl:output omit-xml-declaration="yes" indent="yes"/>
+    <xsl:output omit-xml-declaration="yes" indent="yes" />
   <xsl:template match="node()|@*">
       <xsl:copy>
-         <xsl:apply-templates select="node()|@*"/>
+            <xsl:apply-templates select="node()|@*" />
       </xsl:copy>
    </xsl:template>
   <xsl:template match="/domain/features">
@@ -16,40 +16,43 @@
   <xsl:template match="/domain/os">
       {cputune}
       <xsl:copy>
-          <xsl:apply-templates select="@*|node()"/>
+            <xsl:apply-templates select="@*|node()" />
       </xsl:copy>
   </xsl:template>
 
   <xsl:template match="/domain/devices/disk">
       <filesystem type='mount' accessmode='passthrough'>
-          <source dir='{sharedFSMount}'/>
-          <target dir='kernel-version-testing'/>
+            <source dir='{sharedFSMount}' />
+            <target dir='kernel-version-testing' />
       </filesystem>
-      <readonly/>
+        <readonly />
       <xsl:copy>
-          <xsl:apply-templates select="@*|node()"/>
+            <xsl:apply-templates select="@*|node()" />
       </xsl:copy>
   </xsl:template>
 
   <xsl:template match="/domain/devices/interface[@type='network']/mac/@address">
       <xsl:attribute name="address">
-          <xsl:value-of select="'{mac}'"/>
+            <xsl:value-of select="'{mac}'" />
       </xsl:attribute>
   </xsl:template>
 
   <xsl:template match="/domain/devices">
     <xsl:copy>
-        <xsl:apply-templates select="node()|@*"/>
+            <xsl:apply-templates select="node()|@*" />
             <xsl:element name ="controller">
                 <xsl:attribute name="type">usb</xsl:attribute>
-            	<xsl:attribute name="model">
-                    <xsl:value-of select="'none'"/>
-            	</xsl:attribute>
+                <xsl:attribute name="model">
+                    <xsl:value-of select="'none'" />
+                </xsl:attribute>
             </xsl:element>
-    </xsl:copy>
-  </xsl:template>
-  <xsl:template match="domain/devices/graphics"/>
-  <xsl:template match="domain/devices/audio"/>
-  <xsl:template match="domain/devices/video"/>
+            <xsl:element name="memballoon">
+                <xsl:attribute name="model">virtio</xsl:attribute>
+                <xsl:attribute name="autodeflate">on</xsl:attribute>
+            </xsl:element>
+        </xsl:copy>
+    </xsl:template>
+    <xsl:template match="domain/devices/graphics" />
+    <xsl:template match="domain/devices/audio" />
+    <xsl:template match="domain/devices/video" />
 </xsl:stylesheet>
-

--- a/scenarios/aws/microVMs/microvms/resources/arm64/domain.xsl
+++ b/scenarios/aws/microVMs/microvms/resources/arm64/domain.xsl
@@ -1,76 +1,77 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-  <xsl:output omit-xml-declaration="yes" indent="yes"/>
+  <xsl:output omit-xml-declaration="yes" indent="yes" />
   <xsl:template match="@firmware" />
 
   <xsl:template match="node()|@*">
-      <xsl:copy>
-         <xsl:apply-templates select="node()|@*"/>
-      </xsl:copy>
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*" />
+    </xsl:copy>
   </xsl:template>
 
   <xsl:template match="/domain/features/pae">
-      <xsl:copy>
-          <xsl:apply-templates select="@* | node()"/>
-      </xsl:copy>
-      <gic version='3'/>
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()" />
+    </xsl:copy>
+    <gic version='3' />
   </xsl:template>
   <xsl:template match="/domain/features">
-       <xsl:copy>
-           <xsl:apply-templates select="@*|node()"/>
-       </xsl:copy>
-       <cpu mode='custom' match='exact'>
-           <model fallback='allow'>host</model>
-       </cpu>
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" />
+    </xsl:copy>
+    <cpu mode='custom' match='exact'>
+      <model fallback='allow'>host</model>
+    </cpu>
   </xsl:template>
 
-  <xsl:template match="/domain/os">
-      {cputune}
-      <xsl:copy>
-          <xsl:apply-templates select="@*|node()"/>
-      </xsl:copy>
+  <xsl:template match="/domain/os"> {cputune} <xsl:copy>
+      <xsl:apply-templates select="@*|node()" />
+    </xsl:copy>
   </xsl:template>
 
   <xsl:template match="/domain/devices/disk">
-      <filesystem type='mount' accessmode='passthrough'>
-          <source dir='{sharedFSMount}'/>
-          <target dir='kernel-version-testing'/>
-      </filesystem>
-      <readonly/>
-      <xsl:copy>
-          <xsl:apply-templates select="@*|node()"/>
-      </xsl:copy>
+    <filesystem type='mount' accessmode='passthrough'>
+      <source dir='{sharedFSMount}' />
+      <target dir='kernel-version-testing' />
+    </filesystem>
+    <readonly />
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" />
+    </xsl:copy>
   </xsl:template>
 
   <xsl:template match="/domain/devices/disk[@type='file']/driver">
-     <readonly/>
-      <xsl:copy>
-          <xsl:apply-templates select="@*|node()"/>
-      </xsl:copy>
+    <readonly />
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" />
+    </xsl:copy>
   </xsl:template>
 
- 
+
   <xsl:template match="/domain/devices/interface[@type='network']/mac/@address">
-      <xsl:attribute name="address">
-          <xsl:value-of select="'{mac}'"/>
-      </xsl:attribute>
+    <xsl:attribute name="address">
+      <xsl:value-of select="'{mac}'" />
+    </xsl:attribute>
   </xsl:template>
 
   <xsl:template match="/domain/devices">
     <xsl:copy>
-        <xsl:apply-templates select="node()|@*"/>
-            <xsl:element name ="controller">
-                <xsl:attribute name="type">usb</xsl:attribute>
-                <xsl:attribute name="model">
-                    <xsl:value-of select="'none'"/>
-                </xsl:attribute>
-            </xsl:element>
+      <xsl:apply-templates select="node()|@*" />
+      <xsl:element name="controller">
+        <xsl:attribute name="type">usb</xsl:attribute>
+        <xsl:attribute name="model">
+          <xsl:value-of select="'none'" />
+        </xsl:attribute>
+      </xsl:element>
+      <xsl:element name="memballoon">
+        <xsl:attribute name="model">virtio</xsl:attribute>
+        <xsl:attribute name="autodeflate">on</xsl:attribute>
+      </xsl:element>
     </xsl:copy>
   </xsl:template>
-  <xsl:template match="features/acpi"/>
-  <xsl:template match="domain/devices/graphics"/>
-  <xsl:template match="domain/devices/audio"/>
-  <xsl:template match="domain/devices/video"/>
+  <xsl:template match="features/acpi" />
+  <xsl:template match="domain/devices/graphics" />
+  <xsl:template match="domain/devices/audio" />
+  <xsl:template match="domain/devices/video" />
 </xsl:stylesheet>
-

--- a/scenarios/aws/microVMs/microvms/resources/distro/domain-amd64.xsl
+++ b/scenarios/aws/microVMs/microvms/resources/distro/domain-amd64.xsl
@@ -1,59 +1,68 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-  <xsl:output omit-xml-declaration="yes" indent="yes"/>
+  <xsl:output omit-xml-declaration="yes" indent="yes" />
   <xsl:template match="node()|@*">
       <xsl:copy>
-         <xsl:apply-templates select="node()|@*"/>
+      <xsl:apply-templates select="node()|@*" />
       </xsl:copy>
    </xsl:template>
   <xsl:template match="/domain/features">
-      <cpu mode='host-passthrough' check='full'/>
-       <clock offset='utc'>                                                                                                                                                                                                                                                            
-           <timer name='rtc' tickpolicy='delay' track='guest'/>                                                                                                                                                                                                                          
-       </clock> 
+    <cpu mode='host-passthrough' check='full' />
+    <clock offset='utc'>
+      <timer name='rtc' tickpolicy='delay' track='guest' />
+    </clock>
   </xsl:template>
 
   <xsl:template match="/domain/os">
       {cputune}
       <xsl:copy>
-          <xsl:apply-templates select="@*|node()"/>
+      <xsl:apply-templates select="@*|node()" />
       </xsl:copy>
   </xsl:template>
 
   <xsl:template match="/domain/devices/disk">
       <filesystem type='mount' accessmode='passthrough'>
-          <source dir='{sharedFSMount}'/>
-          <target dir='kernel-version-testing'/>
+      <source dir='{sharedFSMount}' />
+      <target dir='kernel-version-testing' />
       </filesystem>
       <xsl:copy>
-          <xsl:apply-templates select="@*|node()"/>
+      <xsl:apply-templates select="@*|node()" />
       </xsl:copy>
   </xsl:template>
 
   <xsl:template match="/domain/devices/disk[@type='file']/driver">
-      <readonly/>
+    <readonly />
       <xsl:copy>
-          <xsl:apply-templates select="@*|node()"/>
+      <xsl:apply-templates select="@*|node()" />
       </xsl:copy>
   </xsl:template>
 
   <xsl:template match="/domain/devices/interface[@type='network']/mac/@address">
       <xsl:attribute name="address">
-          <xsl:value-of select="'{mac}'"/>
+      <xsl:value-of select="'{mac}'" />
       </xsl:attribute>
   </xsl:template>
 
   <xsl:template match="/domain/devices/interface[@type='network']/mac">
-      <driver name="vhost" queues="{vcpu}"/>
+    <driver name="vhost" queues="{vcpu}" />
       <xsl:copy>
-          <xsl:apply-templates select="@*|node()"/>
+      <xsl:apply-templates select="@*|node()" />
       </xsl:copy>
   </xsl:template>
 
 
-  <xsl:template match="domain/devices/graphics"/>
-  <xsl:template match="domain/devices/audio"/>
-  <xsl:template match="domain/devices/video"/>
-</xsl:stylesheet>
+  <xsl:template match="domain/devices/graphics" />
+  <xsl:template match="domain/devices/audio" />
+  <xsl:template match="domain/devices/video" />
 
+  <xsl:template match="/domain/devices">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*" />
+      <xsl:element name="memballoon">
+        <xsl:attribute name="model">virtio</xsl:attribute>
+        <xsl:attribute name="autodeflate">on</xsl:attribute>
+      </xsl:element>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/scenarios/aws/microVMs/microvms/resources/distro/domain-arm64.xsl
+++ b/scenarios/aws/microVMs/microvms/resources/distro/domain-arm64.xsl
@@ -85,4 +85,14 @@
     <xsl:template match="domain/devices/graphics" />
     <xsl:template match="domain/devices/audio" />
     <xsl:template match="domain/devices/video" />
+
+    <xsl:template match="/domain/devices">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*" />
+            <xsl:element name="memballoon">
+                <xsl:attribute name="model">virtio</xsl:attribute>
+                <xsl:attribute name="autodeflate">on</xsl:attribute>
+            </xsl:element>
+        </xsl:copy>
+    </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
What does this PR do?
---------------------

This PR enables autoballooning with automatic deflation in KMT VMs. 

Which scenarios this will impact?
-------------------

microVMs

Motivation
----------

Reduce memory usage of the VMs, reducing the chances of out of memory errors.

Additional Notes
----------------

Validated [in the agent](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines?ref=guillermo.julian/kmt-autoballoon), and checked in manual stacks and CI that minimum free memory goes from ~2GB in the worst case to ~10GB with these changes.

This PR also adds indentation to the XSL files.