### PR TITLE
Move the aws tasks into the aws package

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,10 +1,11 @@
+# type: ignore[reportArgumentType]
+
 from invoke.collection import Collection
 
-import tasks.aws as aws
-import tasks.az as azure
 import tasks.ci as ci
 import tasks.setup as setup
 import tasks.test as test
+from tasks import aws, azure
 from tasks.aks import create_aks, destroy_aks
 from tasks.deploy import check_s3_image_exists
 from tasks.docker import create_docker, destroy_docker
@@ -13,30 +14,29 @@ from tasks.eks import create_eks, destroy_eks
 from tasks.installer import create_installer_lab, destroy_installer_lab
 from tasks.kind import create_kind, destroy_kind
 from tasks.pipeline import retry_job
-
-from .vm import create_vm, destroy_vm
+from tasks.vm import create_vm, destroy_vm
 
 ns = Collection()
 
-ns.add_task(check_s3_image_exists)  # pyright: ignore [reportArgumentType]
-ns.add_task(create_aks)  # pyright: ignore [reportArgumentType]
-ns.add_task(create_docker)  # pyright: ignore [reportArgumentType]
-ns.add_task(create_ecs)  # pyright: ignore [reportArgumentType]
-ns.add_task(create_eks)  # pyright: ignore [reportArgumentType]
-ns.add_task(create_installer_lab)  # pyright: ignore [reportArgumentType]
-ns.add_task(create_kind)  # pyright: ignore [reportArgumentType]
-ns.add_task(create_vm)  # pyright: ignore [reportArgumentType]
-ns.add_task(destroy_aks)  # pyright: ignore [reportArgumentType]
-ns.add_task(destroy_docker)  # pyright: ignore [reportArgumentType]
-ns.add_task(destroy_ecs)  # pyright: ignore [reportArgumentType]
-ns.add_task(destroy_eks)  # pyright: ignore [reportArgumentType]
-ns.add_task(destroy_installer_lab)  # pyright: ignore [reportArgumentType]
-ns.add_task(destroy_kind)  # pyright: ignore [reportArgumentType]
-ns.add_task(destroy_vm)  # pyright: ignore [reportArgumentType]
-ns.add_task(retry_job)  # pyright: ignore [reportArgumentType]
+ns.add_task(check_s3_image_exists)
+ns.add_task(create_aks)
+ns.add_task(create_docker)
+ns.add_task(create_ecs)
+ns.add_task(create_eks)
+ns.add_task(create_installer_lab)
+ns.add_task(create_kind)
+ns.add_task(create_vm)
+ns.add_task(destroy_aks)
+ns.add_task(destroy_docker)
+ns.add_task(destroy_ecs)
+ns.add_task(destroy_eks)
+ns.add_task(destroy_installer_lab)
+ns.add_task(destroy_kind)
+ns.add_task(destroy_vm)
+ns.add_task(retry_job)
 
-ns.add_collection(aws)  # pyright: ignore [reportArgumentType]
-ns.add_collection(azure)  # pyright: ignore [reportArgumentType]
-ns.add_collection(ci)  # pyright: ignore [reportArgumentType]
-ns.add_collection(setup)  # pyright: ignore [reportArgumentType]
-ns.add_collection(test)  # pyright: ignore [reportArgumentType]
+ns.add_collection(aws.collection, "aws")
+ns.add_collection(azure.collection, "az")
+ns.add_collection(ci)
+ns.add_collection(setup)
+ns.add_collection(test)

--- a/tasks/aks.py
+++ b/tasks/aks.py
@@ -1,16 +1,9 @@
-import os
 from typing import Optional
 
-import pyperclip
-import yaml
 from invoke.context import Context
 from invoke.tasks import task
 
