### PR TITLE
Add parameters to the fakeintake component on Azure

### DIFF
--- a/scenarios/azure/fakeintake/params.go
+++ b/scenarios/azure/fakeintake/params.go
@@ -1,0 +1,25 @@
+package fakeintake
+
+import "github.com/DataDog/test-infra-definitions/common"
+
+type Params struct {
+	ImageURL string
+}
+
+type Option = func(*Params) error
+
+// NewParams returns a new instance of Fakeintake Params
+func NewParams(options ...Option) (*Params, error) {
+	params := &Params{
+		ImageURL: "public.ecr.aws/datadog/fakeintake:latest",
+	}
+	return common.ApplyOption(params, options)
+}
+
+// WithImageURL sets the URL of the image to use to define the fakeintake
+func WithImageURL(imageURL string) Option {
+	return func(p *Params) error {
+		p.ImageURL = imageURL
+		return nil
+	}
+}


### PR DESCRIPTION
What does this PR do?
---------------------

Add parameters to the fakeintake component on Azure

Which scenarios this will impact?
-------------------

Azure ones only

Motivation
----------

- The imageUrl is a parameter on the AWS side too 
- We might add more in the future
- [We use it](https://github.com/DataDog/datadog-agent/blob/3923572cabe0f924fb81947a993dffa8a328ddd3/test/new-e2e/pkg/environments/aws/host/host.go#L121-L127) to avoid deploying the fakeintake in AWS tests and I'd like to do the same for consistency

Additional Notes
----------------
