### PR TITLE
Launch statsd in datadog-agent

### DIFF
--- a/scenarios/aws/microVMs/microvms/files/datadog.yaml
+++ b/scenarios/aws/microVMs/microvms/files/datadog.yaml
@@ -1,3 +1,5 @@
+use_dogstatsd: true
+dogstatsd_port: 8125
 process_config:
   process_collection:
     enabled: true


### PR DESCRIPTION
What does this PR do?
---------------------
Launch statsd in datadog-agent running on the host metal instance.

Which scenarios this will impact?
-------------------
microvms scenario

Motivation
----------
Write custom collectors to emit metrics to the backend.
https://github.com/DataDog/datadog-agent/pull/29099

Additional Notes
----------------