-from . import doc, tool
-from .deploy import deploy
-from .destroy import destroy
-
-scenario_name = "az/aks"
+from . import doc
 
 
 @task(
@@ -29,50 +22,24 @@ def create_aks(
     install_workload: Optional[bool] = True,
     agent_version: Optional[str] = None,
 ):
-    """
-    Create a new AKS environment. It lasts around 5 minutes.
-    """
+    print('This command is deprecated, please use `az.create-aks` instead')
+    print("Running `az.create-aks`...")
+    from tasks.azure.aks import create_aks as create_aks_azure
 
-    extra_flags = {}
-    extra_flags["ddinfra:env"] = "az/sandbox"
-
-    full_stack_name = deploy(
+    create_aks_azure(
         ctx,
-        scenario_name,
         debug=debug,
-        app_key_required=True,
         stack_name=stack_name,
         install_agent=install_agent,
         install_workload=install_workload,
         agent_version=agent_version,
-        extra_flags=extra_flags,
     )
-
-    tool.notify(ctx, "Your AKS cluster is now created")
-
-    _show_connection_message(ctx, full_stack_name)
-
-
-def _show_connection_message(ctx: Context, full_stack_name: str):
-    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
-    kubeconfig_output = yaml.safe_load(outputs["dd-Cluster-az-aks"]["kubeConfig"])
-    kubeconfig_content = yaml.dump(kubeconfig_output)
-    kubeconfig = f"{full_stack_name}-config.yaml"
-    f = os.open(path=kubeconfig, flags=(os.O_WRONLY | os.O_CREAT | os.O_TRUNC), mode=0o600)
-    with open(f, "w") as f:
-        f.write(kubeconfig_content)
-
-    command = f"KUBECONFIG={kubeconfig} kubectl get nodes"
-
-    print(f"\nYou can run the following command to connect to the AKS cluster\n\n{command}\n")
-
-    input("Press a key to copy command to clipboard...")
-    pyperclip.copy(command)
 
 
 @task(help={"stack_name": doc.stack_name, "yes": doc.yes})
 def destroy_aks(ctx: Context, stack_name: Optional[str] = None, yes: Optional[bool] = False):
-    """
-    Destroy a AKS environment created with invoke create-aks.
-    """
-    destroy(ctx, scenario_name=scenario_name, stack=stack_name, force_yes=yes)
+    print('This command is deprecated, please use `az.destroy-aks` instead')
+    print("Running `az.destroy-aks`...")
+    from tasks.azure.aks import destroy_aks as destroy_aks_azure
+
+    destroy_aks_azure(ctx, stack_name=stack_name, yes=yes)

--- a/tasks/aws/__init__.py
+++ b/tasks/aws/__init__.py
@@ -1,0 +1,24 @@
+# type: ignore[reportArgumentType]
+
+from invoke.collection import Collection
+
+from tasks.aws.docker import create_docker, destroy_docker
+from tasks.aws.ecs import create_ecs, destroy_ecs
+from tasks.aws.eks import create_eks, destroy_eks
+from tasks.aws.installer import create_installer_lab, destroy_installer_lab
+from tasks.aws.kind import create_kind, destroy_kind
+from tasks.aws.vm import create_vm, destroy_vm
+
+collection = Collection()
+collection.add_task(destroy_vm)
+collection.add_task(create_vm)
+collection.add_task(create_docker)
+collection.add_task(destroy_docker)
+collection.add_task(create_ecs)
+collection.add_task(destroy_ecs)
+collection.add_task(create_eks)
+collection.add_task(destroy_eks)
+collection.add_task(create_installer_lab)
+collection.add_task(destroy_installer_lab)
+collection.add_task(create_kind)
+collection.add_task(destroy_kind)

--- a/tasks/aws/docker.py
+++ b/tasks/aws/docker.py
@@ -1,0 +1,113 @@
+from typing import Optional
+
+import pyperclip
+from invoke.context import Context
+from invoke.exceptions import Exit
+from invoke.tasks import task
+
+from tasks import doc, tool
+from tasks.deploy import deploy
+from tasks.destroy import destroy
+
+scenario_name = "aws/dockervm"
+
+
+@task(
+    help={
+        "config_path": doc.config_path,
+        "install_agent": doc.install_agent,
+        "agent_version": doc.container_agent_version,
+        "stack_name": doc.stack_name,
+        "architecture": doc.architecture,
+        "use_fakeintake": doc.fakeintake,
+        "use_loadBalancer": doc.use_loadBalancer,
+        "interactive": doc.interactive,
+    }
+)
+def create_docker(
+    ctx: Context,
+    config_path: Optional[str] = None,
+    stack_name: Optional[str] = None,
+    install_agent: Optional[bool] = True,
+    agent_version: Optional[str] = None,
+    architecture: Optional[str] = None,
+    use_fakeintake: Optional[bool] = False,
+    use_loadBalancer: Optional[bool] = False,
+    interactive: Optional[bool] = True,
+):
+    """
+    Create a docker environment.
+    """
+
+    extra_flags = {}
+    extra_flags["ddinfra:osDescriptor"] = f"::{_get_architecture(architecture)}"
+    extra_flags["ddinfra:deployFakeintakeWithLoadBalancer"] = use_loadBalancer
+
+    full_stack_name = deploy(
+        ctx,
+        scenario_name,
+        config_path,
+        key_pair_required=True,
+        stack_name=stack_name,
+        install_agent=install_agent,
+        agent_version=agent_version,
+        use_fakeintake=use_fakeintake,
+        extra_flags=extra_flags,
+    )
+
+    if interactive:
+        tool.notify(ctx, "Your Docker environment is now created")
+
+    _show_connection_message(ctx, full_stack_name, interactive)
+
+
+def _show_connection_message(ctx: Context, full_stack_name: str, copy_to_clipboard: Optional[bool]):
+    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
+    remoteHost = tool.RemoteHost("aws-vm", outputs)
+    host = remoteHost.host
+    user = remoteHost.user
+
+    command = (
+        f"\nssh {user}@{host} --  'echo \"Successfully connected to VM\" && exit' \n"
+        + f'docker context create pulumi-{host} --docker "host=ssh://{user}@{host}"\n'
+        + f"docker --context pulumi-{host} container ls\n"
+    )
+    print(f"If you want to use docker context, you can run the following commands \n\n{command}")
+
+    if copy_to_clipboard:
+        input("Press a key to copy command to clipboard...")
+        pyperclip.copy(command)
+
+
+@task(
+    help={
+        "config_path": doc.config_path,
+        "stack_name": doc.stack_name,
+        "yes": doc.yes,
+    }
+)
+def destroy_docker(
+    ctx: Context,
+    config_path: Optional[str] = None,
+    stack_name: Optional[str] = None,
+    yes: Optional[bool] = False,
+):
+    """
+    Destroy an environment created by invoke aws.create-docker.
+    """
+    destroy(
+        ctx,
+        scenario_name=scenario_name,
+        config_path=config_path,
+        stack=stack_name,
+        force_yes=yes,
+    )
+
+
+def _get_architecture(architecture: Optional[str]) -> str:
+    architectures = tool.get_architectures()
+    if architecture is None:
+        architecture = tool.get_default_architecture()
+    if architecture.lower() not in architectures:
+        raise Exit(f"The os family '{architecture}' is not supported. Possibles values are {', '.join(architectures)}")
+    return architecture

--- a/tasks/aws/ecs.py
+++ b/tasks/aws/ecs.py
@@ -1,0 +1,92 @@
+from typing import Optional
+
+import pyperclip
+from invoke.context import Context
+from invoke.exceptions import Exit
+from invoke.tasks import task
+from pydantic import ValidationError
+
+from tasks import config, doc, tool
+from tasks.deploy import deploy
+from tasks.destroy import destroy
+
+scenario_name = "aws/ecs"
+
+
+@task(
+    help={
+        "config_path": doc.config_path,
+        "install_agent": doc.install_agent,
+        "install_workload": doc.install_workload,
+        "agent_version": doc.container_agent_version,
+        "stack_name": doc.stack_name,
+        "use_fargate": doc.use_fargate,
+        "linux_node_group": doc.linux_node_group,
+        "linux_arm_node_group": doc.linux_arm_node_group,
+        "bottlerocket_node_group": doc.bottlerocket_node_group,
+        "windows_node_group": doc.windows_node_group,
+    }
+)
+def create_ecs(
+    ctx: Context,
+    config_path: Optional[str] = None,
+    stack_name: Optional[str] = None,
+    install_agent: Optional[bool] = True,
+    install_workload: Optional[bool] = True,
+    agent_version: Optional[str] = None,
+    use_fargate: bool = True,
+    linux_node_group: bool = True,
+    linux_arm_node_group: bool = False,
+    bottlerocket_node_group: bool = True,
+    windows_node_group: bool = False,
+):
+    """
+    Create a new ECS environment.
+    """
+    extra_flags = {}
+    extra_flags["ddinfra:aws/ecs/fargateCapacityProvider"] = use_fargate
+    extra_flags["ddinfra:aws/ecs/linuxECSOptimizedNodeGroup"] = linux_node_group
+    extra_flags["ddinfra:aws/ecs/linuxECSOptimizedARMNodeGroup"] = linux_arm_node_group
+    extra_flags["ddinfra:aws/ecs/linuxBottlerocketNodeGroup"] = bottlerocket_node_group
+    extra_flags["ddinfra:aws/ecs/windowsLTSCNodeGroup"] = windows_node_group
+
+    full_stack_name = deploy(
+        ctx,
+        scenario_name,
+        config_path,
+        stack_name=stack_name,
+        install_agent=install_agent,
+        install_workload=install_workload,
+        agent_version=agent_version,
+        extra_flags=extra_flags,
+    )
+
+    tool.notify(ctx, "Your ECS cluster is now created")
+
+    _show_connection_message(ctx, config_path, full_stack_name)
+
+
+def _show_connection_message(ctx: Context, config_path: Optional[str], full_stack_name: str):
+    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
+    cluster_name = outputs["ecs-cluster-name"]
+
+    try:
+        local_config = config.get_local_config(config_path)
+    except ValidationError as e:
+        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}:{e}")
+
+    command = (
+        f"{tool.get_aws_wrapper(local_config.get_aws().get_account())} aws ecs list-tasks --cluster {cluster_name}"
+    )
+    print(f"\nYou can run the following command to list tasks on the ECS cluster\n\n{command}\n")
+
+    input("Press a key to copy command to clipboard...")
+    pyperclip.copy(command)
+
+
+@task(help={"stack_name": doc.stack_name, "yes": doc.yes})
+def destroy_ecs(ctx: Context, stack_name: Optional[str] = None, yes: Optional[bool] = False):
+    """
+    Destroy a ECS environment created with invoke aws.create-ecs.
+    """
+    destroy(ctx, scenario_name=scenario_name, stack=stack_name, force_yes=yes)

--- a/tasks/aws/eks.py
+++ b/tasks/aws/eks.py
@@ -1,0 +1,109 @@
+import json
+import os
+from typing import Optional
+
+import pyperclip
+import yaml
+from invoke.context import Context
+from invoke.exceptions import Exit
+from invoke.tasks import task
+from pydantic import ValidationError
+
+from tasks import config, doc, tool
+from tasks.deploy import deploy
+from tasks.destroy import destroy
+
+scenario_name = "aws/eks"
+
+
+@task(
+    help={
+        "config_path": doc.config_path,
+        "install_agent": doc.install_agent,
+        "install_workload": doc.install_workload,
+        "agent_version": doc.container_agent_version,
+        "stack_name": doc.stack_name,
+        "linux_node_group": doc.linux_node_group,
+        "linux_arm_node_group": doc.linux_arm_node_group,
+        "bottlerocket_node_group": doc.bottlerocket_node_group,
+        "windows_node_group": doc.windows_node_group,
+        "instance_type": doc.instance_type,
+    }
+)
+def create_eks(
+    ctx: Context,
+    config_path: Optional[str] = None,
+    debug: Optional[bool] = False,
+    stack_name: Optional[str] = None,
+    install_agent: Optional[bool] = True,
+    install_workload: Optional[bool] = True,
+    agent_version: Optional[str] = None,
+    linux_node_group: bool = True,
+    linux_arm_node_group: bool = False,
+    bottlerocket_node_group: bool = True,
+    windows_node_group: bool = False,
+    instance_type: Optional[str] = None,
+):
+    """
+    Create a new EKS environment. It lasts around 20 minutes.
+    """
+
+    extra_flags = {}
+    extra_flags["ddinfra:aws/eks/linuxNodeGroup"] = linux_node_group
+    extra_flags["ddinfra:aws/eks/linuxARMNodeGroup"] = linux_arm_node_group
+    extra_flags["ddinfra:aws/eks/linuxBottlerocketNodeGroup"] = bottlerocket_node_group
+    extra_flags["ddinfra:aws/eks/windowsNodeGroup"] = windows_node_group
+
+    # Override the instance type if specified
+    # ARM node groups use defaultARMInstanceType, all others (Linux, Bottlerocket, Windows) use defaultInstanceType
+    if instance_type is not None:
+        if linux_arm_node_group:
+            extra_flags["ddinfra:aws/defaultARMInstanceType"] = instance_type
+        else:
+            extra_flags["ddinfra:aws/defaultInstanceType"] = instance_type
+
+    full_stack_name = deploy(
+        ctx,
+        scenario_name,
+        debug=debug,
+        app_key_required=True,
+        stack_name=stack_name,
+        install_agent=install_agent,
+        install_workload=install_workload,
+        agent_version=agent_version,
+        extra_flags=extra_flags,
+    )
+
+    tool.notify(ctx, "Your EKS cluster is now created")
+
+    _show_connection_message(ctx, full_stack_name, config_path)
+
+
+def _show_connection_message(ctx: Context, full_stack_name: str, config_path: Optional[str]):
+    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
+    kubeconfig_output = json.loads(outputs["dd-Cluster-aws-eks"]["kubeConfig"])
+    kubeconfig_content = yaml.dump(kubeconfig_output)
+    kubeconfig = f"{full_stack_name}-kubeconfig.yaml"
+    f = os.open(path=kubeconfig, flags=(os.O_WRONLY | os.O_CREAT | os.O_TRUNC), mode=0o600)
+    with open(f, "w") as f:
+        f.write(kubeconfig_content)
+
+    try:
+        local_config = config.get_local_config(config_path)
+    except ValidationError as e:
+        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}:{e}")
+
+    command = f"KUBECONFIG={kubeconfig} {tool.get_aws_wrapper(local_config.get_aws().get_account())} kubectl get nodes"
+
+    print(f"\nYou can run the following command to connect to the EKS cluster\n\n{command}\n")
+
+    input("Press a key to copy command to clipboard...")
+    pyperclip.copy(command)
+
+
+@task(help={"stack_name": doc.stack_name, "yes": doc.yes})
+def destroy_eks(ctx: Context, stack_name: Optional[str] = None, yes: Optional[bool] = False):
+    """
+    Destroy a EKS environment created with invoke aws.create-eks.
+    """
+    destroy(ctx, scenario_name=scenario_name, stack=stack_name, force_yes=yes)

