### PR TITLE
Do not accept DD_API_KEY in microVMs

### DIFF
--- a/scenarios/aws/microVMs/microvms/provision.go
+++ b/scenarios/aws/microVMs/microvms/provision.go
@@ -256,12 +256,8 @@ func provisionRemoteMicroVMs(vmCollections []*VMCollection, instanceEnv *Instanc
 					return nil, err
 				}
 
-				allowEnvDone, err := setupSSHAllowEnv(microRunner, append(readKeyDone, domain.lvDomain))
-				if err != nil {
-					return nil, err
-				}
 
-				reloadSSHDDone, err := reloadSSHD(microRunner, append(allowEnvDone, setDockerDataRootDone...))
+				reloadSSHDDone, err := reloadSSHD(microRunner, append(setDockerDataRootDone...))
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
What does this PR do?
---------------------

Removes `AcceptEnv DD_API_KEY` setting for microVMs to avoid API key leaks.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
