### PR TITLE
[task] return error if aws or az cli are not installed

### DIFF
--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -27,13 +27,11 @@ def setup(
     Setup a local environment, interactively by default
     """
     # Ensure aws cli is installed
-    result = ctx.run("aws --version", warn=True, hide=True)
-    if result is None or result.exited != 0:
+    if not shutil.which("aws"):
         error("AWS CLI not found, please install it: https://aws.amazon.com/cli/")
         raise Exit(code=1)
     # Ensure azure cli is installed
-    result = ctx.run("az --version", warn=True, hide=True)
-    if result is None or result.exited != 0:
+    if not shutil.which("az"):
         error("Azure CLI not found, please install it: https://learn.microsoft.com/en-us/cli/azure/install-azure-cli")
         raise Exit(code=1)
 

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -26,6 +26,17 @@ def setup(
     """
     Setup a local environment, interactively by default
     """
+    # Ensure aws cli is installed
+    result = ctx.run("aws --version", warn=True, hide=True)
+    if result is None or result.exited != 0:
+        error("AWS CLI not found, please install it: https://aws.amazon.com/cli/")
+        raise Exit(code=1)
+    # Ensure azure cli is installed
+    result = ctx.run("az --version", warn=True, hide=True)
+    if result is None or result.exited != 0:
+        error("Azure CLI not found, please install it: https://learn.microsoft.com/en-us/cli/azure/install-azure-cli")
+        raise Exit(code=1)
+
     pulumi_version, pulumi_up_to_date = _pulumi_version(ctx)
     if pulumi_up_to_date:
         info(f"Pulumi is up to date: {pulumi_version}")


### PR DESCRIPTION
What does this PR do?
---------------------

Add check at setup time to ensure az and aws cli are installed

Which scenarios this will impact?
-------------------

None

Motivation
----------

I did not have az cli installed, don't think it comes by default on our laptops. Better to warn contributors inline.

Additional Notes
----------------
