### PR TITLE
Set ubuntu as default OS family for AWS

### DIFF
--- a/tasks/aws/common.py
+++ b/tasks/aws/common.py
@@ -7,7 +7,7 @@ from invoke.exceptions import Exit
 
 
 def get_default_os_family() -> str:
-    return "debian"
+    return "ubuntu"
 
 
 def get_os_families() -> List[str]:


### PR DESCRIPTION
What does this PR do?
---------------------

Set ubuntu as default OS family for AWS

Which scenarios this will impact?
-------------------

Motivation
----------

It used to be the default but we changed it by mistake

Additional Notes
----------------
