### PR TITLE
add another pulumi install dir for windows

### DIFF
--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -98,6 +98,7 @@ def _install_pulumi(ctx: Context):
                     Path().home().joinpath(".pulumi", "bin"),
                     Path().home().joinpath("AppData", "Local", "pulumi", "bin"),
                     'C:\\Program Files (x86)\\Pulumi\\bin',
+                    'C:\\Program Files (x86)\\Pulumi',
                 ]
             ]
             os.environ["PATH"] = ';'.join([os.environ["PATH"]] + paths)


### PR DESCRIPTION
What does this PR do?
---------------------
Adds `'C:\\Program Files (x86)\\Pulumi'` to the process env if pulumi is not found on the path.

Which scenarios this will impact?
-------------------

Motivation
----------
Previously had `'C:\\Program Files (x86)\\Pulumi\\bin'` but an update seems to have moved it, or maybe I was just wrong the first time. get-pulumi [install.ps1](https://github.com/pulumi/get.pulumi.com/blob/0e87dd6fd35abfc22dd0bfc0db1cfe8b0b4df421/dist/install.ps1#L58) still has `bin` in the path so idk what happened.

Additional Notes
----------------
