### PR TITLE
Adds environment variables to the agents in helm to prepare for e2e-testing generic tagging

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -217,7 +217,7 @@ func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentI
 				"related_team": pulumi.String("team"),
 			},
 			"namespaceAnnotationsAsTags": pulumi.Map{
-				"related_email": pulumi.String("email"),
+				"related_email": pulumi.String("email"), // should be overridden by kubernetesResourcesAnnotationsAsTags
 			},
 			"logs": pulumi.Map{
 				"enabled":             pulumi.Bool(true),
@@ -293,6 +293,18 @@ func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentI
 				pulumi.StringMap{
 					"name":  pulumi.String("DD_TELEMETRY_CHECKS"),
 					"value": pulumi.String("*"),
+				},
+				pulumi.StringMap{
+					"name":  pulumi.String("placeholder_env"),
+					"value": pulumi.String("placeholder_val"),
+				},
+				pulumi.StringMap{
+					"name":  pulumi.String("DD_KUBERNETES_RESOURCES_LABELS_AS_TAGS"),
+					"value": pulumi.JSONMarshal(getResourcesLabelsAsTags().toJSONString()),
+				},
+				pulumi.StringMap{
+					"name":  pulumi.String("DD_KUBERNETES_RESOURCES_ANNOTATIONS_AS_TAGS"),
+					"value": pulumi.JSONMarshal(getResourcesAnnotationsAsTags().toJSONString()),
 				},
 			},
 		},

--- a/components/datadog/agent/kubernetes_helm_utils.go
+++ b/components/datadog/agent/kubernetes_helm_utils.go
@@ -1,0 +1,33 @@
+package agent
+
+import "encoding/json"
+
+// TODO: Remove these defaults when kubernetes_resource_labels_as_tags and kubernetes_resource_annotations_as_tags are added to the helm chart
+
+type KubernetesResourcesMetadataAsTags map[string]map[string]string
+
+func (k KubernetesResourcesMetadataAsTags) toJSONString() string {
+	bytes, err := json.Marshal(k)
+	if err != nil {
+		return ""
+	}
+
+	return string(bytes)
+}
+
+func getResourcesLabelsAsTags() KubernetesResourcesMetadataAsTags {
+	return KubernetesResourcesMetadataAsTags{
+		"deployments.apps": {"x-team": "team"},
+		"pods":             {"x-parent-type": "domain"},
+		"namespaces":       {"kubernetes.io/metadata.name": "metadata-name"},
+		"nodes":            {"kubernetes.io/os": "os", "kubernetes.io/arch": "arch"},
+	}
+}
+
+func getResourcesAnnotationsAsTags() KubernetesResourcesMetadataAsTags {
+	return KubernetesResourcesMetadataAsTags{
+		"deployments.apps": {"x-sub-team": "sub-team"},
+		"pods":             {"x-parent-name": "parent-name"},
+		"namespaces":       {"related_email": "mail"},
+	}
+}

--- a/components/datadog/apps/nginx/k8s.go
+++ b/components/datadog/apps/nginx/k8s.go
@@ -69,7 +69,11 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 			Name:      pulumi.String("nginx"),
 			Namespace: pulumi.String(namespace),
 			Labels: pulumi.StringMap{
-				"app": pulumi.String("nginx"),
+				"app":    pulumi.String("nginx"),
+				"x-team": pulumi.String("contp"),
+			},
+			Annotations: pulumi.StringMap{
+				"x-sub-team": pulumi.String("contint"),
 			},
 		},
 		Spec: &appsv1.DeploymentSpecArgs{
@@ -81,9 +85,11 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 			Template: &corev1.PodTemplateSpecArgs{
 				Metadata: &metav1.ObjectMetaArgs{
 					Labels: pulumi.StringMap{
-						"app": pulumi.String("nginx"),
+						"app":           pulumi.String("nginx"),
+						"x-parent-type": pulumi.String("deployment"),
 					},
 					Annotations: pulumi.StringMap{
+						"x-parent-name": pulumi.String("nginx"),
 						"ad.datadoghq.com/nginx.checks": pulumi.String(utils.JSONMustMarshal(
 							map[string]interface{}{
 								"nginx": map[string]interface{}{


### PR DESCRIPTION
What does this PR do?
---------------------
- Modifies helm installation of the agent to set `kubernetes_resources_labels_as_tags` and `kubernetes_resources_annotations_as_tags` on the agents.
- Add some labels and annotations to nginx workload.

Which scenarios this will impact?
-------------------
- Kind
- AKS
- EKS

Motivation
----------
- E2E test the feature implemented in [this](https://github.com/DataDog/datadog-agent/pull/27369) PR.

Additional Notes
----------------
