### PR TITLE
Extract AWS-specific parts from the common deploy function

### DIFF
--- a/tasks/aws/deploy.py
+++ b/tasks/aws/deploy.py
@@ -1,0 +1,109 @@
+import os
+import subprocess
+from typing import Any, Dict, List, Optional
+
+from invoke.context import Context
+from invoke.exceptions import Exit
+from pydantic_core._pydantic_core import ValidationError
+
+from tasks import config, tool
+from tasks.config import Config, get_full_profile_path
+from tasks.deploy import deploy as common_deploy
+
+default_public_path_key_name = "ddinfra:aws/defaultPublicKeyPath"
+
+
+def deploy(
+    ctx: Context,
+    scenario_name: str,
+    config_path: Optional[str] = None,
+    key_pair_required: bool = False,
+    public_key_required: bool = False,
+    app_key_required: bool = False,
+    stack_name: Optional[str] = None,
+    pipeline_id: Optional[str] = None,
+    install_agent: Optional[bool] = None,
+    install_updater: Optional[bool] = None,
+    install_workload: Optional[bool] = None,
+    agent_version: Optional[str] = None,
+    debug: Optional[bool] = False,
+    extra_flags: Optional[Dict[str, Any]] = None,
+    use_fakeintake: Optional[bool] = False,
+    deploy_job: Optional[str] = None,
+) -> str:
+    flags = extra_flags if extra_flags else {}
+
+    try:
+        cfg = config.get_local_config(config_path)
+    except ValidationError as e:
+        raise Exit(f"Error in config {get_full_profile_path(config_path)}") from e
+
+    flags[default_public_path_key_name] = _get_public_path_key_name(cfg, public_key_required)
+
+    awsKeyPairName = cfg.get_aws().keyPairName
+
+    flags["ddinfra:aws/defaultKeyPairName"] = awsKeyPairName
+    aws_account = cfg.get_aws().get_account()
+    flags.setdefault("ddinfra:env", "aws/" + aws_account)
+
+    # Verify image deployed and not outdated in s3
+    if deploy_job is not None and pipeline_id is not None:
+        cmd = f"inv -e check-s3-image-exists --pipeline-id={pipeline_id} --deploy-job={deploy_job}"
+        cmd = tool.get_aws_wrapper(aws_account) + cmd
+        output = ctx.run(cmd, warn=True)
+
+        # The command already has a traceback
+        if not output or output.return_code != 0:
+            exit(1)
+
+    if cfg.get_aws().teamTag is None or cfg.get_aws().teamTag == "":
+        raise Exit(
+            "Error in config, missing configParams.aws.teamTag. Run `inv setup` again and provide a valid team name"
+        )
+
+    if key_pair_required and cfg.get_options().checkKeyPair:
+        _check_key_pair(awsKeyPairName)
+
+    return common_deploy(
+        ctx,
+        scenario_name,
+        config_path,
+        app_key_required,
+        stack_name,
+        pipeline_id,
+        install_agent,
+        install_updater,
+        install_workload,
+        agent_version,
+        debug,
+        flags,
+        use_fakeintake,
+    )
+
+
+def _check_key_pair(key_pair_to_search: Optional[str]):
+    if key_pair_to_search is None or key_pair_to_search == "":
+        raise Exit("This scenario requires to define 'defaultKeyPairName' in the configuration file")
+    output = subprocess.check_output(["ssh-add", "-L"])
+    key_pairs: List[str] = []
+    output = output.decode("utf-8")
+    for line in output.splitlines():
+        parts = line.split(" ")
+        if parts:
+            key_pair_path = os.path.basename(parts[-1])
+            key_pair = os.path.splitext(key_pair_path)[0]
+            key_pairs.append(key_pair)
+
+    if key_pair_to_search not in key_pairs:
+        raise Exit(
+            f"Your key pair value '{key_pair_to_search}' is not find in ssh-agent. "
+            + f"You may have issue to connect to the remote instance. Possible values are \n{key_pairs}. "
+            + "You can skip this check by setting `checkKeyPair: false` in the config"
+        )
+
+
+def _get_public_path_key_name(cfg: Config, require: bool) -> Optional[str]:
+    defaultPublicKeyPath = cfg.get_aws().publicKeyPath
+    if require and defaultPublicKeyPath is None:
+        raise Exit(f"Your scenario requires to define {default_public_path_key_name} in the configuration file")
+    return f'"{defaultPublicKeyPath}"'

