### PR TITLE
Remove entrypoint that is not useful

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,6 +126,3 @@ RUN rm -rf /tmp/test-infra
 
 # Configure aws retries
 COPY .awsconfig $HOME/.aws/config
-
-# I think it's safe to say if we're using this mega image, we want pulumi
-ENTRYPOINT ["pulumi"]


### PR DESCRIPTION
What does this PR do?
---------------------

Remove Dockerfile entrypoint that is not needed. With that we will no longer need to override the entrypoint each time we use the image

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
