### PR TITLE
cws-centos7: move to vault repository

### DIFF
--- a/components/datadog/apps/cws/images/cws-centos7/Dockerfile
+++ b/components/datadog/apps/cws/images/cws-centos7/Dockerfile
@@ -2,6 +2,14 @@ FROM centos:7
 
 ENV DOCKER_DD_AGENT=yes
 
+# import all gpg keys
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-*
+
+# use vault repository
+RUN mv /etc/yum.repos.d/CentOS-Base.{repo,bak}
+COPY vault.repo.* /etc/yum.repos.d/
+RUN mv /etc/yum.repos.d/vault.repo{.$(uname -m),}
+
 RUN mkdir -p /opt/datadog-agent/embedded/bin
 RUN yum -y install xfsprogs e2fsprogs iproute perl && \
     yum clean all && \

--- a/components/datadog/apps/cws/images/cws-centos7/vault.repo.aarch64
+++ b/components/datadog/apps/cws/images/cws-centos7/vault.repo.aarch64
@@ -1,0 +1,20 @@
+[base]
+name=CentOS-$releasever - Base
+baseurl=https://vault.centos.org/altarch/7.9.2009/os//$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7-aarch64
+enabled=1
+
+[updates]
+name=CentOS-$releasever - Updates
+baseurl=https://vault.centos.org/altarch/7.9.2009/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7-aarch64
+enabled=1
+
+[extras]
+name=CentOS-$releasever - Extras
+baseurl=https://vault.centos.org/altarch/7.9.2009/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7-aarch64
+enabled=1

--- a/components/datadog/apps/cws/images/cws-centos7/vault.repo.x86_64
+++ b/components/datadog/apps/cws/images/cws-centos7/vault.repo.x86_64
@@ -1,0 +1,20 @@
+[base]
+name=CentOS-$releasever - Base
+baseurl=https://vault.centos.org/7.9.2009/os/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+enabled=1
+
+[updates]
+name=CentOS-$releasever - Updates
+baseurl=https://vault.centos.org/7.9.2009/updates/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+enabled=1
+
+[extras]
+name=CentOS-$releasever - Extras
+baseurl=https://vault.centos.org/7.9.2009/extras/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+enabled=1


### PR DESCRIPTION
What does this PR do?
---------------------

This PR fixes the build of the `cws-centos7` image. The default centos 7 repository is not there anymore (because of EOL status) so we are moving to the vault repository.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
