### PR TITLE
Add two tasks to create and destroy VM stacks in Azure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,6 +68,11 @@ integration-testing:
     - chmod 400 $E2E_PRIVATE_KEY_PATH
     - ssh-add $E2E_PRIVATE_KEY_PATH
     - pip install -r requirements.txt
+    - export AZURE_CLIENT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_id --with-decryption --query "Parameter.Value" --out text)
+    - export AZURE_CLIENT_SECRET=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_secret --with-decryption --query "Parameter.Value" --out text)
+    - export AZURE_TENANT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_tenant_id --with-decryption --query "Parameter.Value" --out text)
+    - export AZURE_SUBSCRIPTION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_subscription_id --with-decryption --query "Parameter.Value" --out text)
+    - az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" --tenant "$AZURE_TENANT_ID" > /dev/null
   script:
     - |
       if [ ! -f ./dist/main ]; then 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,6 +57,12 @@ integration-testing:
   rules:
     - when: on_success
   before_script:
+    # Setup Azure credentials
+    - export AZURE_CLIENT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_id --with-decryption --query "Parameter.Value" --out text)
+    - export AZURE_CLIENT_SECRET=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_secret --with-decryption --query "Parameter.Value" --out text)
+    - export AZURE_TENANT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_tenant_id --with-decryption --query "Parameter.Value" --out text)
+    - export AZURE_SUBSCRIPTION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_subscription_id --with-decryption --query "Parameter.Value" --out text)
+    - az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" --tenant "$AZURE_TENANT_ID" > /dev/null
     # Setup AWS Credentials
     - mkdir -p ~/.aws
     - aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.agent-qa-profile --with-decryption --query "Parameter.Value" --out text >> ~/.aws/config
@@ -68,11 +74,6 @@ integration-testing:
     - chmod 400 $E2E_PRIVATE_KEY_PATH
     - ssh-add $E2E_PRIVATE_KEY_PATH
     - pip install -r requirements.txt
-    - export AZURE_CLIENT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_id --with-decryption --query "Parameter.Value" --out text)
-    - export AZURE_CLIENT_SECRET=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_secret --with-decryption --query "Parameter.Value" --out text)
-    - export AZURE_TENANT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_tenant_id --with-decryption --query "Parameter.Value" --out text)
-    - export AZURE_SUBSCRIPTION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_subscription_id --with-decryption --query "Parameter.Value" --out text)
-    - az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" --tenant "$AZURE_TENANT_ID" > /dev/null
   script:
     - |
       if [ ! -f ./dist/main ]; then 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,12 +57,12 @@ integration-testing:
   rules:
     - when: on_success
   before_script:
-    # Setup Azure credentials
-    - export AZURE_CLIENT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_id --with-decryption --query "Parameter.Value" --out text)
-    - export AZURE_CLIENT_SECRET=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_secret --with-decryption --query "Parameter.Value" --out text)
-    - export AZURE_TENANT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_tenant_id --with-decryption --query "Parameter.Value" --out text)
-    - export AZURE_SUBSCRIPTION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_subscription_id --with-decryption --query "Parameter.Value" --out text)
-    - az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" --tenant "$AZURE_TENANT_ID" > /dev/null
+    # Setup Azure credentials. Uncomment once the resources are ready
+#    - export AZURE_CLIENT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_id --with-decryption --query "Parameter.Value" --out text)
+#    - export AZURE_CLIENT_SECRET=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_secret --with-decryption --query "Parameter.Value" --out text)
+#    - export AZURE_TENANT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_tenant_id --with-decryption --query "Parameter.Value" --out text)
+#    - export AZURE_SUBSCRIPTION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_subscription_id --with-decryption --query "Parameter.Value" --out text)
+#    - az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" --tenant "$AZURE_TENANT_ID" > /dev/null
     # Setup AWS Credentials
     - mkdir -p ~/.aws
     - aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.agent-qa-profile --with-decryption --query "Parameter.Value" --out text >> ~/.aws/config

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Available tasks:
   create-docker    Create a docker environment.
   create-ecs       Create a new ECS environment.
   create-eks       Create a new EKS environment. It lasts around 20 minutes.
-  create-vm        Create a new virtual machine on the cloud.
-  destroy-aks      Destroy a AKS environment created with invoke create-aks.
+  aws.create-vm        Create a new virtual machine on the cloud.
+  aws.destroy-aks      Destroy a AKS environment created with invoke create-aks.
   destroy-docker   Destroy an environment created by invoke create_docker.
   destroy-ecs      Destroy a ECS environment created with invoke create-ecs.
   destroy-eks      Destroy a EKS environment created with invoke create-eks.

--- a/README.md
+++ b/README.md
@@ -62,11 +62,14 @@ Available tasks:
   create-docker    Create a docker environment.
   create-ecs       Create a new ECS environment.
   create-eks       Create a new EKS environment. It lasts around 20 minutes.
-  aws.create-vm        Create a new virtual machine on the cloud.
-  aws.destroy-aks      Destroy a AKS environment created with invoke create-aks.
+  aws.create-vm        Create a new virtual machine on aws.
+  az.create-vm        Create a new virtual machine on azure.
+  destroy-aks      Destroy a AKS environment created with invoke create-aks.
   destroy-docker   Destroy an environment created by invoke create_docker.
   destroy-ecs      Destroy a ECS environment created with invoke create-ecs.
   destroy-eks      Destroy a EKS environment created with invoke create-eks.
