### PR TITLE
Move the `vulture` config to the `pyproject.toml` file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,9 +23,3 @@ repos:
     rev: 'v2.3'
     hooks:
       - id: vulture
-        args:
-          - --ignore-decorators
-          - "@task"
-          - --ignore-names
-          - 'test_*,Test*'
-          - tasks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,3 +59,8 @@ ban-relative-imports = "all"
 [tool.ruff.format]
 # Enable preview style formatting.
 quote-style = "preserve"
+
+[tool.vulture]
+ignore_decorators = ["@task"]
+ignore_names = ["test_*", "Test*"]
+paths = ["tasks"]


### PR DESCRIPTION
What does this PR do?
---------------------

Move the `vulture` config to the `pyproject.toml` file to make it compatible with IDEs

Which scenarios this will impact?
-------------------

Motivation
----------

Same as https://github.com/DataDog/datadog-agent/pull/26916

Additional Notes
----------------
