### PR TITLE
[agent/host] add WithTags option

### DIFF
--- a/common/utils/yaml.go
+++ b/common/utils/yaml.go
@@ -14,7 +14,7 @@ func MergeYAML(oldValuesYamlContent string, newValuesYamlContent string) (string
 	var oldValuesYAML map[string]interface{}
 	var newValuesYAML map[string]interface{}
 
-	err := yaml.Unmarshal([]byte(oldValuesYamlContent), &oldValuesYamlContent)
+	err := yaml.Unmarshal([]byte(oldValuesYamlContent), &oldValuesYAML)
 	if err != nil {
 		return "", err
 	}

--- a/components/datadog/agent/host.go
+++ b/components/datadog/agent/host.go
@@ -147,7 +147,7 @@ func (h *HostAgent) updateCoreAgentConfig(
 	mergedConfig := pulumi.All(convertedArgs...).ApplyT(func(args []interface{}) (string, error) {
 		baseConfig := args[0].(string)
 		apiKey := args[1].(string)
-		extraConfigs := []string{}
+		extraConfigs := make([]string, 0, len(args))
 
 		if len(args) > 2 {
 			for _, extraConfig := range args[2:] {

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -304,3 +304,11 @@ func WithSkipAPIKeyInConfig() func(*Params) error {
 		return nil
 	}
 }
+
+// WithTags add tags to the agent configuration
+func WithTags(tags []string) func(*Params) error {
+	return func(p *Params) error {
+		p.ExtraAgentConfig = append(p.ExtraAgentConfig, pulumi.Sprintf("tags: [%s]", strings.Join(tags, ", ")))
+		return nil
+	}
+}


### PR DESCRIPTION
What does this PR do?
---------------------

Add `WithTags` option to the host agent deployment. This PRs also handles configuration merges as deep merges, rather than string concatenations 

Which scenarios this will impact?
-------------------

VM

Motivation
----------

I want to tag all payloads by the stack name to help finding them in `dddev` when they are forwarded. This helps configuring the stack name from the deployment caller 

Additional Notes
----------------
