### PR TITLE
Enable integration tests for Azure in the CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,6 +58,7 @@ integration-testing:
     - when: on_success
   before_script:
     # Setup Azure credentials. https://www.pulumi.com/registry/packages/azure-native/installation-configuration/#set-configuration-using-pulumi-config
+    # The app is called `agent-e2e-tests`
     - export ARM_CLIENT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_id --with-decryption --query "Parameter.Value" --out text)
     - export ARM_CLIENT_SECRET=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_secret --with-decryption --query "Parameter.Value" --out text)
     - export ARM_TENANT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_tenant_id --with-decryption --query "Parameter.Value" --out text)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,12 +57,11 @@ integration-testing:
   rules:
     - when: on_success
   before_script:
-    # Setup Azure credentials
-    - export AZURE_CLIENT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_id --with-decryption --query "Parameter.Value" --out text)
-    - export AZURE_CLIENT_SECRET=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_secret --with-decryption --query "Parameter.Value" --out text)
-    - export AZURE_TENANT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_tenant_id --with-decryption --query "Parameter.Value" --out text)
-    - export AZURE_SUBSCRIPTION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_subscription_id --with-decryption --query "Parameter.Value" --out text)
-    - az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" --tenant "$AZURE_TENANT_ID" > /dev/null
+    # Setup Azure credentials. https://www.pulumi.com/registry/packages/azure-native/installation-configuration/#set-configuration-using-pulumi-config
+    - export ARM_CLIENT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_id --with-decryption --query "Parameter.Value" --out text)
+    - export ARM_CLIENT_SECRET=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_secret --with-decryption --query "Parameter.Value" --out text)
+    - export ARM_TENANT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_tenant_id --with-decryption --query "Parameter.Value" --out text)
+    - export ARM_SUBSCRIPTION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_subscription_id --with-decryption --query "Parameter.Value" --out text)
     # Setup AWS Credentials
     - mkdir -p ~/.aws
     - aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.agent-qa-profile --with-decryption --query "Parameter.Value" --out text >> ~/.aws/config

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,12 +57,12 @@ integration-testing:
   rules:
     - when: on_success
   before_script:
-    # Setup Azure credentials. Uncomment once the resources are ready
-#    - export AZURE_CLIENT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_id --with-decryption --query "Parameter.Value" --out text)
-#    - export AZURE_CLIENT_SECRET=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_secret --with-decryption --query "Parameter.Value" --out text)
-#    - export AZURE_TENANT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_tenant_id --with-decryption --query "Parameter.Value" --out text)
-#    - export AZURE_SUBSCRIPTION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_subscription_id --with-decryption --query "Parameter.Value" --out text)
-#    - az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" --tenant "$AZURE_TENANT_ID" > /dev/null
+    # Setup Azure credentials
+    - export AZURE_CLIENT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_id --with-decryption --query "Parameter.Value" --out text)
+    - export AZURE_CLIENT_SECRET=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_secret --with-decryption --query "Parameter.Value" --out text)
+    - export AZURE_TENANT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_tenant_id --with-decryption --query "Parameter.Value" --out text)
+    - export AZURE_SUBSCRIPTION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_subscription_id --with-decryption --query "Parameter.Value" --out text)
+    - az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" --tenant "$AZURE_TENANT_ID" > /dev/null
     # Setup AWS Credentials
     - mkdir -p ~/.aws
     - aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.agent-qa-profile --with-decryption --query "Parameter.Value" --out text >> ~/.aws/config

--- a/integration-tests/invoke_test.go
+++ b/integration-tests/invoke_test.go
@@ -55,20 +55,20 @@ func TestInvokes(t *testing.T) {
 		testAzureInvokeVM(t, tmpConfigFile, *workingDir)
 	})
 
