### PR TITLE
Improvements to `setup.debug` task

### DIFF
--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -721,13 +721,17 @@ def _pulumi_version(ctx: Context) -> Tuple[str, bool]:
 
 
 def ssh_fingerprint_to_bytes(fingerprint: str) -> bytes:
-    out = fingerprint.strip().split(' ')[1].split(':', 1)
-    if ':' in out[1]:
+    out = fingerprint.strip().split(' ')[1]
+    if out.count(':') > 1:
+        # EXAMPLE: MD5(stdin)= 81:e4:46:e9:dd:a6:3d:41:6d:ca:94:21:5c:e5:1d:24
         # EXAMPLE: 2048 MD5:19:b3:a8:5f:13:7e:b9:d3:6c:75:20:d6:18:7f:e2:1d no comment (RSA)
-        return bytes.fromhex(out[1].replace(':', ''))
+        if out.startswith('MD5') or out.startswith('SHA'):
+            out = out.split(':', 1)[1]
+        return bytes.fromhex(out.replace(':', ''))
     else:
         # EXAMPLE: 256 SHA1:41jsg4Z9lgylj6/zmhGxtZ6/qZs testname (ED25519)
         # ssh leaves out padding but python will ignore extra padding so add the missing padding
+        out = out.split(':', 1)
         return base64.b64decode(out[1] + '==')
 
 

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -1066,6 +1066,21 @@ def debug_env(ctx, config_path: Optional[str] = None):
 
     print()
 
+    # check .aws/config exists and contains expected profile
+    # some invoke taskes hard code this value.
+    expected_profile = 'sso-agent-sandbox-account-admin'
+    aws_conf_path = Path.home().joinpath(".aws", "config")
+    if not os.path.isfile(aws_conf_path):
+        error(f"Missing aws config file: {aws_conf_path}")
+        info("Please run `inv setup.aws-sso` or create it manually with `aws configure sso`.")
+        raise Exit(code=1)
+    with open(aws_conf_path) as f:
+        conf = f.read()
+        if expected_profile not in conf:
+            error(f"Profile {expected_profile} not found in aws config file: {aws_conf_path}")
+            info("Please run `inv setup.aws-sso` or create it manually with `aws configure sso`.")
+            raise Exit(code=1)
+
     # Show AWS account info
     info("Logged-in aws account info:")
     if os.environ.get("AWS_PROFILE"):

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -1066,14 +1066,6 @@ def debug_env(ctx, config_path: Optional[str] = None):
 
     print()
 
-    # Check if aws creds are valid
-    try:
-        out = ctx.run("aws sts get-caller-identity", hide=True)
-    except UnexpectedExit as e:
-        error(f"{e}")
-        error("No AWS credentials found or they are expired, please configure and/or login")
-        raise Exit(code=1)
-
     # Show AWS account info
     info("Logged-in aws account info:")
     if os.environ.get("AWS_PROFILE"):
@@ -1088,6 +1080,14 @@ def debug_env(ctx, config_path: Optional[str] = None):
             if val is None:
                 raise Exit(f"Missing env var {env}, please login with awscli/aws-vault or set AWS_PROFILE", 1)
             info(f"\t{env}={val}")
+
+    # Check if aws creds are valid
+    try:
+        out = ctx.run("aws sts get-caller-identity", hide=True)
+    except UnexpectedExit as e:
+        error(f"{e}")
+        error("No AWS credentials found or they are expired, please configure and/or login")
+        raise Exit(code=1)
 
     print()
 

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -1076,11 +1076,18 @@ def debug_env(ctx, config_path: Optional[str] = None):
 
     # Show AWS account info
     info("Logged-in aws account info:")
-    for env in ["AWS_VAULT", "AWS_REGION"]:
-        val = os.environ.get(env, None)
-        if val is None:
-            raise Exit(f"Missing env var {env}, please login with awscli/aws-vault", 1)
-        info(f"\t{env}={val}")
+    if os.environ.get("AWS_PROFILE"):
+        info(f"\tAWS_PROFILE={os.environ.get('AWS_PROFILE')}")
+        region = os.environ.get("AWS_REGION")
+        if not region:
+            raise Exit("Missing env var AWS_REGION, please set var", 1)
+        info(f"\tAWS_REGION={region}")
+    else:
+        for env in ["AWS_VAULT", "AWS_REGION"]:
+            val = os.environ.get(env, None)
+            if val is None:
+                raise Exit(f"Missing env var {env}, please login with awscli/aws-vault or set AWS_PROFILE", 1)
+            info(f"\t{env}={val}")
 
     print()
 


### PR DESCRIPTION
What does this PR do?
---------------------
fix fingerprint parsing bug (was chopping off first byte)

Match imported RSA keys by calculating public key MD5 from RSA private key 

Allow `AWS_PROFILE` as an alternative to `AWS_VAULT`

Skip `ssh-agent` assertions on Windows, since pulumi doesn't support it

Which scenarios this will impact?
-------------------
troubleshooting

Motivation
----------
https://datadoghq.atlassian.net/browse/WINA-980

Additional Notes
----------------
run with
```
inv setup.debug
```