### PR TITLE
Update dependency between helm installation and Kubernetes agent comp…

### DIFF
--- a/components/datadog/agent/helm/kubernetes_agent.go
+++ b/components/datadog/agent/helm/kubernetes_agent.go
@@ -2,6 +2,7 @@ package helm
 
 import (
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent"
 
@@ -16,6 +17,7 @@ func NewKubernetesAgent(e config.Env, resourceName string, kubeProvider *kuberne
 		if err != nil {
 			return err
 		}
+		pulumiResourceOptions := append(params.PulumiResourceOptions, pulumi.Parent(comp))
 
 		helmComponent, err := agent.NewHelmInstallation(e, agent.HelmInstallationArgs{
 			KubeProvider:                   kubeProvider,
@@ -26,7 +28,7 @@ func NewKubernetesAgent(e config.Env, resourceName string, kubeProvider *kuberne
 			AgentFullImagePath:             params.AgentFullImagePath,
 			ClusterAgentFullImagePath:      params.ClusterAgentFullImagePath,
 			DisableLogsContainerCollectAll: params.DisableLogsContainerCollectAll,
-		}, params.PulumiResourceOptions...)
+		}, pulumiResourceOptions...)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
…onent

What does this PR do?
---------------------

Before the changes introduced in https://github.com/DataDog/test-infra-definitions/pull/881 we had helmComponent -> workloads
After the change we added an extra nesting with helmComponent -/-> kubernetesAgentComponent -> workloads
We need to wait for the helmComponent to be deployed before trying to deploy the workload because they need the CRD that are created by datadog-agent helm chart.
My PR should add back the broken link between helmComponent and kubernetesAgentComponent and prevent flakiness

Fix dependency issue

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
