### PR TITLE
Add AWS key create/import to setup task

### DIFF
--- a/tasks/config.py
+++ b/tasks/config.py
@@ -48,7 +48,7 @@ You should consider moving to the agent-sandbox account. Please follow https://d
         class Agent(BaseModel, extra=Extra.forbid):
             apiKey: Optional[str]
             appKey: Optional[str]
-            verifyCodeSignature: Optional[bool] = True
+            verifyCodeSignature: Optional[bool] = True  # noqa used in e2e tests
 
         agent: Optional[Agent]
 

--- a/tasks/config.py
+++ b/tasks/config.py
@@ -48,6 +48,7 @@ You should consider moving to the agent-sandbox account. Please follow https://d
         class Agent(BaseModel, extra=Extra.forbid):
             apiKey: Optional[str]
             appKey: Optional[str]
+            verifyCodeSignature: Optional[bool] = True
 
         agent: Optional[Agent]
 

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -333,7 +333,7 @@ def resolve_keypair_opts(
             account_part = f"{awsConf.account}_" if awsConf.account else ""
             account_part = account_part.replace("-", "_")
             default_private_key_path = Path.home().joinpath(
-                ".ssh", f'id_{key_type or "rsa"}_e2e_{keypair_name}.{key_format}'
+                ".ssh", f'id_{key_type or "rsa"}_e2e_{account_part}{keypair_name}.{key_format}'
             )
         while True:
             private_key_path = ask(f"🔑 Private key path (default: {default_private_key_path}): ")

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -329,8 +329,11 @@ def resolve_keypair_opts(
         key_format = "pem"
     if not private_key_path:
         if default_private_key_path is None or keypair_name != default_keypair_name:
+            # Example: ~/.ssh/id_rsa_e2e_agent_sandbox_mykeyname.pem
+            account_part = f"{awsConf.account}_" if awsConf.account else ""
+            account_part = account_part.replace("-", "_")
             default_private_key_path = Path.home().joinpath(
-                ".ssh", f'id_{key_type or "rsa"}_{keypair_name}.{key_format}'
+                ".ssh", f'id_{key_type or "rsa"}_e2e_{keypair_name}.{key_format}'
             )
         while True:
             private_key_path = ask(f"🔑 Private key path (default: {default_private_key_path}): ")

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -14,9 +14,10 @@ from invoke.tasks import task
 
 from . import doc
 from .config import Config, get_full_profile_path, get_local_config
-from .tool import ask, debug, error, info, is_linux, is_windows, warn
+from .tool import ask, ask_yesno, debug, error, get_aws_cmd, info, is_linux, is_windows, warn
 
 available_aws_accounts = ["agent-sandbox", "sandbox", "agent-qa", "tse-playground"]
+supported_key_types = ["rsa", "ed25519"]
 
 
 @task(help={"config_path": doc.config_path, "interactive": doc.interactive, "debug": doc.debug}, default=True)
@@ -54,7 +55,7 @@ def setup(
     if interactive:
         info("🤖 Let's configure your environment for e2e tests! Press ctrl+c to stop me")
         # AWS config
-        setupAWSConfig(config)
+        setupAWSConfig(ctx, config)
         # Azure config
         setup_azure_config(config)
         # Agent config
@@ -113,7 +114,7 @@ def _check_config(config: Config):
         warn("WARNING: privateKeyPassword is set. Please ensure privateKeyPath is used ONLY for E2E tests.")
 
 
-def setupAWSConfig(config: Config):
+def setupAWSConfig(ctx: Context, config: Config):
     if config.configParams is None:
         config.configParams = Config.Params(aws=None, agent=None, pulumi=None, azure=None, devMode=False)
     if config.configParams.aws is None:
@@ -134,35 +135,23 @@ def setupAWSConfig(config: Config):
             break
         warn(f"{config.configParams.aws.account} is not a valid aws account")
 
-    # aws keypair name
-    if config.configParams.aws.keyPairName is None:
-        config.configParams.aws.keyPairName = getpass.getuser()
-    keyPairName = ask(f"🔑 Key pair name - stored in AWS Sandbox, default [{config.configParams.aws.keyPairName}]: ")
-    if len(keyPairName) > 0:
-        config.configParams.aws.keyPairName = keyPairName
+    # ask user if they want to create a new key or import an existing key
+    if ask_yesno("Do you want to create a new key pair?"):
+        _aws_create_keypair(ctx, config, use_aws_vault=True, aws_account_name=config.configParams.aws.account)
+    elif ask_yesno("Do you want to import an existing key pair?"):
+        _aws_import_keypair(ctx, config, use_aws_vault=True, aws_account_name=config.configParams.aws.account)
+    else:
+        warn("No key pair configured, you will need to manually configure a key pair")
 
     # check keypair name
     if config.options is None:
         config.options = Config.Options(checkKeyPair=False)
     default_check_key_pair = "Y" if config.options.checkKeyPair else "N"
     checkKeyPair = ask(
-        f"Did you create your SSH key on AWS and want me to check it is loaded on your ssh agent when creating manual environments or running e2e tests [Y/N]? Default [{default_check_key_pair}]: "
+        f"Do you want check that the keypair is loaded in ssh agent when creating manual environments or running e2e tests [Y/N]? Default [{default_check_key_pair}]: "
     )
     if len(checkKeyPair) > 0:
         config.options.checkKeyPair = checkKeyPair.lower() == "y" or checkKeyPair.lower() == "yes"
-
-    # aws public key path
-    if config.configParams.aws.publicKeyPath is None:
-        config.configParams.aws.publicKeyPath = str(Path.home().joinpath(".ssh", "id_ed25519.pub").absolute())
-    default_public_key_path = config.configParams.aws.publicKeyPath
-    while True:
-        config.configParams.aws.publicKeyPath = default_public_key_path
-        publicKeyPath = ask(f"🔑 Path to your public ssh key, default [{config.configParams.aws.publicKeyPath}]: ")
-        if len(publicKeyPath) > 0:
-            config.configParams.aws.publicKeyPath = publicKeyPath
-        if os.path.isfile(config.configParams.aws.publicKeyPath):
-            break
-        warn(f"{config.configParams.aws.publicKeyPath} is not a valid ssh key")
 
     # team tag
     if config.configParams.aws.teamTag is None:
@@ -275,6 +264,351 @@ def setupPulumiConfig(config):
             config.configParams.pulumi.logToStdErr = logs_to_std_err.lower() == "true"
             break
         warn(f"Expecting one of [true, false], got {logs_to_std_err}")
+
+
+def resolve_keypair_opts(
+    config: Config,
+    keypair_name: Optional[str] = None,
+    key_type: Optional[str] = None,
+    key_format: Optional[str] = None,
+    private_key_path: Optional[Path | str] = None,
+    public_key_path: Optional[Path | str] = None,
+    require_key_type: Optional[bool] = False,
+    require_keyfile_exists: Optional[bool] = False,
+):
+    """
+    Resolve key pair options, in decreasing order of priority:
+    - user input (parameters)
+    - local config
+    - defaults
+
+    Returns a dict with the resolved values.
+    """
+    if config.configParams is None or config.configParams.aws is None:
+        raise Exit("Config is missing aws section")
+    awsConf = config.configParams.aws
+
+    # defaults
+    if awsConf.keyPairName:
+        default_keypair_name = awsConf.keyPairName
+    else:
+        default_keypair_name = getpass.getuser()
+    if awsConf.privateKeyPath:
+        default_private_key_path = awsConf.privateKeyPath
+    else:
+        default_private_key_path = None
+    if awsConf.publicKeyPath:
+        default_public_key_path = awsConf.publicKeyPath
+    else:
+        default_public_key_path = None
+
+    # ask for missing values
+    if not keypair_name:
+        keypair_name = ask(f"🔑 Key pair name (default: {default_keypair_name}): ")
+        if not keypair_name:
+            keypair_name = default_keypair_name
+    if not key_type and require_key_type:
+        warn('Creating Windows VMs requires "rsa" key type')
+        keytype_default = "rsa"
+        while True:
+            supported = "|".join(supported_key_types)
+            key_type = ask(f"🔑 Key type [{supported}] (default: {keytype_default}): ")
+            if not key_type:
+                key_type = keytype_default
+            if key_type in supported_key_types:
+                break
+            warn(f"{key_type} is not a supported key type")
+    if not key_format:
+        # Just use pem for now
+        key_format = "pem"
+    if not private_key_path:
+        if default_private_key_path is None or keypair_name != default_keypair_name:
+            default_private_key_path = Path.home().joinpath(".ssh", f'id_{key_type}_{keypair_name}.{key_format}')
+        while True:
+            private_key_path = ask(f"🔑 Private key path (default: {default_private_key_path}): ")
+            if not private_key_path:
+                private_key_path = default_private_key_path
+            if not require_keyfile_exists or os.path.isfile(private_key_path):
+                break
+            warn(f"{private_key_path} is not a valid ssh key")
+    if not public_key_path:
+        if default_public_key_path is None or keypair_name != default_keypair_name:
+            filename_nosuffix = Path(private_key_path).stem
+            parent_dir = Path(private_key_path).parent
+            default_public_key_path = parent_dir.joinpath(f'{filename_nosuffix}.pub')
+        while True:
+            public_key_path = ask(f"🔑 Public key path (default: {default_public_key_path}): ")
+            if not public_key_path:
+                public_key_path = default_public_key_path
+            if not require_keyfile_exists or os.path.isfile(public_key_path):
+                break
+            warn(f"{public_key_path} is not a valid ssh key")
+
+    # pathlib expand paths
+    private_key_path = Path(private_key_path).expanduser().resolve()
+    public_key_path = Path(public_key_path).expanduser().resolve()
+
+    return {
+        "keypair_name": keypair_name,
+        "key_type": key_type,
+        "key_format": key_format,
+        "private_key_path": private_key_path,
+        "public_key_path": public_key_path,
+    }
+
+
+def update_config_aws_keypair(
+    config: Config,
+    config_path: Optional[str] = None,
+) -> None:
+    if config.configParams is None or config.configParams.aws is None:
+        raise Exit("Config is missing aws section")
+    awsConf = config.configParams.aws
+    info(f"keyPairName: {awsConf.keyPairName}")
+    info(f"publicKeyPath: {awsConf.publicKeyPath}")
+    info(f"privateKeyPath: {awsConf.privateKeyPath}")
+    if ask_yesno("Do you want to update the local config?"):
+        config.save_to_local_config(config_path)
+
+
+def check_existing_aws_keypair(
+    ctx: Context,
+    keypair_name: str,
+    use_aws_vault: Optional[bool] = False,
+    aws_account_name: Optional[str] = None,
+) -> bool:
+    """
+    Check if aws key pair already exists.
+    If it does, ask if user wants to overwrite it.
+    If user does want to overwrite it, delete the existing key pair.
+
+    Return True if key pair does not exist or user wants to overwrite it.
+    """
+
+    def _get_aws_cmd(cmd):
+        return get_aws_cmd(cmd, use_aws_vault=use_aws_vault, aws_account=aws_account_name)
+
+    # check if key pair already exists
+    cmd = f'ec2 describe-key-pairs --key-names "{keypair_name}"'
+    out = ctx.run(_get_aws_cmd(cmd), hide=True, warn=True)
+    if out is None:
+        raise Exit(f"Failed to check if key pair {keypair_name} exists")
+    if out.exited == 0:
+        warn(f"Key pair {keypair_name} already exists.")
+        if not ask_yesno("Do you want to overwrite it?"):
+            return False
+        # delete existing key pair
+        cmd = f'ec2 delete-key-pair --key-name "{keypair_name}"'
+        ctx.run(_get_aws_cmd(cmd))
+    return True
+
+
+@task
+def aws_create_keypair(
+    ctx: Context,
+    keypair_name: Optional[str] = None,
+    key_type: Optional[str] = None,
+    private_key_path: Optional[str] = None,
+    public_key_path: Optional[str] = None,
+    use_aws_vault: Optional[bool] = False,
+    aws_account_name: Optional[str] = None,
+    config_path: Optional[str] = None,
+) -> None:
+    """
+    Create a new key pair using the AWS CLI, save the key pair to disk, and update the local config.
+
+    This task is interactive and can be run with no options:
+      - Prompt user for missing values
+      - Confirm overwrite of existing key pair
+      - Confirm update of local config
+    """
+    try:
+        config = get_local_config(config_path)
+    except Exception as e:
+        error(f"{e}")
+        error("Failed to load config")
+        raise Exit(code=1)
+
+    _aws_create_keypair(
+        ctx=ctx,
+        config=config,
+        keypair_name=keypair_name,
+        key_type=key_type,
+        private_key_path=private_key_path,
+        public_key_path=public_key_path,
+        use_aws_vault=use_aws_vault,
+        aws_account_name=aws_account_name,
+    )
+
+    update_config_aws_keypair(
+        config,
+        config_path=config_path,
+    )
+
+
+def _aws_create_keypair(
+    ctx: Context,
+    config: Config,
+    keypair_name: Optional[str] = None,
+    key_type: Optional[str] = None,
+    private_key_path: Optional[str] = None,
+    public_key_path: Optional[str] = None,
+    use_aws_vault: Optional[bool] = False,
+    aws_account_name: Optional[str] = None,
+) -> None:
+    if config.configParams is None or config.configParams.aws is None:
+        raise Exit("Config is missing aws section")
+
+    keypair_opts = resolve_keypair_opts(
+        config=config,
+        keypair_name=keypair_name,
+        key_type=key_type,
+        private_key_path=private_key_path,
+        public_key_path=public_key_path,
+        require_key_type=True,
+        require_keyfile_exists=False,
+    )
+    keypair_name = str(keypair_opts["keypair_name"])
+    key_type = str(keypair_opts["key_type"])
+    private_key_path = str(keypair_opts["private_key_path"])
+    public_key_path = str(keypair_opts["public_key_path"])
+
+    def _get_aws_cmd(cmd):
+        return get_aws_cmd(cmd, use_aws_vault=use_aws_vault, aws_account=aws_account_name)
+
+    # check if key pair already exists
+    if not check_existing_aws_keypair(
+        ctx, keypair_name, use_aws_vault=use_aws_vault, aws_account_name=aws_account_name
+    ):
+        return
+    if Path(private_key_path).exists():
+        warn(f"Private key {private_key_path} already exists.")
+        if not ask_yesno("Do you want to overwrite it?"):
+            return
+        # delete existing key pair
+        os.remove(private_key_path)
+
+    # generate private key
+    cmd = f'ec2 create-key-pair --key-name "{keypair_name}" --key-type {key_type} --query KeyMaterial --output text'
+    out = ctx.run(_get_aws_cmd(cmd), hide=True)
+    if out is None:
+        raise Exit(f"Failed to create key pair {keypair_name}")
+    key_material = out.stdout.strip()
+    # write private key to disk
+    os.makedirs(Path(private_key_path).parent, exist_ok=True)
+    with open(private_key_path, "w") as f:
+        f.write(key_material)
+    if not is_windows():
+        os.chmod(private_key_path, 0o600)
+        # Windows permissions should be fine as is via inheritance
+
+    # generate public key from private key
+    cmd = f'ssh-keygen -f "{private_key_path}" -y'
+    out = ctx.run(cmd, hide=True)
+    if out is None:
+        raise Exit(f"Failed to generate public key from private key {private_key_path}")
+    public_key = out.stdout.strip()
+    # write public key to disk
+    with open(public_key_path, "w") as f:
+        f.write(public_key)
+
+    # update config object
+    awsConf = config.configParams.aws
+    if keypair_name:
+        awsConf.keyPairName = keypair_name
+    if public_key_path:
+        awsConf.publicKeyPath = public_key_path
+    if private_key_path:
+        awsConf.privateKeyPath = private_key_path
+
+
+@task
+def aws_import_keypair(
+    ctx: Context,
+    keypair_name: Optional[str] = None,
+    private_key_path: Optional[str] = None,
+    public_key_path: Optional[str] = None,
+    use_aws_vault: Optional[bool] = False,
+    aws_account_name: Optional[str] = None,
+    config_path: Optional[str] = None,
+) -> None:
+    """
+    Import an existing key pair to AWS and update the config.
+
+    This task is interactive and can be run with no options:
+      - Prompt user for missing values
+      - Confirm overwrite of existing key pair
+      - Confirm update of local config
+    """
+    try:
+        config = get_local_config(config_path)
+    except Exception as e:
+        error(f"{e}")
+        error("Failed to load config")
+        raise Exit(code=1)
+
+    _aws_import_keypair(
+        ctx=ctx,
+        config=config,
+        keypair_name=keypair_name,
+        private_key_path=private_key_path,
+        public_key_path=public_key_path,
+        use_aws_vault=use_aws_vault,
+        aws_account_name=aws_account_name,
+    )
+
+    update_config_aws_keypair(
+        config,
+        config_path=config_path,
+    )
+
+
+def _aws_import_keypair(
+    ctx: Context,
+    config: Config,
+    keypair_name: Optional[str] = None,
+    private_key_path: Optional[str] = None,
+    public_key_path: Optional[str] = None,
+    use_aws_vault: Optional[bool] = False,
+    aws_account_name: Optional[str] = None,
+) -> None:
+    if config.configParams is None or config.configParams.aws is None:
+        raise Exit("Config is missing aws section")
+
+    keypair_opts = resolve_keypair_opts(
+        config=config,
+        keypair_name=keypair_name,
+        private_key_path=private_key_path,
+        public_key_path=public_key_path,
+        require_key_type=False,
+        require_keyfile_exists=True,
+    )
+    keypair_name = str(keypair_opts["keypair_name"])
+    private_key_path = str(keypair_opts["private_key_path"])
+    public_key_path = keypair_opts["public_key_path"]
+
+    def _get_aws_cmd(cmd):
+        return get_aws_cmd(cmd, use_aws_vault=use_aws_vault, aws_account=aws_account_name)
+
+    # check if key pair already exists
+    if not check_existing_aws_keypair(
+        ctx, keypair_name, use_aws_vault=use_aws_vault, aws_account_name=aws_account_name
+    ):
+        return
+
+    # upload public key to aws
+    cmd = f'ec2 import-key-pair --key-name "{keypair_name}" --public-key-material "fileb://{public_key_path}"'
+    ctx.run(_get_aws_cmd(cmd))
+    info(f"Public key imported to AWS as key pair {keypair_name}")
+
+    # update config object
+    awsConf = config.configParams.aws
+    if keypair_name:
+        awsConf.keyPairName = keypair_name
+    if public_key_path:
+        awsConf.publicKeyPath = public_key_path
+    if private_key_path:
+        awsConf.privateKeyPath = private_key_path
 
 
 def _get_safe_dd_key(key: str) -> str:

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -323,7 +323,9 @@ def resolve_keypair_opts(
         key_format = "pem"
     if not private_key_path:
         if default_private_key_path is None or keypair_name != default_keypair_name:
-            default_private_key_path = Path.home().joinpath(".ssh", f'id_{key_type}_{keypair_name}.{key_format}')
+            default_private_key_path = Path.home().joinpath(
+                ".ssh", f'id_{key_type or "rsa"}_{keypair_name}.{key_format}'
+            )
         while True:
             private_key_path = ask(f"🔑 Private key path (default: {default_private_key_path}): ")
             if not private_key_path:

--- a/tasks/tool.py
+++ b/tasks/tool.py
@@ -41,6 +41,7 @@ def ask_yesno(question: str, default='N') -> bool:
         res = ask(question + f" [Y/N] Default [{default}]: ")
         if res == "":
             res = default
+            break
 
     return res.lower() in yes_opts
 

--- a/tasks/tool.py
+++ b/tasks/tool.py
@@ -33,6 +33,18 @@ def ask(question: str) -> str:
     return input(colored(question, "blue"))
 
 
+def ask_yesno(question: str, default='N') -> bool:
+    res = ""
+    yes_opts = ["y", "yes"]
+    no_opts = ["n", "no"]
+    while res.lower() not in (yes_opts + no_opts):
+        res = ask(question + f" [Y/N] Default [{default}]: ")
+        if res == "":
+            res = default
+
+    return res.lower() in yes_opts
+
+
 def debug(msg: str):
     print(colored(msg, "white"))
 
@@ -96,6 +108,22 @@ def get_aws_wrapper(
     aws_account: str,
 ) -> str:
     return f"aws-vault exec sso-{aws_account}-account-admin -- "
+
+
+def get_aws_cmd(
+    cmd: str,
+    use_aws_vault: Optional[bool] = True,
+    aws_account: Optional[str] = None,
+) -> str:
+    wrapper = ""
+    if use_aws_vault:
+        if aws_account is None:
+            raise Exit("AWS account is required when using aws-vault.")
+        wrapper = get_aws_wrapper(aws_account)
+    # specify .exe for windows to work around conflicts with aws.rb
+    aws = "aws.exe" if is_windows() else "aws"
+    cmd = f"{wrapper}{aws} {cmd}"
+    return cmd
 
 
 def is_linux():

--- a/tasks/tool.py
+++ b/tasks/tool.py
@@ -111,7 +111,7 @@ def get_aws_instance_password_data(
 ) -> str:
     buffer = StringIO()
     with ctx.cd(_get_root_path()):
-        cmd = f"aws ec2 get-password-data --instance-id {vm_id} --priv-launch-key {key_path}"
+        cmd = f'aws ec2 get-password-data --instance-id "{vm_id}" --priv-launch-key "{key_path}"'
         if use_aws_vault:
             if aws_account is None:
                 raise Exit("AWS account is required when using aws-vault.")


### PR DESCRIPTION
What does this PR do?
---------------------
Add ability to create or import an AWS key during `inv setup`, or through new invoke tests `inv setup.aws-create-keypair` and `inv setup.aws-import-keypair`, and update the config.

Which scenarios this will impact?
-------------------
setup

Motivation
----------
easier setup and key rotation

Additional Notes
----------------

example new keypair
```
$ inv setup --config-path /tmp/test-config
Pulumi is up to date: v3.129.0
Logged in to LAPTOP-J4KNN9ON as brandenclark (file://~)
🤖 Let's configure your environment for e2e tests! Press ctrl+c to stop me
Which aws account do you want to create instances on? Default [agent-sandbox], available [agent-sandbox|sandbox|tse-playground]:
Do you want to create a new key pair? [Y/N] Default [N]: Y
🔑 Key pair name (default: brandenclark): bc-test-keypair
Creating Windows VMs requires "rsa" key type
🔑 Key type [rsa|ed25519] (default: rsa):
🔑 Private key path (default: /home/brandenclark/.ssh/id_rsa_agent_sandbox_bc-test-keypair.pem):
🔑 Public key path (default: /home/brandenclark/.ssh/id_rsa_agent_sandbox_bc-test-keypair.pub):
...
```

example new keypair (confirms overwrite)
```
$ inv setup --config-path /tmp/test-config
Pulumi is up to date: v3.129.0
Logged in to LAPTOP-J4KNN9ON as brandenclark (file://~)
🤖 Let's configure your environment for e2e tests! Press ctrl+c to stop me
Which aws account do you want to create instances on? Default [agent-sandbox], available [agent-sandbox|sandbox|tse-playground]:
Do you want to create a new key pair? [Y/N] Default [N]: Y
🔑 Key pair name (default: brandenclark): bc-test-keypair
Creating Windows VMs requires "rsa" key type
🔑 Key type [rsa|ed25519] (default: rsa):
🔑 Private key path (default: /home/brandenclark/.ssh/id_rsa_agent_sandbox_bc-test-keypair.pem):
🔑 Public key path (default: /home/brandenclark/.ssh/id_rsa_agent_sandbox_bc-test-keypair.pub):
Key pair bc-test-keypair already exists.
Do you want to overwrite it? [Y/N] Default [N]: Y
Private key /home/brandenclark/.ssh/id_rsa_agent_sandbox_bc-test-keypair.pem already exists.
Do you want to overwrite it? [Y/N] Default [N]: Y
...
```

example import existing
```
$ inv setup --config-path /tmp/test-config
Pulumi is up to date: v3.129.0
Logged in to LAPTOP-J4KNN9ON as brandenclark (file://~)
🤖 Let's configure your environment for e2e tests! Press ctrl+c to stop me
Which aws account do you want to create instances on? Default [agent-sandbox], available [agent-sandbox|sandbox|tse-playground]:
Do you want to create a new key pair? [Y/N] Default [N]: N
Do you want to import an existing key pair? [Y/N] Default [N]: Y
🔑 Key pair name (default: brandenclark): bc-test-keypair
🔑 Private key path (default: /home/brandenclark/.ssh/id_rsa_agent_sandbox_bc-test-keypair.pem): /home/brandenclark/.ssh/mykey.pem
🔑 Public key path (default: /home/brandenclark/.ssh/id_rsa_agent_sandbox_bc-test-keypair.pub): /home/brandenclark/.ssh/mykey.pub
...
```