--- a/tasks/aws/installer.py
+++ b/tasks/aws/installer.py
@@ -1,0 +1,50 @@
+from typing import Optional
+
+from invoke.context import Context
+from invoke.tasks import task
+
+from tasks import doc
+from tasks.deploy import deploy
+from tasks.destroy import destroy
+
+scenario_name = "aws/installer"
+
+
+@task(
+    help={
+        "debug": doc.debug,
+        "pipeline_id": doc.pipeline_id,
+        "site": doc.site,
+    }
+)
+def create_installer_lab(
+    ctx: Context,
+    debug: Optional[bool] = False,
+    pipeline_id: Optional[str] = None,
+    site: Optional[str] = "datad0g.com",
+):
+    full_stack_name = deploy(
+        ctx,
+        scenario_name,
+        stack_name="installer-lab",
+        pipeline_id=pipeline_id,
+        install_updater=True,
+        debug=debug,
+        extra_flags={"ddagent:site": site},
+    )
+
+    print(f"Installer lab created: {full_stack_name}")
+
+
+@task(
+    help={
+        "yes": doc.yes,
+    }
+)
+def destroy_installer_lab(
+    ctx: Context,
+    yes: Optional[bool] = False,
+):
+    destroy(ctx, scenario_name=scenario_name, stack="installer-lab", force_yes=yes)
+
+    print("Installer lab destroyed")

