### PR TITLE
Add a flag to enable dddev-forwarding

### DIFF
--- a/scenarios/aws/fakeintake/params.go
+++ b/scenarios/aws/fakeintake/params.go
@@ -7,6 +7,7 @@ type Params struct {
 	ImageURL            string
 	CPU                 int
 	Memory              int
+	DDDevForwarding     bool
 }
 
 type Option = func(*Params) error
@@ -50,6 +51,13 @@ func WithCPU(cpu int) Option {
 func WithMemory(memory int) Option {
 	return func(p *Params) error {
 		p.Memory = memory
+		return nil
+	}
+}
+
+func WithDDDevForwarding() Option {
+	return func(p *Params) error {
+		p.DDDevForwarding = true
 		return nil
 	}
 }


### PR DESCRIPTION
What does this PR do?
---------------------

Add a flag that allow user to enable fakeintake forwarding payloads to dddev.
In a second time we could make it the default behavior

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