--- a/tasks/aws/docker.py
+++ b/tasks/aws/docker.py
@@ -6,7 +6,7 @@ from invoke.exceptions import Exit
 from invoke.tasks import task
 
 from tasks import doc, tool
-from tasks.deploy import deploy
+from tasks.aws.deploy import deploy
 from tasks.destroy import destroy
 
 scenario_name = "aws/dockervm"

--- a/tasks/aws/ecs.py
+++ b/tasks/aws/ecs.py
@@ -7,7 +7,7 @@ from invoke.tasks import task
 from pydantic import ValidationError
 
 from tasks import config, doc, tool
-from tasks.deploy import deploy
+from tasks.aws.deploy import deploy
 from tasks.destroy import destroy
 
 scenario_name = "aws/ecs"

--- a/tasks/aws/eks.py
+++ b/tasks/aws/eks.py
@@ -10,7 +10,7 @@ from invoke.tasks import task
 from pydantic import ValidationError
 
 from tasks import config, doc, tool
-from tasks.deploy import deploy
+from tasks.aws.deploy import deploy
 from tasks.destroy import destroy
 
 scenario_name = "aws/eks"

--- a/tasks/aws/installer.py
+++ b/tasks/aws/installer.py
@@ -4,7 +4,7 @@ from invoke.context import Context
 from invoke.tasks import task
 
 from tasks import doc
-from tasks.deploy import deploy
+from tasks.aws.deploy import deploy
 from tasks.destroy import destroy
 
 scenario_name = "aws/installer"

--- a/tasks/aws/kind.py
+++ b/tasks/aws/kind.py
@@ -6,7 +6,7 @@ from invoke.exceptions import Exit
 from invoke.tasks import task
 
 from tasks import doc, tool
-from tasks.deploy import deploy
+from tasks.aws.deploy import deploy
 from tasks.destroy import destroy
 
 scenario_name = "aws/kind"

--- a/tasks/aws/vm.py
+++ b/tasks/aws/vm.py
@@ -5,7 +5,7 @@ from invoke.exceptions import Exit
 from invoke.tasks import task
 
 from tasks import doc, tool
-from tasks.deploy import deploy
+from tasks.aws.deploy import deploy
 from tasks.destroy import destroy
 from tasks.tool import clean_known_hosts as clean_known_hosts_func
 from tasks.tool import get_host, show_connection_message