--- a/tasks/aws/kind.py
+++ b/tasks/aws/kind.py
@@ -1,0 +1,112 @@
+from typing import Optional
+
+import pyperclip
+from invoke.context import Context
+from invoke.exceptions import Exit
+from invoke.tasks import task
+
+from tasks import doc, tool
+from tasks.deploy import deploy
+from tasks.destroy import destroy
+
+scenario_name = "aws/kind"
+
+
+# TODO add dogstatsd and workload options
+@task(
+    help={
+        "config_path": doc.config_path,
+        "install_agent": doc.install_agent,
+        "agent_version": doc.container_agent_version,
+        "stack_name": doc.stack_name,
+        "architecture": doc.architecture,
+        "use_fakeintake": doc.fakeintake,
+        "use_loadBalancer": doc.use_loadBalancer,
+        "interactive": doc.interactive,
+    }
+)
+def create_kind(
+    ctx: Context,
+    config_path: Optional[str] = None,
+    stack_name: Optional[str] = None,
+    install_agent: Optional[bool] = True,
+    agent_version: Optional[str] = None,
+    architecture: Optional[str] = None,
+    use_fakeintake: Optional[bool] = False,
+    use_loadBalancer: Optional[bool] = False,
+    interactive: Optional[bool] = True,
+):
+    """
+    Create a kind environment.
+    """
+
+    extra_flags = {}
+    extra_flags["ddinfra:osDescriptor"] = f"amazonlinuxecs::{_get_architecture(architecture)}"
+    extra_flags["ddinfra:deployFakeintakeWithLoadBalancer"] = use_loadBalancer
+    extra_flags["ddinfra:aws/defaultInstanceType"] = "t3.xlarge"
+
+    full_stack_name = deploy(
+        ctx,
+        scenario_name,
+        config_path,
+        key_pair_required=True,
+        stack_name=stack_name,
+        install_agent=install_agent,
+        agent_version=agent_version,
+        use_fakeintake=use_fakeintake,
+        extra_flags=extra_flags,
+        app_key_required=True,
+    )
+
+    if interactive:
+        tool.notify(ctx, "Your Kind environment is now created")
+
+    _show_connection_message(ctx, full_stack_name, interactive)
+
+
+def _show_connection_message(ctx: Context, full_stack_name: str, copy_to_clipboard: Optional[bool]):
+    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
+    remoteHost = tool.RemoteHost("aws-kind", outputs)
+    host = remoteHost.host
+    user = remoteHost.user
+
+    command = f"\nssh {user}@{host}"
+    print(f"If you want to connect to the remote host, you can run the following command \n\n{command}")
+
+    if copy_to_clipboard:
+        input("Press a key to copy command to clipboard...")
+        pyperclip.copy(command)
+
+
+@task(
+    help={
+        "config_path": doc.config_path,
+        "stack_name": doc.stack_name,
+        "yes": doc.yes,
+    }
+)
+def destroy_kind(
+    ctx: Context,
+    config_path: Optional[str] = None,
+    stack_name: Optional[str] = None,
+    yes: Optional[bool] = False,
+):
+    """
+    Destroy an environment created by invoke aws.create-kind.
+    """
+    destroy(
+        ctx,
+        scenario_name=scenario_name,
+        config_path=config_path,
+        stack=stack_name,
+        force_yes=yes,
+    )
+
+
+def _get_architecture(architecture: Optional[str]) -> str:
+    architectures = tool.get_architectures()
+    if architecture is None:
+        architecture = tool.get_default_architecture()
+    if architecture.lower() not in architectures:
+        raise Exit(f"The os family '{architecture}' is not supported. Possibles values are {', '.join(architectures)}")
+    return architecture

