### PR TITLE
Try to fix depdency issue with Helm refactor

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -57,7 +57,7 @@ func NewHelmInstallation(e config.Env, args HelmInstallationArgs, opts ...pulumi
 	apiKey := e.AgentAPIKey()
 	appKey := e.AgentAPPKey()
 	baseName := "dda"
-	opts = append(opts, pulumi.Providers(args.KubeProvider), e.WithProviders(config.ProviderRandom), pulumi.Parent(args.KubeProvider), pulumi.DeletedWith(args.KubeProvider))
+	opts = append(opts, pulumi.Providers(args.KubeProvider), e.WithProviders(config.ProviderRandom), pulumi.DeletedWith(args.KubeProvider))
 
 	helmComponent := &HelmComponent{}
 	if err := e.Ctx().RegisterComponentResource("dd:agent", "dda", helmComponent, opts...); err != nil {


### PR DESCRIPTION
What does this PR do?
---------------------

We need the new `KubernetesAgent` component to be parent of all the resources created in it, otherwise the creation of these resource will not be waited before creating the workload. This should fix it by removing the `pulumi.Parent` that were changing the parent to 

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
