### PR TITLE
[gitlab] pre-build pulumi go program

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ Pulumi.*.yaml
 
 # JetBrains IDE
 .idea/
+
+# Build files
+dist/main
+mem.pprof

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,11 +30,30 @@ build-runner-image:
     - docker buildx build --no-cache --pull --push --label target=build --tag ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA} --tag ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHA:0:12} --secret id=github_token,env=GITHUB_TOKEN .
   retry: 2
 
+build-pulumi-go-main:
+  stage: build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:v38375519-53773733
+  tags: ["arch:amd64"]
+  rules:
+    - when: on_success
+  script:
+    - go build -o dist/main -gcflags="all=-c=6" main.go 
+  artifacts:
+    paths:
+      - dist/main
+    expire_in: "1 day"
+  variables:
+    KUBERNETES_MEMORY_REQUEST: 12Gi
+    KUBERNETES_MEMORY_LIMIT: 16Gi
+    KUBERNETES_CPU_REQUEST: 6
 
 integration-testing:
   stage: test
   image: ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA}
   tags: ["arch:amd64"]
+  needs:
+    - build-runner-image
+    - build-pulumi-go-main
   rules:
     - when: on_success
   before_script:
@@ -50,14 +69,12 @@ integration-testing:
     - ssh-add $E2E_PRIVATE_KEY_PATH
     - pip install -r requirements.txt
   script:
-    - go test ./integration-tests -v -timeout 0s
+    # execute test from dist directory to use the generated binary
+    - go test ./integration-tests -v -timeout 0s -workingDir=dist
   variables:
     E2E_PUBLIC_KEY_PATH: /tmp/agent-integration-test-ssh-key.pub
     E2E_PRIVATE_KEY_PATH: /tmp/agent-integration-test-ssh-key
     E2E_KEY_PAIR_NAME: e2e-integration-test-ssh-key
-    KUBERNETES_MEMORY_REQUEST: 24Gi
-    KUBERNETES_MEMORY_LIMIT: 30Gi
-    KUBERNETES_CPU_REQUEST: 12
 
 release-runner-image:
   stage: release

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,6 +69,11 @@ integration-testing:
     - ssh-add $E2E_PRIVATE_KEY_PATH
     - pip install -r requirements.txt
   script:
+    - |
+      if [ ! -f ./dist/main ]; then 
+        echo "no main binary found, please run 'build-pulumi-go-main' job"
+        exit 1
+      fi
     # execute test from dist directory to use the generated binary
     - go test ./integration-tests -v -timeout 0s -workingDir=dist
   variables:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,8 @@
 {
-  "python.linting.enabled": true,
-  "python.analysis.typeCheckingMode": "basic",
-  "python.languageServer": "Pylance",
-  "python.formatting.provider": "black",
-  "python.analysis.diagnosticMode": "workspace",
+  "editor.formatOnSave": true,
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true,
+  },
+  "ruff.configurationPreference": "filesystemFirst",
 }

--- a/dist/Pulumi.yaml
+++ b/dist/Pulumi.yaml
@@ -1,0 +1,8 @@
+name: dd
+runtime:
+  name: go
+  options:
+    binary: main
+description: Generic scenario (check scenario variable)
+config:
+  pulumi:disable-default-providers: ["*"]

--- a/integration-tests/invoke_test.go
+++ b/integration-tests/invoke_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"bytes"
 	_ "embed"