-	//t.Run("aws.create-vm", func(t *testing.T) {
-	//	t.Parallel()
-	//	testAwsInvokeVM(t, tmpConfigFile, *workingDir)
-	//})
-	//
-	//t.Run("invoke-docker-vm", func(t *testing.T) {
-	//	t.Parallel()
-	//	testInvokeDockerVM(t, tmpConfigFile, *workingDir)
-	//})
-	//
-	//t.Run("invoke-kind", func(t *testing.T) {
-	//	t.Parallel()
-	//	testInvokeKind(t, tmpConfigFile, *workingDir)
-	//})
+	t.Run("aws.create-vm", func(t *testing.T) {
+		t.Parallel()
+		testAwsInvokeVM(t, tmpConfigFile, *workingDir)
+	})
+
+	t.Run("invoke-docker-vm", func(t *testing.T) {
+		t.Parallel()
+		testInvokeDockerVM(t, tmpConfigFile, *workingDir)
+	})
+
+	t.Run("invoke-kind", func(t *testing.T) {
+		t.Parallel()
+		testInvokeKind(t, tmpConfigFile, *workingDir)
+	})
 }
 
 func testAzureInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
@@ -88,68 +88,67 @@ func testAzureInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory stri
 	require.NoError(t, err, "Error found destroying stack: %s", string(destroyOutput))
 }
 
