### PR TITLE
Fix microVMs template overwriting

### DIFF
--- a/scenarios/aws/microVMs/microvms/resources/distro/domain-arm64.xsl
+++ b/scenarios/aws/microVMs/microvms/resources/distro/domain-arm64.xsl
@@ -27,6 +27,7 @@
         <commandline xmlns="http://libvirt.org/schemas/domain/qemu/1.0">
             {commandLine}
         </commandline>
+        <memballoon model="virtio" autodeflate="on" />
         <xsl:copy>
             <xsl:apply-templates select="@*|node()" />
         </xsl:copy>
@@ -85,14 +86,4 @@
     <xsl:template match="domain/devices/graphics" />
     <xsl:template match="domain/devices/audio" />
     <xsl:template match="domain/devices/video" />
-
-    <xsl:template match="/domain/devices">
-        <xsl:copy>
-            <xsl:apply-templates select="node()|@*" />
-            <xsl:element name="memballoon">
-                <xsl:attribute name="model">virtio</xsl:attribute>
-                <xsl:attribute name="autodeflate">on</xsl:attribute>
-            </xsl:element>
-        </xsl:copy>
-    </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
What does this PR do?
---------------------

Fixes the XSL template for local arm64 microVMs. In #933 it was changed, adding another template matcher for the `/domain/devices` path. Apparently, this overwrites previous matchers silently, and the result is that the command-line options for QEMU are not applied, which caused VMs to not boot properly.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