--- a/tasks/azure/__init__.py
+++ b/tasks/azure/__init__.py
@@ -1,0 +1,12 @@
+# type: ignore[reportArgumentType]
+
+from invoke.collection import Collection
+
+from tasks.azure.aks import create_aks, destroy_aks
+from tasks.azure.vm import create_vm, destroy_vm
+
+collection = Collection()
+collection.add_task(destroy_vm)
+collection.add_task(create_vm)
+collection.add_task(create_aks)
+collection.add_task(destroy_aks)

--- a/tasks/azure/aks.py
+++ b/tasks/azure/aks.py
@@ -1,0 +1,78 @@
+import os
+from typing import Optional
+
+import pyperclip
+import yaml
+from invoke.context import Context
+from invoke.tasks import task
+
+from tasks import doc, tool
+from tasks.deploy import deploy
+from tasks.destroy import destroy
+
+scenario_name = "az/aks"
+
+
+@task(
+    help={
+        "install_agent": doc.install_agent,
+        "install_workload": doc.install_workload,
+        "agent_version": doc.container_agent_version,
+        "stack_name": doc.stack_name,
+    }
+)
+def create_aks(
+    ctx: Context,
+    debug: Optional[bool] = False,
+    stack_name: Optional[str] = None,
+    install_agent: Optional[bool] = True,
+    install_workload: Optional[bool] = True,
+    agent_version: Optional[str] = None,
+):
+    """
+    Create a new AKS environment. It lasts around 5 minutes.
+    """
+
+    extra_flags = {}
+    extra_flags["ddinfra:env"] = "az/sandbox"
+
+    full_stack_name = deploy(
+        ctx,
+        scenario_name,
+        debug=debug,
+        app_key_required=True,
+        stack_name=stack_name,
+        install_agent=install_agent,
+        install_workload=install_workload,
+        agent_version=agent_version,
+        extra_flags=extra_flags,
+    )
+
+    tool.notify(ctx, "Your AKS cluster is now created")
+
+    _show_connection_message(ctx, full_stack_name)
+
+
+@task(help={"stack_name": doc.stack_name, "yes": doc.yes})
+def destroy_aks(ctx: Context, stack_name: Optional[str] = None, yes: Optional[bool] = False):
+    """
+    Destroy a AKS environment created with invoke az.create-aks.
+    """
+    destroy(ctx, scenario_name=scenario_name, stack=stack_name, force_yes=yes)
+
+
+def _show_connection_message(ctx: Context, full_stack_name: str):
+    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
+    kubeconfig_output = yaml.safe_load(outputs["dd-Cluster-az-aks"]["kubeConfig"])
+    kubeconfig_content = yaml.dump(kubeconfig_output)
+    kubeconfig = f"{full_stack_name}-config.yaml"
+    f = os.open(path=kubeconfig, flags=(os.O_WRONLY | os.O_CREAT | os.O_TRUNC), mode=0o600)
+    with open(f, "w") as f:
+        f.write(kubeconfig_content)
+
+    command = f"KUBECONFIG={kubeconfig} kubectl get nodes"
+
+    print(f"\nYou can run the following command to connect to the AKS cluster\n\n{command}\n")
+
+    input("Press a key to copy command to clipboard...")
+    pyperclip.copy(command)

--- a/tasks/azure/vm.py
+++ b/tasks/azure/vm.py
@@ -5,14 +5,15 @@ from invoke.exceptions import Exit
 from invoke.tasks import task
 from pydantic_core._pydantic_core import ValidationError
 
-from . import config, doc, tool
-from .config import get_full_profile_path
-from .deploy import deploy
-from .destroy import destroy
-from .tool import clean_known_hosts as clean_known_hosts_func
-from .tool import get_host, show_connection_message
+from tasks import config, doc, tool
+from tasks.config import get_full_profile_path
+from tasks.deploy import deploy
+from tasks.destroy import destroy
+from tasks.tool import clean_known_hosts as clean_known_hosts_func
+from tasks.tool import get_host, show_connection_message
 
 scenario_name = "az/vm"
