### PR TITLE
[ASCII-1996] Add missing fakeintake config override

### DIFF
--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -246,12 +246,17 @@ network_devices.snmp_traps.forwarder.logs_dd_url: %[1]s:80
 network_devices.snmp_traps.forwarder.logs_no_ssl: true
 network_devices.netflow.forwarder.logs_dd_url: %[1]s:80
 network_devices.netflow.forwarder.logs_no_ssl: true
+network_path.forwarder.logs_dd_url: %[1]s:80
+network_path.forwarder.logs_no_ssl: true
 container_lifecycle.logs_dd_url: %[1]s:80
 container_lifecycle.logs_no_ssl: true
 container_image.logs_dd_url: %[1]s:80
 container_image.logs_no_ssl: true
 sbom.logs_dd_url: %[1]s:80
-sbom.logs_no_ssl: true`, hostname)
+sbom.logs_no_ssl: true
+service_discovery.forwarder.logs_dd_url: %[1]s:80
+service_discovery.forwarder.logs_no_ssl: true
+`, hostname)
 		p.ExtraAgentConfig = append(p.ExtraAgentConfig, extraConfig)
 		return nil
 	}


### PR DESCRIPTION
What does this PR do?
---------------------
Add missing backend endpoints override for fakeintake.

Which scenarios this will impact?
-------------------

Motivation
----------
The `diagnose` e2e test is failing for those two endpoints because the test actually reaches the real backend instead of the fakeintake.

Additional Notes
----------------
