### PR TITLE
[CONTP-258] add namespace labels and annotations

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -204,6 +204,12 @@ func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentI
 			"apiKeyExistingSecret": pulumi.String(baseName + "-datadog-credentials"),
 			"appKeyExistingSecret": pulumi.String(baseName + "-datadog-credentials"),
 			"checksCardinality":    pulumi.String("high"),
+			"namespaceLabelsAsTags": pulumi.Map{
+				"related_team": pulumi.String("team"),
+			},
+			"namespaceAnnotationsAsTags": pulumi.Map{
+				"related_email": pulumi.String("email"),
+			},
 			"logs": pulumi.Map{
 				"enabled":             pulumi.Bool(true),
 				"containerCollectAll": pulumi.Bool(logsContainerCollectAll),

--- a/components/datadog/apps/nginx/k8s.go
+++ b/components/datadog/apps/nginx/k8s.go
@@ -50,6 +50,12 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 	ns, err := corev1.NewNamespace(e.Ctx(), namespace, &corev1.NamespaceArgs{
 		Metadata: metav1.ObjectMetaArgs{
 			Name: pulumi.String(namespace),
+			Labels: pulumi.StringMap{
+				"related_team": pulumi.String("contp"),
+			},
+			Annotations: pulumi.StringMap{
+				"related_email": pulumi.String("team-container-platform@datadoghq.com"),
+			},
 		},
 	}, opts...)
 	if err != nil {


### PR DESCRIPTION
What does this PR do?
---------------------
[CONTP-258](https://datadoghq.atlassian.net/browse/CONTP-258) 
Add namespaceLabelsAsTags and namespaceAnnotationsAsTags to k8s config


Which scenarios this will impact?
-------------------
k8s provider in kindvm


Motivation
----------
We don’t have any e2e test that uses “namespace labels as tags” and “namespace annotations as tags”.
It’d be good to add a simple test to notice if we accidentally break these features. 
Both configs are supported in [helm charts](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/templates/_components-common-env.yaml#L41-L47).

Additional Notes
----------------
<img width="1332" alt="Screenshot 2024-07-26 at 2 50 39 AM" src="https://github.com/user-attachments/assets/d04a90e6-3b64-4797-b72c-114f4e676df4">

inv create-kind



[CONTP-258]: https://datadoghq.atlassian.net/browse/CONTP-258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