+remote_hostname = "az-vm"
 
 
 @task(
@@ -46,7 +47,7 @@ def create_vm(
     try:
         cfg = config.get_local_config(config_path)
     except ValidationError as e:
-        raise Exit(f"Error in config {get_full_profile_path(config_path)}:{e}")
+        raise Exit(f"Error in config {get_full_profile_path(config_path)}") from e
 
     if not cfg.get_azure().publicKeyPath:
         raise Exit("The field `azure.publicKeyPath` is required in the config file")
@@ -74,7 +75,7 @@ def create_vm(
     if interactive:
         tool.notify(ctx, "Your VM is now created")
 
-    show_connection_message(ctx, "az-vm", full_stack_name, interactive)
+    show_connection_message(ctx, remote_hostname, full_stack_name, interactive)
 
 
 @task(
@@ -93,9 +94,9 @@ def destroy_vm(
     clean_known_hosts: Optional[bool] = True,
 ):
     """
-    Destroy a virtual machine on azure.
+    Destroy a new virtual machine on azure.
     """
-    host = get_host(ctx, "az-vm", scenario_name, stack_name)
+    host = get_host(ctx, remote_hostname, scenario_name, stack_name)
     destroy(
         ctx,
         scenario_name=scenario_name,

--- a/tasks/docker.py
+++ b/tasks/docker.py
@@ -1,15 +1,9 @@
 from typing import Optional
 
-import pyperclip
 from invoke.context import Context
-from invoke.exceptions import Exit
 from invoke.tasks import task
 
-from . import doc, tool
-from .deploy import deploy
-from .destroy import destroy
-
-scenario_name = "aws/dockervm"
+from . import doc
 
 
 @task(
@@ -35,48 +29,21 @@ def create_docker(
     use_loadBalancer: Optional[bool] = False,
     interactive: Optional[bool] = True,
 ):
-    """
-    Create a docker environment.
-    """
+    print('This command is deprecated, please use `aws.create-docker` instead')
+    print("Running `aws.create-docker`...")
+    from tasks.aws.docker import create_docker as create_docker_aws
 
-    extra_flags = {}
-    extra_flags["ddinfra:osDescriptor"] = f"::{_get_architecture(architecture)}"
-    extra_flags["ddinfra:deployFakeintakeWithLoadBalancer"] = use_loadBalancer
-
-    full_stack_name = deploy(
+    create_docker_aws(
         ctx,
-        scenario_name,
         config_path,
-        key_pair_required=True,
-        stack_name=stack_name,
-        install_agent=install_agent,
-        agent_version=agent_version,
-        use_fakeintake=use_fakeintake,
-        extra_flags=extra_flags,
+        stack_name,
+        install_agent,
+        agent_version,
+        architecture,
+        use_fakeintake,
+        use_loadBalancer,
+        interactive,
     )
-
-    if interactive:
-        tool.notify(ctx, "Your Docker environment is now created")
-
-    _show_connection_message(ctx, full_stack_name, interactive)
-
-
-def _show_connection_message(ctx: Context, full_stack_name: str, copy_to_clipboard: Optional[bool]):
-    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
-    remoteHost = tool.RemoteHost("aws-vm", outputs)
-    host = remoteHost.host
-    user = remoteHost.user
-
-    command = (
-        f"\nssh {user}@{host} --  'echo \"Successfully connected to VM\" && exit' \n"
-        + f'docker context create pulumi-{host} --docker "host=ssh://{user}@{host}"\n'
-        + f"docker --context pulumi-{host} container ls\n"
-    )
-    print(f"If you want to use docker context, you can run the following commands \n\n{command}")
-
-    if copy_to_clipboard:
-        input("Press a key to copy command to clipboard...")
-        pyperclip.copy(command)
 
 
 @task(
@@ -92,22 +59,8 @@ def destroy_docker(
     stack_name: Optional[str] = None,
     yes: Optional[bool] = False,
 ):
-    """
-    Destroy an environment created by invoke create_docker.
-    """
-    destroy(
-        ctx,
-        scenario_name=scenario_name,
-        config_path=config_path,
-        stack=stack_name,
-        force_yes=yes,
-    )
+    print('This command is deprecated, please use `aws.destroy-docker` instead')
+    print("Running `aws.destroy-docker`...")
+    from tasks.aws.docker import destroy_docker as destroy_docker_aws
 
-
-def _get_architecture(architecture: Optional[str]) -> str:
-    architectures = tool.get_architectures()
-    if architecture is None:
-        architecture = tool.get_default_architecture()
-    if architecture.lower() not in architectures:
-        raise Exit(f"The os family '{architecture}' is not supported. Possibles values are {', '.join(architectures)}")
-    return architecture
+    destroy_docker_aws(ctx, config_path, stack_name, yes)

--- a/tasks/ecs.py
+++ b/tasks/ecs.py
@@ -1,16 +1,9 @@
 from typing import Optional
 
-import pyperclip
 from invoke.context import Context
-from invoke.exceptions import Exit
 from invoke.tasks import task
-from pydantic import ValidationError
 
-from . import config, doc, tool
-from .deploy import deploy
-from .destroy import destroy
-
-scenario_name = "aws/ecs"
+from . import doc
 
 
 @task(
@@ -40,53 +33,29 @@ def create_ecs(
     bottlerocket_node_group: bool = True,
     windows_node_group: bool = False,
 ):
-    """
-    Create a new ECS environment.
-    """
-    extra_flags = {}
-    extra_flags["ddinfra:aws/ecs/fargateCapacityProvider"] = use_fargate
-    extra_flags["ddinfra:aws/ecs/linuxECSOptimizedNodeGroup"] = linux_node_group
-    extra_flags["ddinfra:aws/ecs/linuxECSOptimizedARMNodeGroup"] = linux_arm_node_group
-    extra_flags["ddinfra:aws/ecs/linuxBottlerocketNodeGroup"] = bottlerocket_node_group
-    extra_flags["ddinfra:aws/ecs/windowsLTSCNodeGroup"] = windows_node_group
+    print('This command is deprecated, please use `aws.create-ecs` instead')
+    print("Running `aws.create-ecs`...")
+    from tasks.aws.ecs import create_ecs as create_ecs_aws
 
-    full_stack_name = deploy(
+    create_ecs_aws(
         ctx,
-        scenario_name,
         config_path,
-        stack_name=stack_name,
-        install_agent=install_agent,
-        install_workload=install_workload,
-        agent_version=agent_version,
-        extra_flags=extra_flags,
+        stack_name,
+        install_agent,
+        install_workload,
+        agent_version,
+        use_fargate,
+        linux_node_group,
+        linux_arm_node_group,
+        bottlerocket_node_group,
+        windows_node_group,
     )
-
-    tool.notify(ctx, "Your ECS cluster is now created")
-
-    _show_connection_message(ctx, config_path, full_stack_name)
-
-
-def _show_connection_message(ctx: Context, config_path: Optional[str], full_stack_name: str):
-    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
-    cluster_name = outputs["ecs-cluster-name"]
-
-    try:
-        local_config = config.get_local_config(config_path)
-    except ValidationError as e:
-        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}:{e}")
-
-    command = (
-        f"{tool.get_aws_wrapper(local_config.get_aws().get_account())} aws ecs list-tasks --cluster {cluster_name}"
-    )
-    print(f"\nYou can run the following command to list tasks on the ECS cluster\n\n{command}\n")
-
-    input("Press a key to copy command to clipboard...")
-    pyperclip.copy(command)
 
 
 @task(help={"stack_name": doc.stack_name, "yes": doc.yes})
 def destroy_ecs(ctx: Context, stack_name: Optional[str] = None, yes: Optional[bool] = False):
-    """
-    Destroy a ECS environment created with invoke create-ecs.
-    """
-    destroy(ctx, scenario_name=scenario_name, stack=stack_name, force_yes=yes)
+    print('This command is deprecated, please use `aws.create-ecs` instead')
+    print("Running `aws.create-ecs`...")
+    from tasks.aws.ecs import destroy_ecs as destroy_ecs_aws
+
+    destroy_ecs_aws(ctx, stack_name, yes)

--- a/tasks/eks.py
+++ b/tasks/eks.py
@@ -1,19 +1,9 @@
-import json
-import os
 from typing import Optional
 
-import pyperclip
-import yaml
 from invoke.context import Context
-from invoke.exceptions import Exit
 from invoke.tasks import task
-from pydantic import ValidationError
 
-from . import config, doc, tool
-from .deploy import deploy
-from .destroy import destroy
-
-scenario_name = "aws/eks"
+from . import doc
 
 
 @task(
@@ -44,66 +34,30 @@ def create_eks(
     windows_node_group: bool = False,
     instance_type: Optional[str] = None,
 ):
-    """
-    Create a new EKS environment. It lasts around 20 minutes.
-    """
+    print('This command is deprecated, please use `aws.create-eks` instead')
+    print("Running `aws.create-eks`...")
+    from tasks.aws.eks import create_eks as create_eks_aws
 
-    extra_flags = {}
-    extra_flags["ddinfra:aws/eks/linuxNodeGroup"] = linux_node_group
-    extra_flags["ddinfra:aws/eks/linuxARMNodeGroup"] = linux_arm_node_group
-    extra_flags["ddinfra:aws/eks/linuxBottlerocketNodeGroup"] = bottlerocket_node_group
-    extra_flags["ddinfra:aws/eks/windowsNodeGroup"] = windows_node_group
-
-    # Override the instance type if specified
-    # ARM node groups use defaultARMInstanceType, all others (Linux, Bottlerocket, Windows) use defaultInstanceType
-    if instance_type is not None:
-        if linux_arm_node_group:
-            extra_flags["ddinfra:aws/defaultARMInstanceType"] = instance_type
-        else:
-            extra_flags["ddinfra:aws/defaultInstanceType"] = instance_type
-
-    full_stack_name = deploy(
+    create_eks_aws(
         ctx,
-        scenario_name,
-        debug=debug,
-        app_key_required=True,
-        stack_name=stack_name,
-        install_agent=install_agent,
-        install_workload=install_workload,
-        agent_version=agent_version,
-        extra_flags=extra_flags,
+        config_path,
+        debug,
+        stack_name,
+        install_agent,
+        install_workload,
+        agent_version,
+        linux_node_group,
+        linux_arm_node_group,
+        bottlerocket_node_group,
+        windows_node_group,
+        instance_type,
     )
-
-    tool.notify(ctx, "Your EKS cluster is now created")
-
-    _show_connection_message(ctx, full_stack_name, config_path)
-
-
-def _show_connection_message(ctx: Context, full_stack_name: str, config_path: Optional[str]):
-    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
-    kubeconfig_output = json.loads(outputs["dd-Cluster-aws-eks"]["kubeConfig"])
-    kubeconfig_content = yaml.dump(kubeconfig_output)
-    kubeconfig = f"{full_stack_name}-kubeconfig.yaml"
-    f = os.open(path=kubeconfig, flags=(os.O_WRONLY | os.O_CREAT | os.O_TRUNC), mode=0o600)
-    with open(f, "w") as f:
-        f.write(kubeconfig_content)
-
-    try:
-        local_config = config.get_local_config(config_path)
-    except ValidationError as e:
-        raise Exit(f"Error in config {config.get_full_profile_path(config_path)}:{e}")
-
-    command = f"KUBECONFIG={kubeconfig} {tool.get_aws_wrapper(local_config.get_aws().get_account())} kubectl get nodes"
-
-    print(f"\nYou can run the following command to connect to the EKS cluster\n\n{command}\n")
-
-    input("Press a key to copy command to clipboard...")
-    pyperclip.copy(command)
 
 
 @task(help={"stack_name": doc.stack_name, "yes": doc.yes})
 def destroy_eks(ctx: Context, stack_name: Optional[str] = None, yes: Optional[bool] = False):
-    """
-    Destroy a EKS environment created with invoke create-eks.
-    """
-    destroy(ctx, scenario_name=scenario_name, stack=stack_name, force_yes=yes)
+    print('This command is deprecated, please use `aws.create-eks` instead')
+    print("Running `aws.create-eks`...")
+    from tasks.aws.eks import destroy_eks as destroy_eks_aws
+
+    destroy_eks_aws(ctx, stack_name, yes)

--- a/tasks/installer.py
+++ b/tasks/installer.py
@@ -4,10 +4,6 @@ from invoke.context import Context
 from invoke.tasks import task
 
 from . import doc
-from .deploy import deploy
-from .destroy import destroy
-
-scenario_name = "aws/installer"
 
 
 @task(
@@ -23,17 +19,16 @@ def create_installer_lab(
     pipeline_id: Optional[str] = None,
     site: Optional[str] = "datad0g.com",
 ):
-    full_stack_name = deploy(
-        ctx,
-        scenario_name,
-        stack_name="installer-lab",
-        pipeline_id=pipeline_id,
-        install_updater=True,
-        debug=debug,
-        extra_flags={"ddagent:site": site},
-    )
+    print('This command is deprecated, please use `aws.create-installer-lab` instead')
+    print("Running `aws.create-installer-lab`...")
+    from tasks.aws.installer import create_installer_lab as create_installer_lab_aws
 
-    print(f"Installer lab created: {full_stack_name}")
+    create_installer_lab_aws(
+        ctx,
+        debug,
+        pipeline_id,
+        site,
+    )
 
 
 @task(
@@ -45,6 +40,11 @@ def destroy_installer_lab(
     ctx: Context,
     yes: Optional[bool] = False,
 ):
-    destroy(ctx, scenario_name=scenario_name, stack="installer-lab", force_yes=yes)
+    print('This command is deprecated, please use `aws.destroy-installer-lab` instead')
+    print("Running `aws.destroy-installer-lab`...")
+    from tasks.aws.installer import create_installer_lab as create_installer_lab_aws
 
-    print("Installer lab destroyed")
+    create_installer_lab_aws(
+        ctx,
+        yes,
+    )

--- a/tasks/kind.py
+++ b/tasks/kind.py
@@ -1,15 +1,9 @@
 from typing import Optional
 
-import pyperclip
 from invoke.context import Context
-from invoke.exceptions import Exit
 from invoke.tasks import task
 
-from . import doc, tool
-from .deploy import deploy
-from .destroy import destroy
-
-scenario_name = "aws/kind"
+from . import doc
 
 
 # TODO add dogstatsd and workload options
@@ -36,46 +30,21 @@ def create_kind(
     use_loadBalancer: Optional[bool] = False,
     interactive: Optional[bool] = True,
 ):
-    """
-    Create a kind environment.
-    """
+    print('This command is deprecated, please use `aws.create-kind` instead')
+    print("Running `aws.create-kind`...")
+    from tasks.aws.kind import create_kind as create_kind_aws
 
-    extra_flags = {}
-    extra_flags["ddinfra:osDescriptor"] = f"amazonlinuxecs::{_get_architecture(architecture)}"
-    extra_flags["ddinfra:deployFakeintakeWithLoadBalancer"] = use_loadBalancer
-    extra_flags["ddinfra:aws/defaultInstanceType"] = "t3.xlarge"
-
-    full_stack_name = deploy(
+    create_kind_aws(
         ctx,
-        scenario_name,
         config_path,
-        key_pair_required=True,
-        stack_name=stack_name,
-        install_agent=install_agent,
-        agent_version=agent_version,
-        use_fakeintake=use_fakeintake,
-        extra_flags=extra_flags,
-        app_key_required=True,
+        stack_name,
+        install_agent,
+        agent_version,
+        architecture,
+        use_fakeintake,
+        use_loadBalancer,
+        interactive,
     )
-
-    if interactive:
-        tool.notify(ctx, "Your Kind environment is now created")
-
-    _show_connection_message(ctx, full_stack_name, interactive)
-
-
-def _show_connection_message(ctx: Context, full_stack_name: str, copy_to_clipboard: Optional[bool]):
-    outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
-    remoteHost = tool.RemoteHost("aws-kind", outputs)
-    host = remoteHost.host
-    user = remoteHost.user
-
-    command = f"\nssh {user}@{host}"
-    print(f"If you want to connect to the remote host, you can run the following command \n\n{command}")
-
-    if copy_to_clipboard:
-        input("Press a key to copy command to clipboard...")
-        pyperclip.copy(command)
 
 
 @task(
@@ -91,22 +60,8 @@ def destroy_kind(
     stack_name: Optional[str] = None,
     yes: Optional[bool] = False,
 ):
-    """
-    Destroy an environment created by invoke create_docker.
-    """
-    destroy(
-        ctx,
-        scenario_name=scenario_name,
-        config_path=config_path,
-        stack=stack_name,
-        force_yes=yes,
-    )
+    print('This command is deprecated, please use `aws.destroy-kind` instead')
+    print("Running `aws.destroy-kind`...")
+    from tasks.aws.kind import destroy_kind as destroy_kind_aws
 
-
-def _get_architecture(architecture: Optional[str]) -> str:
-    architectures = tool.get_architectures()
-    if architecture is None:
-        architecture = tool.get_default_architecture()
-    if architecture.lower() not in architectures:
-        raise Exit(f"The os family '{architecture}' is not supported. Possibles values are {', '.join(architectures)}")
-    return architecture
+    destroy_kind_aws(ctx, config_path, stack_name, yes)

--- a/tasks/vm.py
+++ b/tasks/vm.py
@@ -5,8 +5,6 @@ from invoke.tasks import task
 
 from . import doc
 
-scenario_name = "aws/vm"
-
 
 @task(
     help={
@@ -49,7 +47,7 @@ def create_vm(
     no_verify: Optional[bool] = False,
     ssh_user: Optional[str] = None,
 ) -> None:
-    from tasks.aws import create_vm as create_vm_aws
+    from tasks.aws.vm import create_vm as create_vm_aws
 
     print('This command is deprecated, please use `aws.create-vm` instead')
     print("Running `aws.create-vm`...")
@@ -90,7 +88,7 @@ def destroy_vm(
     yes: Optional[bool] = False,
     clean_known_hosts: Optional[bool] = True,
 ):
-    from tasks.aws import destroy_vm as destroy_vm_aws
+    from tasks.aws.vm import destroy_vm as destroy_vm_aws
 
     print('This command is deprecated, please use `aws.destroy-vm` instead')
     print("Running `aws.destroy-vm`...")


### PR DESCRIPTION
What does this PR do?
---------------------

Migrate all the commands that are provider-specific to a specific package:
- `create-vm` and `destroy-vm` to `aws.create-vm` and `aws.destroy-vm`
- `create-docker` and `destroy-docker` to `aws.create-docker` and `aws.destroy-docker`
- `create-kind` and `destroy-kind` to `aws.create-kind` and `aws.destroy-kind`
- `create-ecs` and `destroy-ecs` to `aws.create-ecs` and `aws.destroy-ecs`
- `create-eks` and `destroy-eks` to `aws.create-eks` and `aws.destroy-eks`
- `create-installer-lab` and `destroy-installer-lab` to `aws.create-installer-lab` and `aws.destroy-installer-lab`
- `create-aks` and `destroy-aks` to `az.create-aks` and `aws.destroy-aks`

Old commands are deprecated and not removed (yet). They will print a warning and redirect to the new version if used. 

This PR does not modify anything else in the code, we're just reorganizing the tasks.

I did not modify the integration test on purpose to make sure the old command still works. I expect people to be used to it

Which scenarios this will impact?
-------------------

Motivation
----------

We started to introduce [Azure](https://github.com/DataDog/test-infra-definitions/pull/958) as a provider and we will soon add GCP, so we need to reorganize the tasks

Additional Notes
----------------

We still have some AWS specific things in common task we will need to clean up in the future
