### PR TITLE
feat(github): Force default permissions of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: test-infra-definition
 
 on: [push]
 
+permissions: {}
+
 jobs:
   build:
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,6 +22,8 @@ on:
       - .github/workflows/docker-publish.yml
       - components/datadog/apps/*/images/**
 
+permissions: {}
+
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,10 +6,7 @@ on:
     branches:
       - main
   pull_request:
-permissions:
-  contents: read
-  # Optional: allow read access to pull request. Use with `only-new-issues` option.
-  pull-requests: read
+permissions: {}
 jobs:
   lint-go:
     runs-on: ubuntu-latest


### PR DESCRIPTION
What does this PR do?
---------------------
Reset workflow permissions to validate we can enable Read-only default permissions at repository level to provide a strong baseline protection measure

Which scenarios this will impact?
-------------------
Github workflows

Motivation
----------
Github token permissions should follow the [least privilege principle](https://datadoghq.atlassian.net/wiki/x/TIVE6Q)

Additional Notes
----------------
[Jira](https://datadoghq.atlassian.net/browse/ACIX-407?atlOrigin=eyJpIjoiMDU2M2QxNTM0NTgzNGUwZTg3NDc1YjIwZmJlMzk4NTciLCJwIjoiaiJ9)