+	"flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -15,7 +16,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var workingDir = flag.String("workingDir", "", "run tests in the specified directory, relative to the root of the repository. Defaults to the root of the repository.")
+
 func TestInvokes(t *testing.T) {
+	// Set working directory
+	rootPath, err := rootPath()
+	require.NoError(t, err)
+	if *workingDir == "" {
+		*workingDir = rootPath
+	}
+	if !filepath.IsAbs(*workingDir) {
+		*workingDir = filepath.Join(rootPath, *workingDir)
+	}
+	t.Logf("Running tests in %s", *workingDir)
+
 	// Arrange
 	t.Log("Creating temporary configuration file")
 	tmpConfigFile, err := createTemporaryConfigurationFile()
@@ -37,40 +51,43 @@ func TestInvokes(t *testing.T) {
 	// Subtests
 	t.Run("invoke-vm", func(t *testing.T) {
 		t.Parallel()
-		testInvokeVM(t, tmpConfigFile)
+		testInvokeVM(t, tmpConfigFile, *workingDir)
 	})
 	t.Run("invoke-docker-vm", func(t *testing.T) {
 		t.Parallel()
-		testInvokeDockerVM(t, tmpConfigFile)
+		testInvokeDockerVM(t, tmpConfigFile, *workingDir)
 	})
 	t.Run("invoke-kind", func(t *testing.T) {
 		t.Parallel()
-		testInvokeKind(t, tmpConfigFile)
+		testInvokeKind(t, tmpConfigFile, *workingDir)
 	})
 }
 
-func testInvokeVM(t *testing.T, tmpConfigFile string) {
+func testInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
 	t.Helper()
 
 	stackName := fmt.Sprintf("invoke-vm-%s", os.Getenv("CI_PIPELINE_ID"))
 	t.Log("creating vm")
 	createCmd := exec.Command("invoke", "create-vm", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake")
+	createCmd.Dir = workingDirectory
 	createOutput, err := createCmd.Output()
 	assert.NoError(t, err, "Error found creating vm: %s", string(createOutput))
 
 	t.Log("destroying vm")
 	destroyCmd := exec.Command("invoke", "destroy-vm", "--yes", "--no-clean-known-hosts", "--stack-name", stackName, "--config-path", tmpConfigFile)
+	destroyCmd.Dir = workingDirectory
 	destroyOutput, err := destroyCmd.Output()
 	require.NoError(t, err, "Error found destroying stack: %s", string(destroyOutput))
 }
 
-func testInvokeDockerVM(t *testing.T, tmpConfigFile string) {
+func testInvokeDockerVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
 	t.Helper()
 	stackName := fmt.Sprintf("invoke-docker-vm-%s", os.Getenv("CI_PIPELINE_ID"))
 	t.Log("creating vm with docker")
 	var stdOut, stdErr bytes.Buffer
 
 	createCmd := exec.Command("invoke", "create-docker", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake", "--use-loadBalancer")
+	createCmd.Dir = workingDirectory
 	createCmd.Stdout = &stdOut
 	createCmd.Stderr = &stdErr
 	err := createCmd.Run()
@@ -81,13 +98,14 @@ func testInvokeDockerVM(t *testing.T, tmpConfigFile string) {
 
 	t.Log("destroying vm with docker")
 	destroyCmd := exec.Command("invoke", "destroy-docker", "--yes", "--stack-name", stackName, "--config-path", tmpConfigFile)
+	destroyCmd.Dir = workingDirectory
 	destroyCmd.Stdout = &stdOut
 	destroyCmd.Stderr = &stdErr
 	err = destroyCmd.Run()
 	require.NoError(t, err, "Error found destroying stack.\n   stdout: %s\n   stderr: %s", stdOut.String(), stdErr.String())
 }
 
-func testInvokeKind(t *testing.T, tmpConfigFile string) {
+func testInvokeKind(t *testing.T, tmpConfigFile string, workingDirectory string) {
 	t.Helper()
 	stackParts := []string{"invoke", "kind"}
 	if os.Getenv("CI") == "true" {
@@ -96,11 +114,13 @@ func testInvokeKind(t *testing.T, tmpConfigFile string) {
 	stackName := strings.Join(stackParts, "-")
 	t.Log("creating kind cluster")
 	createCmd := exec.Command("invoke", "create-kind", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake", "--use-loadBalancer")
+	createCmd.Dir = workingDirectory
 	createOutput, err := createCmd.Output()
 	assert.NoError(t, err, "Error found creating kind cluster: %s", string(createOutput))
 
 	t.Log("destroying kind cluster")
 	destroyCmd := exec.Command("invoke", "destroy-kind", "--yes", "--stack-name", stackName, "--config-path", tmpConfigFile)
+	destroyCmd.Dir = workingDirectory
 	destroyOutput, err := destroyCmd.Output()
 	require.NoError(t, err, "Error found destroying kind cluster: %s", string(destroyOutput))
 }
@@ -149,4 +169,12 @@ func setupTestInfra(tmpConfigFile string) error {
 		return fmt.Errorf("stdout: %s\n%s, %v", setupStdout.String(), setupStderr.String(), err)
 	}
 	return nil
+}
+
+func rootPath() (string, error) {
+	path, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(path)), nil
 }

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -178,9 +178,10 @@ def _deploy(
     global_flags = ""
     up_flags = ""
 
-    # Checking root path
-    root_path = tool._get_root_path()
-    if root_path != os.getcwd():
+    # Check we are in a pulumi project
+    current_path = os.getcwd()
+    root_path = tool.get_root_path()
+    if not os.path.isfile(os.path.join(current_path, "Pulumi.yaml")):
         global_flags += f" -C {root_path}"
 
     # Building run func parameters

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -175,14 +175,11 @@ def _deploy(
     stack_name = tool.get_stack_name(stack_name, flags["scenario"])
     # make sure the stack name is safe
     stack_name = stack_name.replace(" ", "-").lower()
-    global_flags = ""
+    global_flags_array: List[str] = []
     up_flags = ""
 
     # Check we are in a pulumi project
-    current_path = os.getcwd()
-    root_path = tool.get_root_path()
-    if not os.path.isfile(os.path.join(current_path, "Pulumi.yaml")):
-        global_flags += f" -C {root_path}"
+    global_flags_array.append(tool.get_pulumi_dir_flag())
 
     # Building run func parameters
     for key, value in flags.items():
@@ -197,11 +194,12 @@ def _deploy(
         log_to_stderr = debug
     if should_log:
         if log_to_stderr:
-            global_flags += " --logtostderr"
-        global_flags += f" -v {log_level}"
+            global_flags_array.append("--logtostderr")
+        global_flags_array.append(f"-v {log_level}")
         if debug:
             up_flags += " --debug"
 
+    global_flags = " ".join(global_flags_array)
     _create_stack(ctx, stack_name, global_flags)
     cmd = f"pulumi {global_flags} up --yes -s {stack_name} {up_flags}"
 

--- a/tasks/tool.py
+++ b/tasks/tool.py
@@ -145,15 +145,10 @@ def get_stack_name_prefix() -> str:
 
 def get_stack_json_outputs(ctx: Context, full_stack_name: str) -> Any:
     buffer = StringIO()
-    # Check we execute from a pulumi project
-    root_path = get_root_path()
-    current_path = os.getcwd()
-    global_flags = ""
-    if not os.path.isfile(os.path.join(current_path, "Pulumi.yaml")):
-        global_flags += f" -C {root_path}"
 
+    cmd_parts: List[str] = ["pulumi", "stack", "output", "--json", "-s", full_stack_name, get_pulumi_dir_flag()]
     ctx.run(
-        f"pulumi stack output --json -s {full_stack_name}{global_flags}",
+        " ".join(cmd_parts),
         out_stream=buffer,
     )
     return json.loads(buffer.getvalue())
@@ -209,7 +204,17 @@ def notify_windows():
     return
 
 
-def get_root_path() -> str:
+# ensure we run pulumi from a directory with a Pulumi.yaml file
+# defaults to the project root directory
+def get_pulumi_dir_flag():
+    root_path = _get_root_path()
+    current_path = os.getcwd()
+    if not os.path.isfile(os.path.join(current_path, "Pulumi.yaml")):
+        return f"-C {root_path}"
+    return ""
+
+
+def _get_root_path() -> str:
     folder = pathlib.Path(__file__).parent.resolve()
     return str(folder.parent)
 


### PR DESCRIPTION
What does this PR do?
---------------------

* Build `main.go` pulumi program before running integration tests

Which scenarios this will impact?
-------------------

None

Motivation
----------

Running pulumi on the CI requires big runners, both in e2e tests in `datadog-agent` and here when calling invoke tasks to create remote instances, in `integration_tests`. 

@AliDatadog  few months ago noticed how the high mem consumption in e2e tests is requested at compile time. This happens both when running e2e tests in `datadog-agent` and when running integration_tests in test-infra-definitions. 

[I recently added](https://github.com/DataDog/test-infra-definitions/pull/916) `fakeintake` to `integration_tests` as a `pulumi-aws` bump broke its usage in `datadog-agent` e2e tests. This further increased the pipeline time to ~40 minutes, as tests ran sequentially. In an attempt to reduce the CI time here [I ran tests in parallel](https://github.com/DataDog/test-infra-definitions/pull/923). 

The tests run the `inv create-[vm|docker|kind]` tasks: when running concurrently they each build `main.go`, which requires a huge amount of RAM. I increased the `KUBERNETES_MEMORY_LIMIT` to the maximum allowed of `32GB`. 

This got OOM in a [recent PR](https://github.com/DataDog/test-infra-definitions/pull/915) where we add more dependencies.

@KSerrania , @KevinFairise2 and myself investigated what we could do to allow running tests without starving the CI. Building once in a `16GB` runner and then test in // in a `6GB` runner is my suggested solution. 

Additional Notes
----------------