+  aws.destroy-vm          Destroy a virtual machine on aws.
+  az.destroy-vm          Destroy a virtual machine on azure.
 ```
 
 Run any `-h` on any of the available tasks for more information

--- a/integration-tests/invoke_test.go
+++ b/integration-tests/invoke_test.go
@@ -53,20 +53,21 @@ func TestInvokes(t *testing.T) {
 		t.Parallel()
 		testAzureInvokeVM(t, tmpConfigFile, *workingDir)
 	})
-	//	t.Run("aws.create-vm", func(t *testing.T) {
-	//		t.Parallel()
-	//		testAwsInvokeVM(t, tmpConfigFile, *workingDir)
-	//	})
-	//
-	//	t.Run("invoke-docker-vm", func(t *testing.T) {
-	//		t.Parallel()
-	//		testInvokeDockerVM(t, tmpConfigFile, *workingDir)
-	//	})
-	//
-	//	t.Run("invoke-kind", func(t *testing.T) {
-	//		t.Parallel()
-	//		testInvokeKind(t, tmpConfigFile, *workingDir)
-	//	})
+
+	t.Run("aws.create-vm", func(t *testing.T) {
+		t.Parallel()
+		testAwsInvokeVM(t, tmpConfigFile, *workingDir)
+	})
+
+	t.Run("invoke-docker-vm", func(t *testing.T) {
+		t.Parallel()
+		testInvokeDockerVM(t, tmpConfigFile, *workingDir)
+	})
+
+	t.Run("invoke-kind", func(t *testing.T) {
+		t.Parallel()
+		testInvokeKind(t, tmpConfigFile, *workingDir)
+	})
 }
 
 func testAzureInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
@@ -86,67 +87,67 @@ func testAzureInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory stri
 	require.NoError(t, err, "Error found destroying stack: %s", string(destroyOutput))
 }
 
-//func testAwsInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
-//	t.Helper()
-//
-//	stackName := fmt.Sprintf("aws-invoke-vm-%s", os.Getenv("CI_PIPELINE_ID"))
-//	t.Log("creating vm")
-//	createCmd := exec.Command("invoke", "aws.create-vm", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake")
-//	createCmd.Dir = workingDirectory
-//	createOutput, err := createCmd.Output()
-//	assert.NoError(t, err, "Error found creating vm: %s", string(createOutput))
-//
-//	t.Log("destroying vm")
-//	destroyCmd := exec.Command("invoke", "aws.destroy-vm", "--yes", "--no-clean-known-hosts", "--stack-name", stackName, "--config-path", tmpConfigFile)
-//	destroyCmd.Dir = workingDirectory
-//	destroyOutput, err := destroyCmd.Output()
-//	require.NoError(t, err, "Error found destroying stack: %s", string(destroyOutput))
-//}
-//
-//func testInvokeDockerVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
-//	t.Helper()
-//	stackName := fmt.Sprintf("invoke-docker-vm-%s", os.Getenv("CI_PIPELINE_ID"))
-//	t.Log("creating vm with docker")
-//	var stdOut, stdErr bytes.Buffer
-//
-//	createCmd := exec.Command("invoke", "create-docker", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake", "--use-loadBalancer")
-//	createCmd.Dir = workingDirectory
-//	createCmd.Stdout = &stdOut
-//	createCmd.Stderr = &stdErr
-//	err := createCmd.Run()
-//	assert.NoError(t, err, "Error found creating docker vm.\n   stdout: %s\n   stderr: %s", stdOut.String(), stdErr.String())
-//
-//	stdOut.Reset()
-//	stdErr.Reset()
-//
-//	t.Log("destroying vm with docker")
-//	destroyCmd := exec.Command("invoke", "destroy-docker", "--yes", "--stack-name", stackName, "--config-path", tmpConfigFile)
-//	destroyCmd.Dir = workingDirectory
-//	destroyCmd.Stdout = &stdOut
-//	destroyCmd.Stderr = &stdErr
-//	err = destroyCmd.Run()
-//	require.NoError(t, err, "Error found destroying stack.\n   stdout: %s\n   stderr: %s", stdOut.String(), stdErr.String())
-//}
-//
-//func testInvokeKind(t *testing.T, tmpConfigFile string, workingDirectory string) {
-//	t.Helper()
-//	stackParts := []string{"invoke", "kind"}
-//	if os.Getenv("CI") == "true" {
-//		stackParts = append(stackParts, os.Getenv("CI_PIPELINE_ID"))
-//	}
-//	stackName := strings.Join(stackParts, "-")
-//	t.Log("creating kind cluster")
-//	createCmd := exec.Command("invoke", "create-kind", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake", "--use-loadBalancer")
-//	createCmd.Dir = workingDirectory
-//	createOutput, err := createCmd.Output()
-//	assert.NoError(t, err, "Error found creating kind cluster: %s", string(createOutput))
-//
-//	t.Log("destroying kind cluster")
-//	destroyCmd := exec.Command("invoke", "destroy-kind", "--yes", "--stack-name", stackName, "--config-path", tmpConfigFile)
-//	destroyCmd.Dir = workingDirectory
-//	destroyOutput, err := destroyCmd.Output()
-//	require.NoError(t, err, "Error found destroying kind cluster: %s", string(destroyOutput))
-//}
+func testAwsInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
+	t.Helper()
+
+	stackName := fmt.Sprintf("aws-invoke-vm-%s", os.Getenv("CI_PIPELINE_ID"))
+	t.Log("creating vm")
+	createCmd := exec.Command("invoke", "aws.create-vm", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake")
+	createCmd.Dir = workingDirectory
+	createOutput, err := createCmd.Output()
+	assert.NoError(t, err, "Error found creating vm: %s", string(createOutput))
+
+	t.Log("destroying vm")
+	destroyCmd := exec.Command("invoke", "aws.destroy-vm", "--yes", "--no-clean-known-hosts", "--stack-name", stackName, "--config-path", tmpConfigFile)
+	destroyCmd.Dir = workingDirectory
+	destroyOutput, err := destroyCmd.Output()
+	require.NoError(t, err, "Error found destroying stack: %s", string(destroyOutput))
+}
+
+func testInvokeDockerVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
+	t.Helper()
+	stackName := fmt.Sprintf("invoke-docker-vm-%s", os.Getenv("CI_PIPELINE_ID"))
+	t.Log("creating vm with docker")
+	var stdOut, stdErr bytes.Buffer
+
+	createCmd := exec.Command("invoke", "create-docker", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake", "--use-loadBalancer")
+	createCmd.Dir = workingDirectory
+	createCmd.Stdout = &stdOut
+	createCmd.Stderr = &stdErr
+	err := createCmd.Run()
+	assert.NoError(t, err, "Error found creating docker vm.\n   stdout: %s\n   stderr: %s", stdOut.String(), stdErr.String())
+
+	stdOut.Reset()
+	stdErr.Reset()
+
+	t.Log("destroying vm with docker")
+	destroyCmd := exec.Command("invoke", "destroy-docker", "--yes", "--stack-name", stackName, "--config-path", tmpConfigFile)
+	destroyCmd.Dir = workingDirectory
+	destroyCmd.Stdout = &stdOut
+	destroyCmd.Stderr = &stdErr
+	err = destroyCmd.Run()
+	require.NoError(t, err, "Error found destroying stack.\n   stdout: %s\n   stderr: %s", stdOut.String(), stdErr.String())
+}
+
+func testInvokeKind(t *testing.T, tmpConfigFile string, workingDirectory string) {
+	t.Helper()
+	stackParts := []string{"invoke", "kind"}
+	if os.Getenv("CI") == "true" {
+		stackParts = append(stackParts, os.Getenv("CI_PIPELINE_ID"))
+	}
+	stackName := strings.Join(stackParts, "-")
+	t.Log("creating kind cluster")
+	createCmd := exec.Command("invoke", "create-kind", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake", "--use-loadBalancer")
+	createCmd.Dir = workingDirectory
+	createOutput, err := createCmd.Output()
+	assert.NoError(t, err, "Error found creating kind cluster: %s", string(createOutput))
+
+	t.Log("destroying kind cluster")
+	destroyCmd := exec.Command("invoke", "destroy-kind", "--yes", "--stack-name", stackName, "--config-path", tmpConfigFile)
+	destroyCmd.Dir = workingDirectory
+	destroyOutput, err := destroyCmd.Output()
+	require.NoError(t, err, "Error found destroying kind cluster: %s", string(destroyOutput))
+}
 
 //go:embed testfixture/config.yaml
 var testInfraTestConfig string

--- a/integration-tests/invoke_test.go
+++ b/integration-tests/invoke_test.go
@@ -75,7 +75,7 @@ func testAzureInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory stri
 
 	stackName := fmt.Sprintf("az-invoke-vm-%s", os.Getenv("CI_PIPELINE_ID"))
 	t.Log("creating vm")
-	createCmd := exec.Command("invoke", "az.create-vm", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile)
+	createCmd := exec.Command("invoke", "az.create-vm", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--environment", "az/agent-qa")
 	createCmd.Dir = workingDirectory
 	createOutput, err := createCmd.Output()
 	assert.NoError(t, err, "Error found creating vm: %s", string(createOutput))

--- a/integration-tests/invoke_test.go
+++ b/integration-tests/invoke_test.go
@@ -49,81 +49,104 @@ func TestInvokes(t *testing.T) {
 	require.NotEmpty(t, tmpConfig.ConfigParams.AWS.TeamTag)
 
 	// Subtests
-	t.Run("invoke-vm", func(t *testing.T) {
+	t.Run("az.create-vm", func(t *testing.T) {
 		t.Parallel()
-		testInvokeVM(t, tmpConfigFile, *workingDir)
+		testAzureInvokeVM(t, tmpConfigFile, *workingDir)
 	})
-	t.Run("invoke-docker-vm", func(t *testing.T) {
-		t.Parallel()
-		testInvokeDockerVM(t, tmpConfigFile, *workingDir)
-	})
-	t.Run("invoke-kind", func(t *testing.T) {
-		t.Parallel()
-		testInvokeKind(t, tmpConfigFile, *workingDir)
-	})
+	//	t.Run("aws.create-vm", func(t *testing.T) {
+	//		t.Parallel()
+	//		testAwsInvokeVM(t, tmpConfigFile, *workingDir)
+	//	})
+	//
+	//	t.Run("invoke-docker-vm", func(t *testing.T) {
+	//		t.Parallel()
+	//		testInvokeDockerVM(t, tmpConfigFile, *workingDir)
+	//	})
+	//
+	//	t.Run("invoke-kind", func(t *testing.T) {
+	//		t.Parallel()
+	//		testInvokeKind(t, tmpConfigFile, *workingDir)
+	//	})
 }
 
-func testInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
+func testAzureInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
 	t.Helper()
 
-	stackName := fmt.Sprintf("invoke-vm-%s", os.Getenv("CI_PIPELINE_ID"))
+	stackName := fmt.Sprintf("az-invoke-vm-%s", os.Getenv("CI_PIPELINE_ID"))
 	t.Log("creating vm")
-	createCmd := exec.Command("invoke", "create-vm", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake")
+	createCmd := exec.Command("invoke", "az.create-vm", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile)
 	createCmd.Dir = workingDirectory
 	createOutput, err := createCmd.Output()
 	assert.NoError(t, err, "Error found creating vm: %s", string(createOutput))
 
 	t.Log("destroying vm")
-	destroyCmd := exec.Command("invoke", "destroy-vm", "--yes", "--no-clean-known-hosts", "--stack-name", stackName, "--config-path", tmpConfigFile)
+	destroyCmd := exec.Command("invoke", "az.destroy-vm", "--yes", "--no-clean-known-hosts", "--stack-name", stackName, "--config-path", tmpConfigFile)
 	destroyCmd.Dir = workingDirectory
 	destroyOutput, err := destroyCmd.Output()
 	require.NoError(t, err, "Error found destroying stack: %s", string(destroyOutput))
 }
 
-func testInvokeDockerVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
-	t.Helper()
-	stackName := fmt.Sprintf("invoke-docker-vm-%s", os.Getenv("CI_PIPELINE_ID"))
-	t.Log("creating vm with docker")
-	var stdOut, stdErr bytes.Buffer
-
-	createCmd := exec.Command("invoke", "create-docker", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake", "--use-loadBalancer")
-	createCmd.Dir = workingDirectory
-	createCmd.Stdout = &stdOut
-	createCmd.Stderr = &stdErr
-	err := createCmd.Run()
-	assert.NoError(t, err, "Error found creating docker vm.\n   stdout: %s\n   stderr: %s", stdOut.String(), stdErr.String())
-
-	stdOut.Reset()
-	stdErr.Reset()
-
-	t.Log("destroying vm with docker")
-	destroyCmd := exec.Command("invoke", "destroy-docker", "--yes", "--stack-name", stackName, "--config-path", tmpConfigFile)
-	destroyCmd.Dir = workingDirectory
-	destroyCmd.Stdout = &stdOut
-	destroyCmd.Stderr = &stdErr
-	err = destroyCmd.Run()
-	require.NoError(t, err, "Error found destroying stack.\n   stdout: %s\n   stderr: %s", stdOut.String(), stdErr.String())
-}
-
-func testInvokeKind(t *testing.T, tmpConfigFile string, workingDirectory string) {
-	t.Helper()
-	stackParts := []string{"invoke", "kind"}
-	if os.Getenv("CI") == "true" {
-		stackParts = append(stackParts, os.Getenv("CI_PIPELINE_ID"))
-	}
-	stackName := strings.Join(stackParts, "-")
-	t.Log("creating kind cluster")
-	createCmd := exec.Command("invoke", "create-kind", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake", "--use-loadBalancer")
-	createCmd.Dir = workingDirectory
-	createOutput, err := createCmd.Output()
-	assert.NoError(t, err, "Error found creating kind cluster: %s", string(createOutput))
-
-	t.Log("destroying kind cluster")
-	destroyCmd := exec.Command("invoke", "destroy-kind", "--yes", "--stack-name", stackName, "--config-path", tmpConfigFile)
-	destroyCmd.Dir = workingDirectory
-	destroyOutput, err := destroyCmd.Output()
-	require.NoError(t, err, "Error found destroying kind cluster: %s", string(destroyOutput))
-}
+//func testAwsInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
+//	t.Helper()
+//
+//	stackName := fmt.Sprintf("aws-invoke-vm-%s", os.Getenv("CI_PIPELINE_ID"))
+//	t.Log("creating vm")
+//	createCmd := exec.Command("invoke", "aws.create-vm", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake")
+//	createCmd.Dir = workingDirectory
+//	createOutput, err := createCmd.Output()
+//	assert.NoError(t, err, "Error found creating vm: %s", string(createOutput))
+//
+//	t.Log("destroying vm")
+//	destroyCmd := exec.Command("invoke", "aws.destroy-vm", "--yes", "--no-clean-known-hosts", "--stack-name", stackName, "--config-path", tmpConfigFile)
+//	destroyCmd.Dir = workingDirectory
+//	destroyOutput, err := destroyCmd.Output()
+//	require.NoError(t, err, "Error found destroying stack: %s", string(destroyOutput))
+//}
+//
+//func testInvokeDockerVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
+//	t.Helper()
+//	stackName := fmt.Sprintf("invoke-docker-vm-%s", os.Getenv("CI_PIPELINE_ID"))
+//	t.Log("creating vm with docker")
+//	var stdOut, stdErr bytes.Buffer
+//
+//	createCmd := exec.Command("invoke", "create-docker", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake", "--use-loadBalancer")
+//	createCmd.Dir = workingDirectory
+//	createCmd.Stdout = &stdOut
+//	createCmd.Stderr = &stdErr
+//	err := createCmd.Run()
+//	assert.NoError(t, err, "Error found creating docker vm.\n   stdout: %s\n   stderr: %s", stdOut.String(), stdErr.String())
+//
+//	stdOut.Reset()
+//	stdErr.Reset()
+//
+//	t.Log("destroying vm with docker")
+//	destroyCmd := exec.Command("invoke", "destroy-docker", "--yes", "--stack-name", stackName, "--config-path", tmpConfigFile)
+//	destroyCmd.Dir = workingDirectory
+//	destroyCmd.Stdout = &stdOut
+//	destroyCmd.Stderr = &stdErr
+//	err = destroyCmd.Run()
+//	require.NoError(t, err, "Error found destroying stack.\n   stdout: %s\n   stderr: %s", stdOut.String(), stdErr.String())
+//}
+//
+//func testInvokeKind(t *testing.T, tmpConfigFile string, workingDirectory string) {
+//	t.Helper()
+//	stackParts := []string{"invoke", "kind"}
+//	if os.Getenv("CI") == "true" {
+//		stackParts = append(stackParts, os.Getenv("CI_PIPELINE_ID"))
+//	}
+//	stackName := strings.Join(stackParts, "-")
+//	t.Log("creating kind cluster")
+//	createCmd := exec.Command("invoke", "create-kind", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake", "--use-loadBalancer")
+//	createCmd.Dir = workingDirectory
+//	createOutput, err := createCmd.Output()
+//	assert.NoError(t, err, "Error found creating kind cluster: %s", string(createOutput))
+//
+//	t.Log("destroying kind cluster")
+//	destroyCmd := exec.Command("invoke", "destroy-kind", "--yes", "--stack-name", stackName, "--config-path", tmpConfigFile)
+//	destroyCmd.Dir = workingDirectory
+//	destroyOutput, err := destroyCmd.Output()
+//	require.NoError(t, err, "Error found destroying kind cluster: %s", string(destroyOutput))
+//}
 
 //go:embed testfixture/config.yaml
 var testInfraTestConfig string

--- a/integration-tests/invoke_test.go
+++ b/integration-tests/invoke_test.go
@@ -75,7 +75,7 @@ func testAzureInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory stri
 
 	stackName := fmt.Sprintf("az-invoke-vm-%s", os.Getenv("CI_PIPELINE_ID"))
 	t.Log("creating vm")
-	createCmd := exec.Command("invoke", "az.create-vm", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--environment", "az/agent-qa")
+	createCmd := exec.Command("invoke", "az.create-vm", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--account", "agent-qa")
 	createCmd.Dir = workingDirectory
 	createOutput, err := createCmd.Output()
 	assert.NoError(t, err, "Error found creating vm: %s", string(createOutput))

--- a/integration-tests/invoke_test.go
+++ b/integration-tests/invoke_test.go
@@ -49,10 +49,12 @@ func TestInvokes(t *testing.T) {
 	require.NotEmpty(t, tmpConfig.ConfigParams.AWS.TeamTag)
 
 	// Subtests
-	t.Run("az.create-vm", func(t *testing.T) {
-		t.Parallel()
-		testAzureInvokeVM(t, tmpConfigFile, *workingDir)
-	})
+
+	// Uncomment once the resources will be created
+	//t.Run("az.create-vm", func(t *testing.T) {
+	//	t.Parallel()
+	//	testAzureInvokeVM(t, tmpConfigFile, *workingDir)
+	//})
 
 	t.Run("aws.create-vm", func(t *testing.T) {
 		t.Parallel()
@@ -70,22 +72,22 @@ func TestInvokes(t *testing.T) {
 	})
 }
 
-func testAzureInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
-	t.Helper()
-
-	stackName := fmt.Sprintf("az-invoke-vm-%s", os.Getenv("CI_PIPELINE_ID"))
-	t.Log("creating vm")
-	createCmd := exec.Command("invoke", "az.create-vm", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--account", "agent-qa")
-	createCmd.Dir = workingDirectory
-	createOutput, err := createCmd.Output()
-	assert.NoError(t, err, "Error found creating vm: %s", string(createOutput))
-
-	t.Log("destroying vm")
-	destroyCmd := exec.Command("invoke", "az.destroy-vm", "--yes", "--no-clean-known-hosts", "--stack-name", stackName, "--config-path", tmpConfigFile)
-	destroyCmd.Dir = workingDirectory
-	destroyOutput, err := destroyCmd.Output()
-	require.NoError(t, err, "Error found destroying stack: %s", string(destroyOutput))
-}
+//func testAzureInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
+//	t.Helper()
+//
+//	stackName := fmt.Sprintf("az-invoke-vm-%s", os.Getenv("CI_PIPELINE_ID"))
+//	t.Log("creating vm")
+//	createCmd := exec.Command("invoke", "az.create-vm", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--account", "agent-qa")
+//	createCmd.Dir = workingDirectory
+//	createOutput, err := createCmd.Output()
+//	assert.NoError(t, err, "Error found creating vm: %s", string(createOutput))
+//
+//	t.Log("destroying vm")
+//	destroyCmd := exec.Command("invoke", "az.destroy-vm", "--yes", "--no-clean-known-hosts", "--stack-name", stackName, "--config-path", tmpConfigFile)
+//	destroyCmd.Dir = workingDirectory
+//	destroyOutput, err := destroyCmd.Output()
+//	require.NoError(t, err, "Error found destroying stack: %s", string(destroyOutput))
+//}
 
 func testAwsInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
 	t.Helper()

--- a/resources/azure/environment.go
+++ b/resources/azure/environment.go
@@ -50,6 +50,7 @@ func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
 		DisablePulumiPartnerId: pulumi.BoolPtr(true),
 		SubscriptionId:         pulumi.StringPtr(env.envDefault.azure.subscriptionID),
 		TenantId:               pulumi.StringPtr(env.envDefault.azure.tenantID),
+		Location:               pulumi.StringPtr(env.envDefault.azure.location),
 	})
 	if err != nil {
 		return Environment{}, err

--- a/resources/azure/environmentDefaults.go
+++ b/resources/azure/environmentDefaults.go
@@ -50,7 +50,7 @@ func sandboxDefault() environmentDefault {
 			defaultVNet:            "/subscriptions/9972cab2-9e99-419b-a683-86bfa77b3df1/resourceGroups/dd-agent-sandbox/providers/Microsoft.Network/virtualNetworks/dd-agent-sandbox",
 			defaultSubnet:          "/subscriptions/9972cab2-9e99-419b-a683-86bfa77b3df1/resourceGroups/dd-agent-sandbox/providers/Microsoft.Network/virtualNetworks/dd-agent-sandbox/subnets/dd-agent-sandbox-private",
 			defaultSecurityGroup:   "/subscriptions/9972cab2-9e99-419b-a683-86bfa77b3df1/resourceGroups/dd-agent-sandbox/providers/Microsoft.Network/networkSecurityGroups/appgategreen",
-			defaultInstanceType:    "Standard_D4s_v5",  // Allows nested virtualization for kata runtimes
+			defaultInstanceType:    "Standard_D2a_v4",  // Allows nested virtualization for kata runtimes
 			defaultARMInstanceType: "Standard_D4ps_v5", // No azure arm instance supports nested virtualization
 			aks: ddInfraAks{
 				linuxKataNodeGroup: true,

--- a/resources/azure/environmentDefaults.go
+++ b/resources/azure/environmentDefaults.go
@@ -1,7 +1,7 @@
 package azure
 
 const (
-	sandboxEnv = "az/sandbox"
+	sandboxEnv = "az/agent-sandbox"
 )
 
 type environmentDefault struct {
@@ -12,6 +12,7 @@ type environmentDefault struct {
 type azureProvider struct {
 	tenantID       string
 	subscriptionID string
+	location       string
 }
 
 type ddInfra struct {
@@ -40,14 +41,15 @@ func getEnvironmentDefault(envName string) environmentDefault {
 func sandboxDefault() environmentDefault {
 	return environmentDefault{
 		azure: azureProvider{
-			tenantID:       "4d3bac44-0230-4732-9e70-cc00736f0a97",
-			subscriptionID: "8c56d827-5f07-45ce-8f2b-6c5001db5c6f",
+			tenantID:       "cc0b82f3-7c2e-400b-aec3-40a3d720505b",
+			subscriptionID: "9972cab2-9e99-419b-a683-86bfa77b3df1",
+			location:       "West US 2",
 		},
 		ddInfra: ddInfra{
-			defaultResourceGroup:   "datadog-agent-testing",
-			defaultVNet:            "/subscriptions/8c56d827-5f07-45ce-8f2b-6c5001db5c6f/resourceGroups/datadog-agent-testing/providers/Microsoft.Network/virtualNetworks/default-vnet",
-			defaultSubnet:          "/subscriptions/8c56d827-5f07-45ce-8f2b-6c5001db5c6f/resourceGroups/datadog-agent-testing/providers/Microsoft.Network/virtualNetworks/default-vnet/subnets/default-subnet",
-			defaultSecurityGroup:   "/subscriptions/8c56d827-5f07-45ce-8f2b-6c5001db5c6f/resourceGroups/datadog-agent-testing/providers/Microsoft.Network/networkSecurityGroups/default",
+			defaultResourceGroup:   "dd-agent-sandbox",
+			defaultVNet:            "/subscriptions/9972cab2-9e99-419b-a683-86bfa77b3df1/resourceGroups/dd-agent-sandbox/providers/Microsoft.Network/virtualNetworks/dd-agent-sandbox",
+			defaultSubnet:          "/subscriptions/9972cab2-9e99-419b-a683-86bfa77b3df1/resourceGroups/dd-agent-sandbox/providers/Microsoft.Network/virtualNetworks/dd-agent-sandbox/subnets/dd-agent-sandbox-private",
+			defaultSecurityGroup:   "/subscriptions/9972cab2-9e99-419b-a683-86bfa77b3df1/resourceGroups/dd-agent-sandbox/providers/Microsoft.Network/networkSecurityGroups/appgategreen",
 			defaultInstanceType:    "Standard_D4s_v5",  // Allows nested virtualization for kata runtimes
 			defaultARMInstanceType: "Standard_D4ps_v5", // No azure arm instance supports nested virtualization
 			aks: ddInfraAks{

--- a/resources/azure/environmentDefaults.go
+++ b/resources/azure/environmentDefaults.go
@@ -1,7 +1,9 @@
 package azure
 
 const (
-	sandboxEnv = "az/agent-sandbox"
+	sandboxEnv      = "az/sandbox"
+	agentSandboxEnv = "az/agent-sandbox"
+	agentQaEnv      = "az/agent-qa"
 )
 
 type environmentDefault struct {
@@ -33,6 +35,10 @@ func getEnvironmentDefault(envName string) environmentDefault {
 	switch envName {
 	case sandboxEnv:
 		return sandboxDefault()
+	case agentSandboxEnv:
+		return agentSandboxDefault()
+	case agentQaEnv:
+		return agentQaDefault()
 	default:
 		panic("Unknown environment: " + envName)
 	}
@@ -41,8 +47,49 @@ func getEnvironmentDefault(envName string) environmentDefault {
 func sandboxDefault() environmentDefault {
 	return environmentDefault{
 		azure: azureProvider{
+			tenantID:       "4d3bac44-0230-4732-9e70-cc00736f0a97",
+			subscriptionID: "8c56d827-5f07-45ce-8f2b-6c5001db5c6f",
+		},
+		ddInfra: ddInfra{
+			defaultResourceGroup:   "datadog-agent-testing",
+			defaultVNet:            "/subscriptions/8c56d827-5f07-45ce-8f2b-6c5001db5c6f/resourceGroups/datadog-agent-testing/providers/Microsoft.Network/virtualNetworks/default-vnet",
+			defaultSubnet:          "/subscriptions/8c56d827-5f07-45ce-8f2b-6c5001db5c6f/resourceGroups/datadog-agent-testing/providers/Microsoft.Network/virtualNetworks/default-vnet/subnets/default-subnet",
+			defaultSecurityGroup:   "/subscriptions/8c56d827-5f07-45ce-8f2b-6c5001db5c6f/resourceGroups/datadog-agent-testing/providers/Microsoft.Network/networkSecurityGroups/default",
+			defaultInstanceType:    "Standard_D4s_v5",  // Allows nested virtualization for kata runtimes
+			defaultARMInstanceType: "Standard_D4ps_v5", // No azure arm instance supports nested virtualization
+			aks: ddInfraAks{
+				linuxKataNodeGroup: true,
+			},
+		},
+	}
+}
+
+func agentSandboxDefault() environmentDefault {
+	return environmentDefault{
+		azure: azureProvider{
 			tenantID:       "cc0b82f3-7c2e-400b-aec3-40a3d720505b",
 			subscriptionID: "9972cab2-9e99-419b-a683-86bfa77b3df1",
+			location:       "West US 2",
+		},
+		ddInfra: ddInfra{
+			defaultResourceGroup:   "dd-agent-sandbox",
+			defaultVNet:            "/subscriptions/9972cab2-9e99-419b-a683-86bfa77b3df1/resourceGroups/dd-agent-sandbox/providers/Microsoft.Network/virtualNetworks/dd-agent-sandbox",
+			defaultSubnet:          "/subscriptions/9972cab2-9e99-419b-a683-86bfa77b3df1/resourceGroups/dd-agent-sandbox/providers/Microsoft.Network/virtualNetworks/dd-agent-sandbox/subnets/dd-agent-sandbox-private",
+			defaultSecurityGroup:   "/subscriptions/9972cab2-9e99-419b-a683-86bfa77b3df1/resourceGroups/dd-agent-sandbox/providers/Microsoft.Network/networkSecurityGroups/appgategreen",
+			defaultInstanceType:    "Standard_D2a_v4",  // Allows nested virtualization for kata runtimes
+			defaultARMInstanceType: "Standard_D4ps_v5", // No azure arm instance supports nested virtualization
+			aks: ddInfraAks{
+				linuxKataNodeGroup: true,
+			},
+		},
+	}
+}
+
+func agentQaDefault() environmentDefault {
+	return environmentDefault{
+		azure: azureProvider{
+			tenantID:       "cc0b82f3-7c2e-400b-aec3-40a3d720505b",
+			subscriptionID: "c767177d-c6fc-47d3-a87e-3ab195f5b99e",
 			location:       "West US 2",
 		},
 		ddInfra: ddInfra{

--- a/scenarios/azure/compute/vm.go
+++ b/scenarios/azure/compute/vm.go
@@ -23,7 +23,7 @@ func NewVM(e azure.Environment, name string, params ...VMOption) (*remote.Host, 
 	}
 
 	// Default missing parameters
-	if err = defaultVMArgs(vmArgs); err != nil {
+	if err = defaultVMArgs(e, vmArgs); err != nil {
 		return nil, err
 	}
 
@@ -40,9 +40,9 @@ func NewVM(e azure.Environment, name string, params ...VMOption) (*remote.Host, 
 		var nwIface *network.NetworkInterface
 
 		if vmArgs.osInfo.Family() == os.LinuxFamily {
-			_, _, nwIface, err = compute.NewLinuxInstance(e, c.Name(), imageInfo.urn, vmArgs.instanceType, pulumi.StringPtr(vmArgs.userData))
+			_, nwIface, err = compute.NewLinuxInstance(e, c.Name(), imageInfo.urn, vmArgs.instanceType, pulumi.StringPtr(vmArgs.userData))
 		} else if vmArgs.osInfo.Family() == os.WindowsFamily {
-			_, _, nwIface, _, err = compute.NewWindowsInstance(e, c.Name(), imageInfo.urn, vmArgs.instanceType, pulumi.StringPtr(vmArgs.userData), nil)
+			_, nwIface, _, err = compute.NewWindowsInstance(e, c.Name(), imageInfo.urn, vmArgs.instanceType, pulumi.StringPtr(vmArgs.userData), nil)
 		} else {
 			return fmt.Errorf("unsupported OS family %v", vmArgs.osInfo.Family())
 		}
@@ -62,9 +62,16 @@ func NewVM(e azure.Environment, name string, params ...VMOption) (*remote.Host, 
 	})
 }
 
-func defaultVMArgs(vmArgs *vmArgs) error {
+func defaultVMArgs(e azure.Environment, vmArgs *vmArgs) error {
 	if vmArgs.osInfo == nil {
 		vmArgs.osInfo = &os.UbuntuDefault
+	}
+
+	if vmArgs.instanceType == "" {
+		vmArgs.instanceType = e.DefaultInstanceType()
+		if vmArgs.osInfo.Architecture == os.ARM64Arch {
+			vmArgs.instanceType = e.DefaultARMInstanceType()
+		}
 	}
 
 	return nil

--- a/scenarios/azure/compute/vm.go
+++ b/scenarios/azure/compute/vm.go
@@ -64,7 +64,7 @@ func NewVM(e azure.Environment, name string, params ...VMOption) (*remote.Host, 
 
 func defaultVMArgs(e azure.Environment, vmArgs *vmArgs) error {
 	if vmArgs.osInfo == nil {
-		vmArgs.osInfo = &os.UbuntuDefault
+		vmArgs.osInfo = &os.WindowsDefault
 	}
 
 	if vmArgs.instanceType == "" {

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,5 +1,7 @@
 from invoke.collection import Collection
 
+import tasks.aws as aws
+import tasks.az as azure
 import tasks.ci as ci
 import tasks.setup as setup
 import tasks.test as test
@@ -12,26 +14,29 @@ from tasks.installer import create_installer_lab, destroy_installer_lab
 from tasks.kind import create_kind, destroy_kind
 from tasks.pipeline import retry_job
 
-from .vm import create_vm, create_vm_azure, destroy_vm
+from .vm import create_vm, destroy_vm
 
 ns = Collection()
-ns.add_task(create_vm_azure)  # pyright: ignore [reportArgumentType]
-ns.add_task(create_vm)  # pyright: ignore [reportArgumentType]
-ns.add_task(destroy_vm)  # pyright: ignore [reportArgumentType]
-ns.add_task(create_docker)  # pyright: ignore [reportArgumentType]
-ns.add_task(destroy_docker)  # pyright: ignore [reportArgumentType]
-ns.add_task(create_eks)  # pyright: ignore [reportArgumentType]
-ns.add_task(destroy_eks)  # pyright: ignore [reportArgumentType]
-ns.add_task(create_aks)  # pyright: ignore [reportArgumentType]
-ns.add_task(destroy_aks)  # pyright: ignore [reportArgumentType]
-ns.add_task(create_ecs)  # pyright: ignore [reportArgumentType]
-ns.add_task(destroy_ecs)  # pyright: ignore [reportArgumentType]
-ns.add_task(create_kind)  # pyright: ignore [reportArgumentType]
-ns.add_task(destroy_kind)  # pyright: ignore [reportArgumentType]
-ns.add_task(retry_job)  # pyright: ignore [reportArgumentType]
+
 ns.add_task(check_s3_image_exists)  # pyright: ignore [reportArgumentType]
+ns.add_task(create_aks)  # pyright: ignore [reportArgumentType]
+ns.add_task(create_docker)  # pyright: ignore [reportArgumentType]
+ns.add_task(create_ecs)  # pyright: ignore [reportArgumentType]
+ns.add_task(create_eks)  # pyright: ignore [reportArgumentType]
+ns.add_task(create_installer_lab)  # pyright: ignore [reportArgumentType]
+ns.add_task(create_kind)  # pyright: ignore [reportArgumentType]
+ns.add_task(create_vm)  # pyright: ignore [reportArgumentType]
+ns.add_task(destroy_aks)  # pyright: ignore [reportArgumentType]
+ns.add_task(destroy_docker)  # pyright: ignore [reportArgumentType]
+ns.add_task(destroy_ecs)  # pyright: ignore [reportArgumentType]
+ns.add_task(destroy_eks)  # pyright: ignore [reportArgumentType]
+ns.add_task(destroy_installer_lab)  # pyright: ignore [reportArgumentType]
+ns.add_task(destroy_kind)  # pyright: ignore [reportArgumentType]
+ns.add_task(destroy_vm)  # pyright: ignore [reportArgumentType]
+ns.add_task(retry_job)  # pyright: ignore [reportArgumentType]
+
+ns.add_collection(aws)  # pyright: ignore [reportArgumentType]
+ns.add_collection(azure)  # pyright: ignore [reportArgumentType]
+ns.add_collection(ci)  # pyright: ignore [reportArgumentType]
 ns.add_collection(setup)  # pyright: ignore [reportArgumentType]
 ns.add_collection(test)  # pyright: ignore [reportArgumentType]
-ns.add_collection(ci)  # pyright: ignore [reportArgumentType]
-ns.add_task(create_installer_lab)  # pyright: ignore [reportArgumentType]
-ns.add_task(destroy_installer_lab)  # pyright: ignore [reportArgumentType]

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -12,9 +12,10 @@ from tasks.installer import create_installer_lab, destroy_installer_lab
 from tasks.kind import create_kind, destroy_kind
 from tasks.pipeline import retry_job
 
-from .vm import create_vm, destroy_vm
+from .vm import create_vm, create_vm_azure, destroy_vm
 
 ns = Collection()
+ns.add_task(create_vm_azure)  # pyright: ignore [reportArgumentType]
 ns.add_task(create_vm)  # pyright: ignore [reportArgumentType]
 ns.add_task(destroy_vm)  # pyright: ignore [reportArgumentType]
 ns.add_task(create_docker)  # pyright: ignore [reportArgumentType]

--- a/tasks/aws.py
+++ b/tasks/aws.py
@@ -1,0 +1,187 @@
+from typing import Optional, Tuple
+
+from invoke.context import Context
+from invoke.exceptions import Exit
+from invoke.tasks import task
+
+from . import doc, tool
+from .config import Config
+from .deploy import deploy
+from .destroy import destroy
+from .tool import clean_known_hosts as clean_known_hosts_func
+from .tool import get_host, show_connection_message
+
+scenario_name = "aws/vm"
+default_public_path_key_name = "ddinfra:aws/defaultPublicKeyPath"
+
+
+@task(
+    help={
+        "config_path": doc.config_path,
+        "install_agent": doc.install_agent,
+        "install_updater": doc.install_updater,
+        "pipeline_id": doc.pipeline_id,
+        "agent_version": doc.agent_version,
+        "stack_name": doc.stack_name,
+        "debug": doc.debug,
+        "os_family": doc.os_family,
+        "use_fakeintake": doc.fakeintake,
+        "use_loadBalancer": doc.use_loadBalancer,
+        "ami_id": doc.ami_id,
+        "architecture": doc.architecture,
+        "interactive": doc.interactive,
+        "instance_type": doc.instance_type,
+        "no_verify": doc.no_verify,
+        "ssh_user": doc.ssh_user,
+        "os_version": doc.os_version,
+    }
+)
+def create_vm(
+    ctx: Context,
+    config_path: Optional[str] = None,
+    stack_name: Optional[str] = None,
+    pipeline_id: Optional[str] = None,
+    install_agent: Optional[bool] = True,
+    install_updater: Optional[bool] = False,
+    agent_version: Optional[str] = None,
+    debug: Optional[bool] = False,
+    os_family: Optional[str] = None,
+    os_version: Optional[str] = None,
+    use_fakeintake: Optional[bool] = False,
+    use_loadBalancer: Optional[bool] = False,
+    ami_id: Optional[str] = None,
+    architecture: Optional[str] = None,
+    interactive: Optional[bool] = True,
+    instance_type: Optional[str] = None,
+    no_verify: Optional[bool] = False,
+    ssh_user: Optional[str] = None,
+) -> None:
+    """
+    Create a new virtual machine on the cloud.
+    """
+
+    extra_flags = {}
+    os_family, os_arch = _get_os_information(ctx, os_family, architecture, ami_id)
+    deploy_job = None if no_verify else tool.get_deploy_job(os_family, os_arch, agent_version)
+    extra_flags["ddinfra:osDescriptor"] = f"{os_family}:{os_version if os_version else ''}:{os_arch}"
+    extra_flags["ddinfra:deployFakeintakeWithLoadBalancer"] = use_loadBalancer
+
+    if ami_id is not None:
+        extra_flags["ddinfra:osImageID"] = ami_id
+
+    if use_fakeintake and not install_agent:
+        print(
+            "[WARNING] It is currently not possible to deploy a VM with fakeintake and without agent. Your VM will start without fakeintake."
+        )
+    if instance_type is not None:
+        if architecture is None or architecture.lower() == tool.get_default_architecture():
+            extra_flags["ddinfra:aws/defaultInstanceType"] = instance_type
+        else:
+            extra_flags["ddinfra:aws/defaultARMInstanceType"] = instance_type
+
+    if ssh_user:
+        extra_flags["ddinfra:sshUser"] = ssh_user
+
+    full_stack_name = deploy(
+        ctx,
+        scenario_name,
+        config_path,
+        key_pair_required=True,
+        public_key_required=(os_family.lower() == "windows"),
+        stack_name=stack_name,
+        pipeline_id=pipeline_id,
+        install_agent=install_agent,
+        install_updater=install_updater,
+        agent_version=agent_version,
+        debug=debug,
+        extra_flags=extra_flags,
+        use_fakeintake=use_fakeintake,
+        deploy_job=deploy_job,
+    )
+
+    if interactive:
+        tool.notify(ctx, "Your VM is now created")
+
+    show_connection_message(ctx, "aws-vm", full_stack_name, interactive)
+
+
+@task(
+    help={
+        "config_path": doc.config_path,
+        "stack_name": doc.stack_name,
+        "yes": doc.yes,
+        "clean_known_hosts": doc.clean_known_hosts,
+    }
+)
+def destroy_vm(
+    ctx: Context,
+    config_path: Optional[str] = None,
+    stack_name: Optional[str] = None,
+    yes: Optional[bool] = False,
+    clean_known_hosts: Optional[bool] = True,
+):
+    """
+    Destroy a new virtual machine on the cloud.
+    """
+    host = get_host(ctx, "aws-vm", scenario_name, stack_name)
+    destroy(
+        ctx,
+        scenario_name=scenario_name,
+        config_path=config_path,
+        stack=stack_name,
+        force_yes=yes,
+    )
+    if clean_known_hosts:
+        clean_known_hosts_func(host)
+
+
+def _get_os_family(os_family: Optional[str]) -> str:
+    os_families = tool.get_os_families()
+    if os_family is None:
+        os_family = tool.get_default_os_family()
+    if os_family.lower() not in os_families:
+        raise Exit(f"The os family '{os_family}' is not supported. Possibles values are {', '.join(os_families)}")
+    return os_family
+
+
+def _get_architecture(architecture: Optional[str]) -> str:
+    architectures = tool.get_architectures()
+    if architecture is None:
+        architecture = tool.get_default_architecture()
+    if architecture.lower() not in architectures:
+        raise Exit(f"The os family '{architecture}' is not supported. Possibles values are {', '.join(architectures)}")
+    return architecture
+
+
+def _get_os_information(
+    ctx: Context, os_family: Optional[str], arch: Optional[str], ami_id: Optional[str]
+) -> Tuple[str, Optional[str]]:
+    family, architecture = os_family, None
+    if ami_id is not None:
+        image = tool.get_image_description(ctx, ami_id)
+        if family is None:  # Try to guess the distribution
+            os_families = tool.get_os_families()
+            try:
+                if "Description" in image:
+                    image_info = image["Description"]
+                else:
+                    image_info = image["Name"]
+                image_info = image_info.lower().replace(" ", "")
+                family = next(os for os in os_families if os in image_info)
+
+            except StopIteration:
+                raise Exit("We failed to guess the family of your AMI ID. Please provide it with option -o")
+        architecture = image["Architecture"]
+        if arch is not None and architecture != arch:
+            raise Exit(f"The provided architecture is {arch} but the image is {architecture}.")
+    else:
+        family = _get_os_family(os_family)
+        architecture = _get_architecture(arch)
+    return (family, architecture)
+
+
+def _get_public_path_key_name(cfg: Config, require: bool) -> Optional[str]:
+    defaultPublicKeyPath = cfg.get_aws().publicKeyPath
+    if require and defaultPublicKeyPath is None:
+        raise Exit(f"Your scenario requires to define {default_public_path_key_name} in the configuration file")
+    return f'"{defaultPublicKeyPath}"'

--- a/tasks/aws.py
+++ b/tasks/aws.py
@@ -121,7 +121,7 @@ def destroy_vm(
     clean_known_hosts: Optional[bool] = True,
 ):
     """
-    Destroy a new virtual machine on aws.
+    Destroy a virtual machine on aws.
     """
     host = get_host(ctx, "aws-vm", scenario_name, stack_name)
     destroy(

--- a/tasks/az.py
+++ b/tasks/az.py
@@ -10,7 +10,7 @@ from .config import get_full_profile_path
 from .deploy import deploy
 from .destroy import destroy
 from .tool import clean_known_hosts as clean_known_hosts_func
-from .tool import show_connection_message
+from .tool import get_host, show_connection_message
 
 scenario_name = "az/vm"
 
@@ -94,7 +94,7 @@ def destroy_vm(
     """
     Destroy a new virtual machine on the cloud.
     """
-    host = _get_host(ctx, stack_name)
+    host = get_host(ctx, "az-vm", scenario_name, stack_name)
     destroy(
         ctx,
         scenario_name=scenario_name,
@@ -104,13 +104,3 @@ def destroy_vm(
     )
     if clean_known_hosts:
         clean_known_hosts_func(host)
-
-
-def _get_host(ctx: Context, stack_name: Optional[str] = None) -> str:
-    """
-    Get the host of the VM.
-    """
-    full_stack_name = tool.get_stack_name(stack_name, scenario_name)
-    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
-    remoteHost = tool.RemoteHost("az-vm", outputs)
-    return remoteHost.host

--- a/tasks/az.py
+++ b/tasks/az.py
@@ -37,7 +37,7 @@ def create_vm(
     debug: Optional[bool] = False,
     interactive: Optional[bool] = True,
     ssh_user: Optional[str] = None,
-    environment: Optional[str] = None,
+    account: Optional[str] = None,
 ) -> None:
     """
     Create a new virtual machine on azure.
@@ -52,7 +52,7 @@ def create_vm(
         raise Exit("The field `azure.publicKeyPath` is required in the config file")
 
     extra_flags = dict()
-    extra_flags["ddinfra:env"] = environment if environment else cfg.get_azure().defaultEnv
+    extra_flags["ddinfra:env"] = f"az/{account if account else cfg.get_azure().account}"
     extra_flags["ddinfra:az/defaultPublicKeyPath"] = cfg.get_azure().publicKeyPath
 
     if ssh_user:

--- a/tasks/az.py
+++ b/tasks/az.py
@@ -93,7 +93,7 @@ def destroy_vm(
     clean_known_hosts: Optional[bool] = True,
 ):
     """
-    Destroy a new virtual machine on azure.
+    Destroy a virtual machine on azure.
     """
     host = get_host(ctx, "az-vm", scenario_name, stack_name)
     destroy(

--- a/tasks/az.py
+++ b/tasks/az.py
@@ -47,6 +47,9 @@ def create_vm(
     except ValidationError as e:
         raise Exit(f"Error in config {get_full_profile_path(config_path)}:{e}")
 
+    if not cfg.get_azure().publicKeyPath:
+        raise Exit("The field `azure.publicKeyPath` is required in the config file")
+
     extra_flags = dict()
     extra_flags["ddinfra:env"] = "az/agent-sandbox"
     extra_flags["ddinfra:az/defaultPublicKeyPath"] = cfg.get_azure().publicKeyPath

--- a/tasks/az.py
+++ b/tasks/az.py
@@ -37,6 +37,7 @@ def create_vm(
     debug: Optional[bool] = False,
     interactive: Optional[bool] = True,
     ssh_user: Optional[str] = None,
+    environment: Optional[str] = None,
 ) -> None:
     """
     Create a new virtual machine on azure.
@@ -51,7 +52,7 @@ def create_vm(
         raise Exit("The field `azure.publicKeyPath` is required in the config file")
 
     extra_flags = dict()
-    extra_flags["ddinfra:env"] = "az/agent-sandbox"
+    extra_flags["ddinfra:env"] = environment if environment else cfg.get_azure().defaultEnv
     extra_flags["ddinfra:az/defaultPublicKeyPath"] = cfg.get_azure().publicKeyPath
 
     if ssh_user:

--- a/tasks/az.py
+++ b/tasks/az.py
@@ -1,0 +1,113 @@
+from typing import Optional
+
+from invoke.context import Context
+from invoke.exceptions import Exit
+from invoke.tasks import task
+from pydantic_core._pydantic_core import ValidationError
+
+from . import config, doc, tool
+from .config import get_full_profile_path
+from .deploy import deploy
+from .destroy import destroy
+from .tool import clean_known_hosts as clean_known_hosts_func
+from .tool import show_connection_message
+
+scenario_name = "az/vm"
+
+
+@task(
+    help={
+        "config_path": doc.config_path,
+        "install_agent": doc.install_agent,
+        "install_updater": doc.install_updater,
+        "agent_version": doc.agent_version,
+        "stack_name": doc.stack_name,
+        "debug": doc.debug,
+        "interactive": doc.interactive,
+        "ssh_user": doc.ssh_user,
+    }
+)
+def create_vm(
+    ctx: Context,
+    config_path: Optional[str] = None,
+    stack_name: Optional[str] = None,
+    install_agent: Optional[bool] = True,
+    install_updater: Optional[bool] = False,
+    agent_version: Optional[str] = None,
+    debug: Optional[bool] = False,
+    interactive: Optional[bool] = True,
+    ssh_user: Optional[str] = None,
+) -> None:
+    """
+    Create a new virtual machine on the cloud.
+    """
+
+    try:
+        cfg = config.get_local_config(config_path)
+    except ValidationError as e:
+        raise Exit(f"Error in config {get_full_profile_path(config_path)}:{e}")
+
+    extra_flags = dict()
+    extra_flags["ddinfra:env"] = "az/agent-sandbox"
+    extra_flags["ddinfra:az/defaultPublicKeyPath"] = cfg.get_azure().publicKeyPath
+
+    if ssh_user:
+        extra_flags["ddinfra:sshUser"] = ssh_user
+
+    full_stack_name = deploy(
+        ctx,
+        scenario_name,
+        config_path,
+        key_pair_required=True,
+        stack_name=stack_name,
+        install_agent=install_agent,
+        install_updater=install_updater,
+        agent_version=agent_version,
+        debug=debug,
+        extra_flags=extra_flags,
+    )
+
+    if interactive:
+        tool.notify(ctx, "Your VM is now created")
+
+    show_connection_message(ctx, "az-vm", full_stack_name, interactive)
+
+
+@task(
+    help={
+        "config_path": doc.config_path,
+        "stack_name": doc.stack_name,
+        "yes": doc.yes,
+        "clean_known_hosts": doc.clean_known_hosts,
+    }
+)
+def destroy_vm(
+    ctx: Context,
+    config_path: Optional[str] = None,
+    stack_name: Optional[str] = None,
+    yes: Optional[bool] = False,
+    clean_known_hosts: Optional[bool] = True,
+):
+    """
+    Destroy a new virtual machine on the cloud.
+    """
+    host = _get_host(ctx, stack_name)
+    destroy(
+        ctx,
+        scenario_name=scenario_name,
+        config_path=config_path,
+        stack=stack_name,
+        force_yes=yes,
+    )
+    if clean_known_hosts:
+        clean_known_hosts_func(host)
+
+
+def _get_host(ctx: Context, stack_name: Optional[str] = None) -> str:
+    """
+    Get the host of the VM.
+    """
+    full_stack_name = tool.get_stack_name(stack_name, scenario_name)
+    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
+    remoteHost = tool.RemoteHost("az-vm", outputs)
+    return remoteHost.host

--- a/tasks/config.py
+++ b/tasks/config.py
@@ -39,7 +39,9 @@ You should consider moving to the agent-sandbox account. Please follow https://d
         aws: Optional[Aws]
 
         class Azure(BaseModel, extra=Extra.forbid):
-            publicKeyPath: Optional[str]
+            _DEFAULT_ENV = "az/agent-sandbox"
+            publicKeyPath: Optional[str] = None
+            defaultEnv: Optional[str] = _DEFAULT_ENV
 
         azure: Optional[Azure] = None
 

--- a/tasks/config.py
+++ b/tasks/config.py
@@ -41,7 +41,7 @@ You should consider moving to the agent-sandbox account. Please follow https://d
         class Azure(BaseModel, extra=Extra.forbid):
             publicKeyPath: Optional[str]
 
-        azure: Optional[Azure]
+        azure: Optional[Azure] = None
 
         class Agent(BaseModel, extra=Extra.forbid):
             apiKey: Optional[str]

--- a/tasks/config.py
+++ b/tasks/config.py
@@ -38,6 +38,11 @@ You should consider moving to the agent-sandbox account. Please follow https://d
 
         aws: Optional[Aws]
 
+        class Azure(BaseModel, extra=Extra.forbid):
+            publicKeyPath: Optional[str]
+
+        azure: Optional[Azure]
+
         class Agent(BaseModel, extra=Extra.forbid):
             apiKey: Optional[str]
             appKey: Optional[str]
@@ -64,6 +69,14 @@ You should consider moving to the agent-sandbox account. Please follow https://d
         if self.options is None:
             return Config.Options(checkKeyPair=False)
         return self.options
+
+    def get_azure(self) -> Params.Azure:
+        default = Config.Params.Azure(publicKeyPath=None)
+        if self.configParams is None:
+            return default
+        if self.configParams.azure is None:
+            return default
+        return self.configParams.azure
 
     def get_aws(self) -> Params.Aws:
         default = Config.Params.Aws(keyPairName=None, publicKeyPath=None, account=None, teamTag=None)

--- a/tasks/config.py
+++ b/tasks/config.py
@@ -39,9 +39,9 @@ You should consider moving to the agent-sandbox account. Please follow https://d
         aws: Optional[Aws]
 
         class Azure(BaseModel, extra=Extra.forbid):
-            _DEFAULT_ENV = "az/agent-sandbox"
+            _DEFAULT_ACCOUNT = "agent-sandbox"
             publicKeyPath: Optional[str] = None
-            defaultEnv: Optional[str] = _DEFAULT_ENV
+            account: Optional[str] = _DEFAULT_ACCOUNT
 
         azure: Optional[Azure] = None
 

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -57,7 +57,9 @@ def deploy(
     flags["ddagent:fakeintake"] = use_fakeintake
 
     awsKeyPairName = cfg.get_aws().keyPairName
+
     flags["ddinfra:aws/defaultKeyPairName"] = awsKeyPairName
+    flags["ddinfra:az/defaultPublicKeyPath"] = cfg.get_azure().publicKeyPath
     aws_account = cfg.get_aws().get_account()
     flags.setdefault("ddinfra:env", "aws/" + aws_account)
 

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -59,7 +59,6 @@ def deploy(
     awsKeyPairName = cfg.get_aws().keyPairName
 
     flags["ddinfra:aws/defaultKeyPairName"] = awsKeyPairName
-    flags["ddinfra:az/defaultPublicKeyPath"] = cfg.get_azure().publicKeyPath
     aws_account = cfg.get_aws().get_account()
     flags.setdefault("ddinfra:env", "aws/" + aws_account)
 

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -46,6 +46,8 @@ def setup(
         info("🤖 Let's configure your environment for e2e tests! Press ctrl+c to stop me")
         # AWS config
         setupAWSConfig(config)
+        # Azure config
+        setup_azure_config(config)
         # Agent config
         setupAgentConfig(config)
         # Pulumi config
@@ -106,8 +108,6 @@ def setupAWSConfig(config: Config):
         config.configParams = Config.Params(aws=None, agent=None, pulumi=None, azure=None)
     if config.configParams.aws is None:
         config.configParams.aws = Config.Params.Aws(keyPairName=None, publicKeyPath=None, account=None, teamTag=None)
-    if config.configParams.azure is None:
-        config.configParams.azure = Config.Params.Azure(publicKeyPath=None)
 
     # aws account
     if config.configParams.aws.account is None:
@@ -168,6 +168,28 @@ def setupAWSConfig(config: Config):
         if len(config.configParams.aws.teamTag) > 0:
             break
         warn("Provide a non-empty team")
+
+
+def setup_azure_config(config: Config):
+    if config.configParams is None:
+        config.configParams = Config.Params(aws=None, agent=None, pulumi=None, azure=None)
+    if config.configParams.azure is None:
+        config.configParams.azure = Config.Params.Azure(publicKeyPath=None)
+
+    # azure public key path
+    if config.configParams.azure.publicKeyPath is None:
+        config.configParams.azure.publicKeyPath = str(Path.home().joinpath(".ssh", "id_ed25519.pub").absolute())
+    default_public_key_path = config.configParams.azure.publicKeyPath
+    while True:
+        config.configParams.azure.publicKeyPath = default_public_key_path
+        publicKeyPath = ask(
+            f"🔑 Path to your Azure public ssh key, default [{config.configParams.azure.publicKeyPath}]: "
+        )
+        if len(publicKeyPath) > 0:
+            config.configParams.azure.publicKeyPath = publicKeyPath
+        if os.path.isfile(config.configParams.azure.publicKeyPath):
+            break
+        warn(f"{config.configParams.azure.publicKeyPath} is not a valid ssh key")
 
 
 def setupAgentConfig(config):

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -192,9 +192,9 @@ def setup_azure_config(config: Config):
             break
         warn(f"{config.configParams.azure.publicKeyPath} is not a valid ssh key")
 
-    default_environment = ask(f"🔑 Default environment to use, default [{config.configParams.azure.defaultEnv}]: ")
-    if default_environment:
-        config.configParams.azure.defaultEnv = default_environment
+    default_account = ask(f"🔑 Default account to use, default [{config.configParams.azure.account}]: ")
+    if default_account:
+        config.configParams.azure.account = default_account
 
 
 def setupAgentConfig(config):

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -103,9 +103,11 @@ def _check_config(config: Config):
 
 def setupAWSConfig(config: Config):
     if config.configParams is None:
-        config.configParams = Config.Params(aws=None, agent=None, pulumi=None)
+        config.configParams = Config.Params(aws=None, agent=None, pulumi=None, azure=None)
     if config.configParams.aws is None:
         config.configParams.aws = Config.Params.Aws(keyPairName=None, publicKeyPath=None, account=None, teamTag=None)
+    if config.configParams.azure is None:
+        config.configParams.azure = Config.Params.Azure(publicKeyPath=None)
 
     # aws account
     if config.configParams.aws.account is None:

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -182,14 +182,19 @@ def setup_azure_config(config: Config):
     default_public_key_path = config.configParams.azure.publicKeyPath
     while True:
         config.configParams.azure.publicKeyPath = default_public_key_path
-        publicKeyPath = ask(
-            f"🔑 Path to your Azure public ssh key, default [{config.configParams.azure.publicKeyPath}]: "
+        public_key_path = ask(
+            f"🔑 Path to your Azure public ssh key: (default: [{config.configParams.azure.publicKeyPath}])"
         )
-        if len(publicKeyPath) > 0:
-            config.configParams.azure.publicKeyPath = publicKeyPath
+        if public_key_path:
+            config.configParams.azure.publicKeyPath = public_key_path
+
         if os.path.isfile(config.configParams.azure.publicKeyPath):
             break
         warn(f"{config.configParams.azure.publicKeyPath} is not a valid ssh key")
+
+    default_environment = ask(f"🔑 Default environment to use, default [{config.configParams.azure.defaultEnv}]: ")
+    if default_environment:
+        config.configParams.azure.defaultEnv = default_environment
 
 
 def setupAgentConfig(config):

--- a/tasks/tool.py
+++ b/tasks/tool.py
@@ -6,6 +6,7 @@ import platform
 from io import StringIO
 from typing import Any, List, Optional, Union
 
+import pyperclip
 from invoke.context import Context
 from invoke.exceptions import Exit
 from termcolor import colored
@@ -224,3 +225,42 @@ class RemoteHost:
         remoteHost: Any = stack_outputs[f"dd-Host-{name}"]
         self.host: str = remoteHost["address"]
         self.user: str = remoteHost["username"]
+
+
+def show_connection_message(
+    ctx: Context, remote_host_name: str, full_stack_name: str, copy_to_clipboard: Optional[bool] = True
+):
+    outputs = get_stack_json_outputs(ctx, full_stack_name)
+    remoteHost = RemoteHost(remote_host_name, outputs)
+    host = remoteHost.host
+    user = remoteHost.user
+
+    command = f"ssh {user}@{host}"
+
+    print(f"\nYou can run the following command to connect to the host `{command}`.\n")
+    if copy_to_clipboard:
+        input("Press a key to copy command to clipboard...")
+        pyperclip.copy(command)
+
+
+def clean_known_hosts(host: str) -> None:
+    """
+    Remove the host from the known_hosts file.
+    """
+    home = os.environ.get("HOME", f"/Users/{getpass.getuser()}")
+    with open(f"{home}/.ssh/known_hosts") as f:
+        lines = f.readlines()
+
+    filtered_lines = [line for line in lines if not line.startswith(host)]
+    with open(f"{home}/.ssh/known_hosts", "w") as f:
+        f.writelines(filtered_lines)
+
+
+def get_host(ctx: Context, remote_host_name: str, scenario_name: str, stack_name: Optional[str] = None) -> str:
+    """
+    Get the host of the VM.
+    """
+    full_stack_name = get_stack_name(stack_name, scenario_name)
+    outputs = get_stack_json_outputs(ctx, full_stack_name)
+    remoteHost = RemoteHost(remote_host_name, outputs)
+    return remoteHost.host

--- a/tasks/vm.py
+++ b/tasks/vm.py
@@ -1,108 +1,11 @@
-import getpass
-import os
-from typing import Optional, Tuple
+from typing import Optional
 
-import pyperclip
 from invoke.context import Context
-from invoke.exceptions import Exit
 from invoke.tasks import task
 
-from . import doc, tool
-from .deploy import deploy
-from .destroy import destroy
+from . import doc
 
-scenario_name = "az/vm"
-
-
-@task(
-    help={
-        "config_path": doc.config_path,
-        "install_agent": doc.install_agent,
-        "install_updater": doc.install_updater,
-        "pipeline_id": doc.pipeline_id,
-        "agent_version": doc.agent_version,
-        "stack_name": doc.stack_name,
-        "debug": doc.debug,
-        "os_family": doc.os_family,
-        "use_fakeintake": doc.fakeintake,
-        "use_loadBalancer": doc.use_loadBalancer,
-        "ami_id": doc.ami_id,
-        "architecture": doc.architecture,
-        "interactive": doc.interactive,
-        "instance_type": doc.instance_type,
-        "no_verify": doc.no_verify,
-        "ssh_user": doc.ssh_user,
-        "os_version": doc.os_version,
-    }
-)
-def create_vm_azure(
-    ctx: Context,
-    config_path: Optional[str] = None,
-    stack_name: Optional[str] = None,
-    pipeline_id: Optional[str] = None,
-    install_agent: Optional[bool] = True,
-    install_updater: Optional[bool] = False,
-    agent_version: Optional[str] = None,
-    debug: Optional[bool] = False,
-    os_family: Optional[str] = None,
-    os_version: Optional[str] = None,
-    use_fakeintake: Optional[bool] = False,
-    use_loadBalancer: Optional[bool] = False,
-    ami_id: Optional[str] = None,
-    architecture: Optional[str] = None,
-    interactive: Optional[bool] = True,
-    instance_type: Optional[str] = None,
-    no_verify: Optional[bool] = False,
-    ssh_user: Optional[str] = None,
-) -> None:
-    """
-    Create a new virtual machine on the cloud.
-    """
-
-    extra_flags = {}
-    os_family, os_arch = _get_os_information(ctx, os_family, architecture, ami_id)
-    deploy_job = None if no_verify else tool.get_deploy_job(os_family, os_arch, agent_version)
-    # extra_flags["ddinfra:osDescriptor"] = f"{os_family}:{os_version if os_version else ''}:{os_arch}"
-    # extra_flags["ddinfra:deployFakeintakeWithLoadBalancer"] = use_loadBalancer
-    extra_flags["ddinfra:env"] = "az/agent-sandbox"
-
-    if ami_id is not None:
-        extra_flags["ddinfra:osImageID"] = ami_id
-
-    if use_fakeintake and not install_agent:
-        print(
-            "[WARNING] It is currently not possible to deploy a VM with fakeintake and without agent. Your VM will start without fakeintake."
-        )
-    if instance_type is not None:
-        if architecture is None or architecture.lower() == tool.get_default_architecture():
-            extra_flags["ddinfra:aws/defaultInstanceType"] = instance_type
-        else:
-            extra_flags["ddinfra:aws/defaultARMInstanceType"] = instance_type
-
-    if ssh_user:
-        extra_flags["ddinfra:sshUser"] = ssh_user
-
-    full_stack_name = deploy(
-        ctx,
-        scenario_name,
-        config_path,
-        key_pair_required=True,
-        public_key_required=(os_family.lower() == "windows"),
-        stack_name=stack_name,
-        pipeline_id=pipeline_id,
-        install_agent=install_agent,
-        install_updater=install_updater,
-        agent_version=agent_version,
-        debug=debug,
-        extra_flags=extra_flags,
-        use_fakeintake=use_fakeintake,
-        deploy_job=deploy_job,
-    )
-
-    if interactive:
-        tool.notify(ctx, "Your VM is now created")
-
-    _show_connection_message(ctx, full_stack_name, interactive)
+scenario_name = "aws/vm"
 
 
 @task(
@@ -146,67 +49,30 @@ def create_vm(
     no_verify: Optional[bool] = False,
     ssh_user: Optional[str] = None,
 ) -> None:
-    """
-    Create a new virtual machine on the cloud.
-    """
+    from tasks.aws import create_vm as create_vm_aws
 
-    extra_flags = {}
-    os_family, os_arch = _get_os_information(ctx, os_family, architecture, ami_id)
-    deploy_job = None if no_verify else tool.get_deploy_job(os_family, os_arch, agent_version)
-    extra_flags["ddinfra:osDescriptor"] = f"{os_family}:{os_version if os_version else ''}:{os_arch}"
-    extra_flags["ddinfra:deployFakeintakeWithLoadBalancer"] = use_loadBalancer
-
-    if ami_id is not None:
-        extra_flags["ddinfra:osImageID"] = ami_id
-
-    if use_fakeintake and not install_agent:
-        print(
-            "[WARNING] It is currently not possible to deploy a VM with fakeintake and without agent. Your VM will start without fakeintake."
-        )
-    if instance_type is not None:
-        if architecture is None or architecture.lower() == tool.get_default_architecture():
-            extra_flags["ddinfra:aws/defaultInstanceType"] = instance_type
-        else:
-            extra_flags["ddinfra:aws/defaultARMInstanceType"] = instance_type
-
-    if ssh_user:
-        extra_flags["ddinfra:sshUser"] = ssh_user
-
-    full_stack_name = deploy(
+    print('This command is deprecated, please use `aws.create-vm` instead')
+    print("Running `aws.create-vm`...")
+    create_vm_aws(
         ctx,
-        scenario_name,
         config_path,
-        key_pair_required=True,
-        public_key_required=(os_family.lower() == "windows"),
-        stack_name=stack_name,
-        pipeline_id=pipeline_id,
-        install_agent=install_agent,
-        install_updater=install_updater,
-        agent_version=agent_version,
-        debug=debug,
-        extra_flags=extra_flags,
-        use_fakeintake=use_fakeintake,
-        deploy_job=deploy_job,
+        stack_name,
+        pipeline_id,
+        install_agent,
+        install_updater,
+        agent_version,
+        debug,
+        os_family,
+        os_version,
+        use_fakeintake,
+        use_loadBalancer,
+        ami_id,
+        architecture,
+        interactive,
+        instance_type,
+        no_verify,
+        ssh_user,
     )
-
-    if interactive:
-        tool.notify(ctx, "Your VM is now created")
-
-    _show_connection_message(ctx, full_stack_name, interactive)
-
-
-def _show_connection_message(ctx: Context, full_stack_name: str, copy_to_clipboard: Optional[bool] = True):
-    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
-    remoteHost = tool.RemoteHost("aws-vm", outputs)
-    host = remoteHost.host
-    user = remoteHost.user
-
-    command = f"ssh {user}@{host}"
-
-    print(f"\nYou can run the following command to connect to the host `{command}`.\n")
-    if copy_to_clipboard:
-        input("Press a key to copy command to clipboard...")
-        pyperclip.copy(command)
 
 
 @task(
@@ -224,83 +90,8 @@ def destroy_vm(
     yes: Optional[bool] = False,
     clean_known_hosts: Optional[bool] = True,
 ):
-    """
-    Destroy a new virtual machine on the cloud.
-    """
-    host = _get_host(ctx, stack_name)
-    destroy(
-        ctx,
-        scenario_name=scenario_name,
-        config_path=config_path,
-        stack=stack_name,
-        force_yes=yes,
-    )
-    if clean_known_hosts:
-        _clean_known_hosts(host)
+    from tasks.aws import destroy_vm as destroy_vm_aws
 
-
-def _get_host(ctx: Context, stack_name: Optional[str] = None) -> str:
-    """
-    Get the host of the VM.
-    """
-    full_stack_name = tool.get_stack_name(stack_name, scenario_name)
-    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
-    remoteHost = tool.RemoteHost("aws-vm", outputs)
-    return remoteHost.host
-
-
-def _clean_known_hosts(host: str) -> None:
-    """
-    Remove the host from the known_hosts file.
-    """
-    home = os.environ.get("HOME", f"/Users/{getpass.getuser()}")
-    with open(f"{home}/.ssh/known_hosts") as f:
-        lines = f.readlines()
-    filtered_lines = [line for line in lines if not line.startswith(host)]
-    with open(f"{home}/.ssh/known_hosts", "w") as f:
-        f.writelines(filtered_lines)
-
-
-def _get_os_family(os_family: Optional[str]) -> str:
-    os_families = tool.get_os_families()
-    if os_family is None:
-        os_family = tool.get_default_os_family()
-    if os_family.lower() not in os_families:
-        raise Exit(f"The os family '{os_family}' is not supported. Possibles values are {', '.join(os_families)}")
-    return os_family
-
-
-def _get_architecture(architecture: Optional[str]) -> str:
-    architectures = tool.get_architectures()
-    if architecture is None:
-        architecture = tool.get_default_architecture()
-    if architecture.lower() not in architectures:
-        raise Exit(f"The os family '{architecture}' is not supported. Possibles values are {', '.join(architectures)}")
-    return architecture
-
-
-def _get_os_information(
-    ctx: Context, os_family: Optional[str], arch: Optional[str], ami_id: Optional[str]
-) -> Tuple[str, Optional[str]]:
-    family, architecture = os_family, None
-    if ami_id is not None:
-        image = tool.get_image_description(ctx, ami_id)
-        if family is None:  # Try to guess the distribution
-            os_families = tool.get_os_families()
-            try:
-                if "Description" in image:
-                    image_info = image["Description"]
-                else:
-                    image_info = image["Name"]
-                image_info = image_info.lower().replace(" ", "")
-                family = next(os for os in os_families if os in image_info)
-
-            except StopIteration:
-                raise Exit("We failed to guess the family of your AMI ID. Please provide it with option -o")
-        architecture = image["Architecture"]
-        if arch is not None and architecture != arch:
-            raise Exit(f"The provided architecture is {arch} but the image is {architecture}.")
-    else:
-        family = _get_os_family(os_family)
-        architecture = _get_architecture(arch)
-    return (family, architecture)
+    print('This command is deprecated, please use `aws.destroy-vm` instead')
+    print("Running `aws.destroy-vm`...")
+    destroy_vm_aws(ctx, config_path, stack_name, yes, clean_known_hosts)

--- a/tasks/vm.py
+++ b/tasks/vm.py
@@ -11,7 +11,98 @@ from . import doc, tool
 from .deploy import deploy
 from .destroy import destroy
 
-scenario_name = "aws/vm"
+scenario_name = "az/vm"
+
+
+@task(
+    help={
+        "config_path": doc.config_path,
+        "install_agent": doc.install_agent,
+        "install_updater": doc.install_updater,
+        "pipeline_id": doc.pipeline_id,
+        "agent_version": doc.agent_version,
+        "stack_name": doc.stack_name,
+        "debug": doc.debug,
+        "os_family": doc.os_family,
+        "use_fakeintake": doc.fakeintake,
+        "use_loadBalancer": doc.use_loadBalancer,
+        "ami_id": doc.ami_id,
+        "architecture": doc.architecture,
+        "interactive": doc.interactive,
+        "instance_type": doc.instance_type,
+        "no_verify": doc.no_verify,
+        "ssh_user": doc.ssh_user,
+        "os_version": doc.os_version,
+    }
+)
+def create_vm_azure(
+    ctx: Context,
+    config_path: Optional[str] = None,
+    stack_name: Optional[str] = None,
+    pipeline_id: Optional[str] = None,
+    install_agent: Optional[bool] = True,
+    install_updater: Optional[bool] = False,
+    agent_version: Optional[str] = None,
+    debug: Optional[bool] = False,
+    os_family: Optional[str] = None,
+    os_version: Optional[str] = None,
+    use_fakeintake: Optional[bool] = False,
+    use_loadBalancer: Optional[bool] = False,
+    ami_id: Optional[str] = None,
+    architecture: Optional[str] = None,
+    interactive: Optional[bool] = True,
+    instance_type: Optional[str] = None,
+    no_verify: Optional[bool] = False,
+    ssh_user: Optional[str] = None,
+) -> None:
+    """
+    Create a new virtual machine on the cloud.
+    """
+
+    extra_flags = {}
+    os_family, os_arch = _get_os_information(ctx, os_family, architecture, ami_id)
+    deploy_job = None if no_verify else tool.get_deploy_job(os_family, os_arch, agent_version)
+    # extra_flags["ddinfra:osDescriptor"] = f"{os_family}:{os_version if os_version else ''}:{os_arch}"
+    # extra_flags["ddinfra:deployFakeintakeWithLoadBalancer"] = use_loadBalancer
+    extra_flags["ddinfra:env"] = "az/agent-sandbox"
+
+    if ami_id is not None:
+        extra_flags["ddinfra:osImageID"] = ami_id
+
+    if use_fakeintake and not install_agent:
+        print(
+            "[WARNING] It is currently not possible to deploy a VM with fakeintake and without agent. Your VM will start without fakeintake."
+        )
+    if instance_type is not None:
+        if architecture is None or architecture.lower() == tool.get_default_architecture():
+            extra_flags["ddinfra:aws/defaultInstanceType"] = instance_type
+        else:
+            extra_flags["ddinfra:aws/defaultARMInstanceType"] = instance_type
+
+    if ssh_user:
+        extra_flags["ddinfra:sshUser"] = ssh_user
+
+    full_stack_name = deploy(
+        ctx,
+        scenario_name,
+        config_path,
+        key_pair_required=True,
+        public_key_required=(os_family.lower() == "windows"),
+        stack_name=stack_name,
+        pipeline_id=pipeline_id,
+        install_agent=install_agent,
+        install_updater=install_updater,
+        agent_version=agent_version,
+        debug=debug,
+        extra_flags=extra_flags,
+        use_fakeintake=use_fakeintake,
+        deploy_job=deploy_job,
+    )
+
+    if interactive:
+        tool.notify(ctx, "Your VM is now created")
+
+    _show_connection_message(ctx, full_stack_name, interactive)
 
 
 @task(


### PR DESCRIPTION
What does this PR do?
---------------------

- Add two new tasks `az.create-vm` and `az.destroy-vm` to create VMs with the Agent in Azure. They are currently very basic and do not have all the parameters the AWS counterpart has but we'll add them in future PRs to keep this PR readable. 
- This is limited to Linux for now
- Update the `setup` task to include the new parameter for Azure. We have also a key parameter for AWS thsat could be merged in a follow-up PR
- Deprecate the `create-vm` and `destroy-vm` tasks in favour of `aws.create-vm` and `aws.destroy-vm`. The old commands still work. they print a deprecation message and redirect to the new version
- Add an integration test for Azure with all the requirements to run it from the CI
- We currently use the `deploy` function as is, where we have a lot of AWS specific stuff. I did not want to refactor too much and I'll open a PR in the future to move them to the AWS-specific command

To make it work, we need to have an ssh key to use for this instance. For instance: 

```
  azure:
    publicKeyPath: /Users/florent.clarret/.ssh/id_rsa_azure.pub
```

I'll add documentation about this once this will be a bit more stable and usable for everyone. This parameter is not required unless you're trying to deploy a VM on Azure

Which scenarios this will impact?
-------------------

Everyone who uses the `create-vm` or `destroy-vm` and people who want to deploy a VM in Azure.

Motivation
----------

The Azure sandbox is out!

Additional Notes
----------------

Co-authored with @KevinFairise2 
