### PR TITLE
[fakeintake] enable payloads forwarding

### DIFF
--- a/scenarios/aws/fakeintake/params.go
+++ b/scenarios/aws/fakeintake/params.go
@@ -19,6 +19,7 @@ func NewParams(options ...Option) (*Params, error) {
 		ImageURL:            "public.ecr.aws/datadog/fakeintake:latest",
 		CPU:                 512,
 		Memory:              1024,
+		DDDevForwarding:     true,
 	}
 	return common.ApplyOption(params, options)
 }

--- a/scenarios/aws/fakeintake/params.go
+++ b/scenarios/aws/fakeintake/params.go
@@ -56,9 +56,9 @@ func WithMemory(memory int) Option {
 	}
 }
 
-func WithDDDevForwarding() Option {
+func WithoutDDDevForwarding() Option {
 	return func(p *Params) error {
-		p.DDDevForwarding = true
+		p.DDDevForwarding = false
 		return nil
 	}
 }

--- a/scenarios/azure/fakeintake/params.go
+++ b/scenarios/azure/fakeintake/params.go
@@ -27,9 +27,9 @@ func WithImageURL(imageURL string) Option {
 }
 
 // WithDDDevForwarding sets the flag to enable DD Dev forwarding
-func WithDDDevForwarding() Option {
+func WithoutDDDevForwarding() Option {
 	return func(p *Params) error {
-		p.DDDevForwarding = true
+		p.DDDevForwarding = false
 		return nil
 	}
 }

--- a/scenarios/azure/fakeintake/params.go
+++ b/scenarios/azure/fakeintake/params.go
@@ -12,7 +12,8 @@ type Option = func(*Params) error
 // NewParams returns a new instance of Fakeintake Params
 func NewParams(options ...Option) (*Params, error) {
 	params := &Params{
-		ImageURL: "public.ecr.aws/datadog/fakeintake:latest",
+		ImageURL:        "public.ecr.aws/datadog/fakeintake:latest",
+		DDDevForwarding: true,
 	}
 	return common.ApplyOption(params, options)
 }


### PR DESCRIPTION
What does this PR do?
---------------------

Forward payloads received by the fakeintake to `dddev` by default

Which scenarios this will impact?
-------------------

aws.*, azure.*

Motivation
----------

Forwarding payloads helps with investigations in case of test failures, it allows ensuring the agent sent all expected payloads after the fakeintake is removed

Additional Notes
----------------

Tested on 4 pipelines on `datadog-agent` through one [dev pipeline](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/43243501) and one [flakes finder pipeline](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/43254782)