### PR TITLE
Install the Python dependency directly in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -110,8 +110,7 @@ RUN --mount=type=secret,id=github_token \
   export PULUMI_CONFIG_PASSPHRASE=dummy && \
   pulumi --logflow --logtostderr -v 5 --non-interactive plugin install && \
   pulumi --non-interactive plugin ls && \
-  cd / && \
-  rm -rf /tmp/test-infra
+  cd /
 
 # Install Agent requirements, required to run invoke tests task
 # Remove AWS-related deps as we already install AWS CLI v2
@@ -120,7 +119,10 @@ RUN --mount=type=secret,id=github_token \
 RUN pip3 install "cython<3.0.0" && \
   pip3 install --no-build-isolation PyYAML==5.4.1 && \
   pip3 install -r https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/requirements/e2e.txt & \
+  pip3 install -r /tmp/test-infra/requirements.txt & \
   go install gotest.tools/gotestsum@latest
+
+RUN rm -rf /tmp/test-infra
 
 # Configure aws retries
 COPY .awsconfig $HOME/.aws/config


### PR DESCRIPTION
What does this PR do?
---------------------

Install the Python dependencies directly in the docker image. It also fix the issues we had [here](https://gitlab.ddbuild.io/DataDog/test-infra-definitions/-/jobs/581470803) because of the way the dependencies are resolved.

Which scenarios this will impact?
-------------------

None

Motivation
----------

We faced some issues related to building `pyperclip` in the `integration-testing` job, which is running later. Installing the dependencies in the Docker image saves us some time to debug issues on that front

Additional Notes
----------------
