### PR TITLE
[ecs] set pidmode by default to task on fargate

### DIFF
--- a/resources/aws/ecs/fargateService.go
+++ b/resources/aws/ecs/fargateService.go
@@ -61,7 +61,8 @@ func FargateWindowsTaskDefinitionWithAgent(
 		TaskRole: &awsx.DefaultRoleWithPolicyArgs{
 			RoleArn: pulumi.StringPtr(e.ECSTaskRole()),
 		},
-		Family: e.CommonNamer().DisplayName(255, family),
+		Family:  e.CommonNamer().DisplayName(255, family),
+		PidMode: pulumi.StringPtr("task"),
 		RuntimePlatform: classicECS.TaskDefinitionRuntimePlatformArgs{
 			OperatingSystemFamily: pulumi.String("WINDOWS_SERVER_2022_CORE"),
 		},
@@ -91,7 +92,8 @@ func FargateTaskDefinitionWithAgent(
 		TaskRole: &awsx.DefaultRoleWithPolicyArgs{
 			RoleArn: pulumi.StringPtr(e.ECSTaskRole()),
 		},
-		Family: e.CommonNamer().DisplayName(255, family),
+		Family:  e.CommonNamer().DisplayName(255, family),
+		PidMode: pulumi.StringPtr("task"),
 		Volumes: classicECS.TaskDefinitionVolumeArray{
 			classicECS.TaskDefinitionVolumeArgs{
 				Name: pulumi.String("dd-sockets"),


### PR DESCRIPTION
What does this PR do?
---------------------

Set `PidMode` to `task` on ECS Fargate task with Agent

Which scenarios this will impact?
-------------------

ecs

Motivation
----------

This is the [official documentation's value](https://docs.datadoghq.com/integrations/ecs_fargate/?tab=webui#process-collection) 

Additional Notes
----------------