-//
-//func testAwsInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
-//	t.Helper()
-//
-//	stackName := fmt.Sprintf("aws-invoke-vm-%s", os.Getenv("CI_PIPELINE_ID"))
-//	t.Log("creating vm")
-//	createCmd := exec.Command("invoke", "aws.create-vm", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake")
-//	createCmd.Dir = workingDirectory
-//	createOutput, err := createCmd.Output()
-//	assert.NoError(t, err, "Error found creating vm: %s", string(createOutput))
-//
-//	t.Log("destroying vm")
-//	destroyCmd := exec.Command("invoke", "aws.destroy-vm", "--yes", "--no-clean-known-hosts", "--stack-name", stackName, "--config-path", tmpConfigFile)
-//	destroyCmd.Dir = workingDirectory
-//	destroyOutput, err := destroyCmd.Output()
-//	require.NoError(t, err, "Error found destroying stack: %s", string(destroyOutput))
-//}
-//
-//func testInvokeDockerVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
-//	t.Helper()
-//	stackName := fmt.Sprintf("invoke-docker-vm-%s", os.Getenv("CI_PIPELINE_ID"))
-//	t.Log("creating vm with docker")
-//	var stdOut, stdErr bytes.Buffer
-//
-//	createCmd := exec.Command("invoke", "create-docker", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake", "--use-loadBalancer")
-//	createCmd.Dir = workingDirectory
-//	createCmd.Stdout = &stdOut
-//	createCmd.Stderr = &stdErr
-//	err := createCmd.Run()
-//	assert.NoError(t, err, "Error found creating docker vm.\n   stdout: %s\n   stderr: %s", stdOut.String(), stdErr.String())
-//
-//	stdOut.Reset()
-//	stdErr.Reset()
-//
-//	t.Log("destroying vm with docker")
-//	destroyCmd := exec.Command("invoke", "destroy-docker", "--yes", "--stack-name", stackName, "--config-path", tmpConfigFile)
-//	destroyCmd.Dir = workingDirectory
-//	destroyCmd.Stdout = &stdOut
-//	destroyCmd.Stderr = &stdErr
-//	err = destroyCmd.Run()
-//	require.NoError(t, err, "Error found destroying stack.\n   stdout: %s\n   stderr: %s", stdOut.String(), stdErr.String())
-//}
-//
-//func testInvokeKind(t *testing.T, tmpConfigFile string, workingDirectory string) {
-//	t.Helper()
-//	stackParts := []string{"invoke", "kind"}
-//	if os.Getenv("CI") == "true" {
-//		stackParts = append(stackParts, os.Getenv("CI_PIPELINE_ID"))
-//	}
-//	stackName := strings.Join(stackParts, "-")
-//	t.Log("creating kind cluster")
-//	createCmd := exec.Command("invoke", "create-kind", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake", "--use-loadBalancer")
-//	createCmd.Dir = workingDirectory
-//	createOutput, err := createCmd.Output()
-//	assert.NoError(t, err, "Error found creating kind cluster: %s", string(createOutput))
-//
-//	t.Log("destroying kind cluster")
-//	destroyCmd := exec.Command("invoke", "destroy-kind", "--yes", "--stack-name", stackName, "--config-path", tmpConfigFile)
-//	destroyCmd.Dir = workingDirectory
-//	destroyOutput, err := destroyCmd.Output()
-//	require.NoError(t, err, "Error found destroying kind cluster: %s", string(destroyOutput))
-//}
+func testAwsInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
+	t.Helper()
+
+	stackName := fmt.Sprintf("aws-invoke-vm-%s", os.Getenv("CI_PIPELINE_ID"))
+	t.Log("creating vm")
+	createCmd := exec.Command("invoke", "aws.create-vm", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake")
+	createCmd.Dir = workingDirectory
+	createOutput, err := createCmd.Output()
+	assert.NoError(t, err, "Error found creating vm: %s", string(createOutput))
+
+	t.Log("destroying vm")
+	destroyCmd := exec.Command("invoke", "aws.destroy-vm", "--yes", "--no-clean-known-hosts", "--stack-name", stackName, "--config-path", tmpConfigFile)
+	destroyCmd.Dir = workingDirectory
+	destroyOutput, err := destroyCmd.Output()
+	require.NoError(t, err, "Error found destroying stack: %s", string(destroyOutput))
+}
+
+func testInvokeDockerVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
+	t.Helper()
+	stackName := fmt.Sprintf("invoke-docker-vm-%s", os.Getenv("CI_PIPELINE_ID"))
+	t.Log("creating vm with docker")
+	var stdOut, stdErr bytes.Buffer
+
+	createCmd := exec.Command("invoke", "create-docker", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake", "--use-loadBalancer")
+	createCmd.Dir = workingDirectory
+	createCmd.Stdout = &stdOut
+	createCmd.Stderr = &stdErr
+	err := createCmd.Run()
+	assert.NoError(t, err, "Error found creating docker vm.\n   stdout: %s\n   stderr: %s", stdOut.String(), stdErr.String())
+
+	stdOut.Reset()
+	stdErr.Reset()
+
+	t.Log("destroying vm with docker")
+	destroyCmd := exec.Command("invoke", "destroy-docker", "--yes", "--stack-name", stackName, "--config-path", tmpConfigFile)
+	destroyCmd.Dir = workingDirectory
+	destroyCmd.Stdout = &stdOut
+	destroyCmd.Stderr = &stdErr
+	err = destroyCmd.Run()
+	require.NoError(t, err, "Error found destroying stack.\n   stdout: %s\n   stderr: %s", stdOut.String(), stdErr.String())
+}
+
+func testInvokeKind(t *testing.T, tmpConfigFile string, workingDirectory string) {
+	t.Helper()
+	stackParts := []string{"invoke", "kind"}
+	if os.Getenv("CI") == "true" {
+		stackParts = append(stackParts, os.Getenv("CI_PIPELINE_ID"))
+	}
+	stackName := strings.Join(stackParts, "-")
+	t.Log("creating kind cluster")
+	createCmd := exec.Command("invoke", "create-kind", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake", "--use-loadBalancer")
+	createCmd.Dir = workingDirectory
+	createOutput, err := createCmd.Output()
+	assert.NoError(t, err, "Error found creating kind cluster: %s", string(createOutput))
+
+	t.Log("destroying kind cluster")
+	destroyCmd := exec.Command("invoke", "destroy-kind", "--yes", "--stack-name", stackName, "--config-path", tmpConfigFile)
+	destroyCmd.Dir = workingDirectory
+	destroyOutput, err := destroyCmd.Output()
+	require.NoError(t, err, "Error found destroying kind cluster: %s", string(destroyOutput))
+}
 
 //go:embed testfixture/config.yaml
 var testInfraTestConfig string

--- a/integration-tests/invoke_test.go
+++ b/integration-tests/invoke_test.go
@@ -50,106 +50,106 @@ func TestInvokes(t *testing.T) {
 
 	// Subtests
 
-	// Uncomment once the resources will be created
-	//t.Run("az.create-vm", func(t *testing.T) {
+	t.Run("az.create-vm", func(t *testing.T) {
+		t.Parallel()
+		testAzureInvokeVM(t, tmpConfigFile, *workingDir)
+	})
+
+	//t.Run("aws.create-vm", func(t *testing.T) {
 	//	t.Parallel()
-	//	testAzureInvokeVM(t, tmpConfigFile, *workingDir)
+	//	testAwsInvokeVM(t, tmpConfigFile, *workingDir)
 	//})
-
-	t.Run("aws.create-vm", func(t *testing.T) {
-		t.Parallel()
-		testAwsInvokeVM(t, tmpConfigFile, *workingDir)
-	})
-
-	t.Run("invoke-docker-vm", func(t *testing.T) {
-		t.Parallel()
-		testInvokeDockerVM(t, tmpConfigFile, *workingDir)
-	})
-
-	t.Run("invoke-kind", func(t *testing.T) {
-		t.Parallel()
-		testInvokeKind(t, tmpConfigFile, *workingDir)
-	})
+	//
+	//t.Run("invoke-docker-vm", func(t *testing.T) {
+	//	t.Parallel()
+	//	testInvokeDockerVM(t, tmpConfigFile, *workingDir)
+	//})
+	//
+	//t.Run("invoke-kind", func(t *testing.T) {
+	//	t.Parallel()
+	//	testInvokeKind(t, tmpConfigFile, *workingDir)
+	//})
 }
 
-//func testAzureInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
-//	t.Helper()
-//
-//	stackName := fmt.Sprintf("az-invoke-vm-%s", os.Getenv("CI_PIPELINE_ID"))
-//	t.Log("creating vm")
-//	createCmd := exec.Command("invoke", "az.create-vm", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--account", "agent-qa")
-//	createCmd.Dir = workingDirectory
-//	createOutput, err := createCmd.Output()
-//	assert.NoError(t, err, "Error found creating vm: %s", string(createOutput))
-//
-//	t.Log("destroying vm")
-//	destroyCmd := exec.Command("invoke", "az.destroy-vm", "--yes", "--no-clean-known-hosts", "--stack-name", stackName, "--config-path", tmpConfigFile)
-//	destroyCmd.Dir = workingDirectory
-//	destroyOutput, err := destroyCmd.Output()
-//	require.NoError(t, err, "Error found destroying stack: %s", string(destroyOutput))
-//}
-
-func testAwsInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
+func testAzureInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
 	t.Helper()
 
-	stackName := fmt.Sprintf("aws-invoke-vm-%s", os.Getenv("CI_PIPELINE_ID"))
+	stackName := fmt.Sprintf("az-invoke-vm-%s", os.Getenv("CI_PIPELINE_ID"))
 	t.Log("creating vm")
-	createCmd := exec.Command("invoke", "aws.create-vm", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake")
+	createCmd := exec.Command("invoke", "az.create-vm", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--account", "agent-qa")
 	createCmd.Dir = workingDirectory
 	createOutput, err := createCmd.Output()
 	assert.NoError(t, err, "Error found creating vm: %s", string(createOutput))
 
 	t.Log("destroying vm")
-	destroyCmd := exec.Command("invoke", "aws.destroy-vm", "--yes", "--no-clean-known-hosts", "--stack-name", stackName, "--config-path", tmpConfigFile)
+	destroyCmd := exec.Command("invoke", "az.destroy-vm", "--yes", "--no-clean-known-hosts", "--stack-name", stackName, "--config-path", tmpConfigFile)
 	destroyCmd.Dir = workingDirectory
 	destroyOutput, err := destroyCmd.Output()
 	require.NoError(t, err, "Error found destroying stack: %s", string(destroyOutput))
 }
 
-func testInvokeDockerVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
-	t.Helper()
-	stackName := fmt.Sprintf("invoke-docker-vm-%s", os.Getenv("CI_PIPELINE_ID"))
-	t.Log("creating vm with docker")
-	var stdOut, stdErr bytes.Buffer
-
-	createCmd := exec.Command("invoke", "create-docker", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake", "--use-loadBalancer")
-	createCmd.Dir = workingDirectory
-	createCmd.Stdout = &stdOut
-	createCmd.Stderr = &stdErr
-	err := createCmd.Run()
-	assert.NoError(t, err, "Error found creating docker vm.\n   stdout: %s\n   stderr: %s", stdOut.String(), stdErr.String())
-
-	stdOut.Reset()
-	stdErr.Reset()
-
-	t.Log("destroying vm with docker")
-	destroyCmd := exec.Command("invoke", "destroy-docker", "--yes", "--stack-name", stackName, "--config-path", tmpConfigFile)
-	destroyCmd.Dir = workingDirectory
-	destroyCmd.Stdout = &stdOut
-	destroyCmd.Stderr = &stdErr
-	err = destroyCmd.Run()
-	require.NoError(t, err, "Error found destroying stack.\n   stdout: %s\n   stderr: %s", stdOut.String(), stdErr.String())
-}
-
-func testInvokeKind(t *testing.T, tmpConfigFile string, workingDirectory string) {
-	t.Helper()
-	stackParts := []string{"invoke", "kind"}
-	if os.Getenv("CI") == "true" {
-		stackParts = append(stackParts, os.Getenv("CI_PIPELINE_ID"))
-	}
-	stackName := strings.Join(stackParts, "-")
-	t.Log("creating kind cluster")
-	createCmd := exec.Command("invoke", "create-kind", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake", "--use-loadBalancer")
-	createCmd.Dir = workingDirectory
-	createOutput, err := createCmd.Output()
-	assert.NoError(t, err, "Error found creating kind cluster: %s", string(createOutput))
-
-	t.Log("destroying kind cluster")
-	destroyCmd := exec.Command("invoke", "destroy-kind", "--yes", "--stack-name", stackName, "--config-path", tmpConfigFile)
-	destroyCmd.Dir = workingDirectory
-	destroyOutput, err := destroyCmd.Output()
-	require.NoError(t, err, "Error found destroying kind cluster: %s", string(destroyOutput))
-}
+//
+//func testAwsInvokeVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
+//	t.Helper()
+//
+//	stackName := fmt.Sprintf("aws-invoke-vm-%s", os.Getenv("CI_PIPELINE_ID"))
+//	t.Log("creating vm")
+//	createCmd := exec.Command("invoke", "aws.create-vm", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake")
+//	createCmd.Dir = workingDirectory
+//	createOutput, err := createCmd.Output()
+//	assert.NoError(t, err, "Error found creating vm: %s", string(createOutput))
+//
+//	t.Log("destroying vm")
+//	destroyCmd := exec.Command("invoke", "aws.destroy-vm", "--yes", "--no-clean-known-hosts", "--stack-name", stackName, "--config-path", tmpConfigFile)
+//	destroyCmd.Dir = workingDirectory
+//	destroyOutput, err := destroyCmd.Output()
+//	require.NoError(t, err, "Error found destroying stack: %s", string(destroyOutput))
+//}
+//
+//func testInvokeDockerVM(t *testing.T, tmpConfigFile string, workingDirectory string) {
+//	t.Helper()
+//	stackName := fmt.Sprintf("invoke-docker-vm-%s", os.Getenv("CI_PIPELINE_ID"))
+//	t.Log("creating vm with docker")
+//	var stdOut, stdErr bytes.Buffer
+//
+//	createCmd := exec.Command("invoke", "create-docker", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake", "--use-loadBalancer")
+//	createCmd.Dir = workingDirectory
+//	createCmd.Stdout = &stdOut
+//	createCmd.Stderr = &stdErr
+//	err := createCmd.Run()
+//	assert.NoError(t, err, "Error found creating docker vm.\n   stdout: %s\n   stderr: %s", stdOut.String(), stdErr.String())
+//
+//	stdOut.Reset()
+//	stdErr.Reset()
+//
+//	t.Log("destroying vm with docker")
+//	destroyCmd := exec.Command("invoke", "destroy-docker", "--yes", "--stack-name", stackName, "--config-path", tmpConfigFile)
+//	destroyCmd.Dir = workingDirectory
+//	destroyCmd.Stdout = &stdOut
+//	destroyCmd.Stderr = &stdErr
+//	err = destroyCmd.Run()
+//	require.NoError(t, err, "Error found destroying stack.\n   stdout: %s\n   stderr: %s", stdOut.String(), stdErr.String())
+//}
+//
+//func testInvokeKind(t *testing.T, tmpConfigFile string, workingDirectory string) {
+//	t.Helper()
+//	stackParts := []string{"invoke", "kind"}
+//	if os.Getenv("CI") == "true" {
+//		stackParts = append(stackParts, os.Getenv("CI_PIPELINE_ID"))
+//	}
+//	stackName := strings.Join(stackParts, "-")
+//	t.Log("creating kind cluster")
+//	createCmd := exec.Command("invoke", "create-kind", "--no-interactive", "--stack-name", stackName, "--config-path", tmpConfigFile, "--use-fakeintake", "--use-loadBalancer")
+//	createCmd.Dir = workingDirectory
+//	createOutput, err := createCmd.Output()
+//	assert.NoError(t, err, "Error found creating kind cluster: %s", string(createOutput))
+//
+//	t.Log("destroying kind cluster")
+//	destroyCmd := exec.Command("invoke", "destroy-kind", "--yes", "--stack-name", stackName, "--config-path", tmpConfigFile)
+//	destroyCmd.Dir = workingDirectory
+//	destroyOutput, err := destroyCmd.Output()
+//	require.NoError(t, err, "Error found destroying kind cluster: %s", string(destroyOutput))
+//}
 
 //go:embed testfixture/config.yaml
 var testInfraTestConfig string

--- a/integration-tests/testfixture/config.yaml
+++ b/integration-tests/testfixture/config.yaml
@@ -7,6 +7,8 @@ configParams:
     keyPairName: KEY_PAIR_NAME
     publicKeyPath: PUBLIC_KEY_PATH
     teamTag: test-ci
+  azure:
+    publicKeyPath: PUBLIC_KEY_PATH
   pulumi:
     logLevel: 1
     logToStdErr: true

--- a/resources/azure/environmentDefaults.go
+++ b/resources/azure/environmentDefaults.go
@@ -93,10 +93,10 @@ func agentQaDefault() environmentDefault {
 			location:       "West US 2",
 		},
 		ddInfra: ddInfra{
-			defaultResourceGroup:   "dd-agent-sandbox",
-			defaultVNet:            "/subscriptions/9972cab2-9e99-419b-a683-86bfa77b3df1/resourceGroups/dd-agent-sandbox/providers/Microsoft.Network/virtualNetworks/dd-agent-sandbox",
-			defaultSubnet:          "/subscriptions/9972cab2-9e99-419b-a683-86bfa77b3df1/resourceGroups/dd-agent-sandbox/providers/Microsoft.Network/virtualNetworks/dd-agent-sandbox/subnets/dd-agent-sandbox-private",
-			defaultSecurityGroup:   "/subscriptions/9972cab2-9e99-419b-a683-86bfa77b3df1/resourceGroups/dd-agent-sandbox/providers/Microsoft.Network/networkSecurityGroups/appgategreen",
+			defaultResourceGroup:   "dd-agent-qa",
+			defaultVNet:            "/subscriptions/c767177d-c6fc-47d3-a87e-3ab195f5b99e/resourceGroups/dd-agent-qa/providers/Microsoft.Network/virtualNetworks/dd-agent-qa",
+			defaultSubnet:          "/subscriptions/c767177d-c6fc-47d3-a87e-3ab195f5b99e/resourceGroups/dd-agent-qa/providers/Microsoft.Network/virtualNetworks/dd-agent-qa/subnets/dd-agent-qa-private",
+			defaultSecurityGroup:   "/subscriptions/c767177d-c6fc-47d3-a87e-3ab195f5b99e/resourceGroups/dd-agent-qa/providers/Microsoft.Network/networkSecurityGroups/appgategreen",
 			defaultInstanceType:    "Standard_D2a_v4",  // Allows nested virtualization for kata runtimes
 			defaultARMInstanceType: "Standard_D4ps_v5", // No azure arm instance supports nested virtualization
 			aks: ddInfraAks{


### PR DESCRIPTION
What does this PR do?
---------------------

Enable integration tests for Azure in the CI

- The app was created in https://github.com/DataDog/cloud-inventory/pull/20422 and https://github.com/DataDog/cloud-inventory/pull/20461 with the help of the #cloudops team.
- The secret was manually created by the cloudops team. I added an alert for the expiration, which is in 2 years

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------

I'll store the secret in the Agent Platform 1password vault 