--- a/tasks/azure/vm.py
+++ b/tasks/azure/vm.py
@@ -63,7 +63,6 @@ def create_vm(
         ctx,
         scenario_name,
         config_path,
-        key_pair_required=True,
         stack_name=stack_name,
         install_agent=install_agent,
         install_updater=install_updater,

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 from typing import Any, Callable, Dict, List, Optional
 
 import boto3
@@ -11,15 +10,11 @@ from pydantic import ValidationError
 from . import config, tool
 from .config import Config, get_full_profile_path
 
-default_public_path_key_name = "ddinfra:aws/defaultPublicKeyPath"
-
 
 def deploy(
     ctx: Context,
     scenario_name: str,
     config_path: Optional[str] = None,
-    key_pair_required: bool = False,
-    public_key_required: bool = False,
     app_key_required: bool = False,
     stack_name: Optional[str] = None,
     pipeline_id: Optional[str] = None,
@@ -30,7 +25,6 @@ def deploy(
     debug: Optional[bool] = False,
     extra_flags: Optional[Dict[str, Any]] = None,
     use_fakeintake: Optional[bool] = False,
-    deploy_job: Optional[str] = None,
 ) -> str:
     flags = extra_flags if extra_flags else {}
 
@@ -48,39 +42,13 @@ def deploy(
     except ValidationError as e:
         raise Exit(f"Error in config {get_full_profile_path(config_path)}") from e
 
-    flags[default_public_path_key_name] = _get_public_path_key_name(cfg, public_key_required)
     flags["scenario"] = scenario_name
     flags["ddagent:pipeline_id"] = pipeline_id
     flags["ddagent:version"] = agent_version
     flags["ddagent:fakeintake"] = use_fakeintake
 
-    awsKeyPairName = cfg.get_aws().keyPairName
-
-    flags["ddinfra:aws/defaultKeyPairName"] = awsKeyPairName
-    aws_account = cfg.get_aws().get_account()
-    flags.setdefault("ddinfra:env", "aws/" + aws_account)
-
-    # Verify image deployed and not outdated in s3
-    if deploy_job is not None and pipeline_id is not None:
-        cmd = f"inv -e check-s3-image-exists --pipeline-id={pipeline_id} --deploy-job={deploy_job}"
-        cmd = tool.get_aws_wrapper(aws_account) + cmd
-        output = ctx.run(cmd, warn=True)
-
-        # The command already has a traceback
-        if not output or output.return_code != 0:
-            exit(1)
-
-    if cfg.get_aws().teamTag is None or cfg.get_aws().teamTag == "":
-        raise Exit(
-            "Error in config, missing configParams.aws.teamTag. Run `inv setup` again and provide a valid team name"
-        )
-    flags["ddinfra:extraResourcesTags"] = f"team:{cfg.get_aws().teamTag}"
-
     if install_agent:
         flags["ddagent:apiKey"] = _get_api_key(cfg)
-
-    if key_pair_required and cfg.get_options().checkKeyPair:
-        _check_key_pair(awsKeyPairName)
 
     # add stack params values
     stackParams = cfg.get_stack_params()
@@ -230,31 +198,3 @@ def _get_key(
             f"The scenario requires a valid {key_name} with a length of {expected_size} characters but none was found. You must define it in the config file"
         )
     return key
-
-
-def _check_key_pair(key_pair_to_search: Optional[str]):
-    if key_pair_to_search is None or key_pair_to_search == "":
-        raise Exit("This scenario requires to define 'defaultKeyPairName' in the configuration file")
-    output = subprocess.check_output(["ssh-add", "-L"])
-    key_pairs: List[str] = []
-    output = output.decode("utf-8")
-    for line in output.splitlines():
-        parts = line.split(" ")
-        if parts:
-            key_pair_path = os.path.basename(parts[-1])
-            key_pair = os.path.splitext(key_pair_path)[0]
-            key_pairs.append(key_pair)
-
-    if key_pair_to_search not in key_pairs:
-        raise Exit(
-            f"Your key pair value '{key_pair_to_search}' is not find in ssh-agent. "
-            + f"You may have issue to connect to the remote instance. Possible values are \n{key_pairs}. "
-            + "You can skip this check by setting `checkKeyPair: false` in the config"
-        )
-
-
-def _get_public_path_key_name(cfg: Config, require: bool) -> Optional[str]:
-    defaultPublicKeyPath = cfg.get_aws().publicKeyPath
-    if require and defaultPublicKeyPath is None:
-        raise Exit(f"Your scenario requires to define {default_public_path_key_name} in the configuration file")
-    return f'"{defaultPublicKeyPath}"'


### PR DESCRIPTION
What does this PR do?
---------------------

Extract AWS-specific parts from the common deploy function

Which scenarios this will impact?
-------------------

Motivation
----------

We now support Azure and it would be better to stop doing all these steps that are specific to AWS when spinning up resources on Azure

Additional Notes
----------------
