### PR TITLE
Add the tasks to run VMs on GCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Available tasks:
   az.destroy-aks                                            Destroy a AKS environment created with invoke az.create-aks.
   az.destroy-vm                                             Destroy a new virtual machine on azure.
   ci.create-bump-pr-and-close-stale-ones-on-datadog-agent
+  gcp.create-vm                                             Create a new virtual machine on GCP.
+  gcp.destroy-vm                                            Destroy a virtual machine environment created with invoke gcp.create-vm.
   setup.debug                                               Debug E2E and test-infra-definitions required tools and configuration
   setup.debug-keys                                          Debug E2E and test-infra-definitions SSH keys
   setup.setup (setup)                                       Setup a local environment, interactively by default

--- a/integration-tests/testfixture/config.yaml
+++ b/integration-tests/testfixture/config.yaml
@@ -10,6 +10,9 @@ configParams:
   azure:
     publicKeyPath: PUBLIC_KEY_PATH
     account: ACCOUNT
+  gcp:
+    publicKeyPath: PUBLIC_KEY_PATH
+    account: ACCOUNT
   pulumi:
     logLevel: 1
     logToStdErr: true

--- a/scenarios/gcp/compute/run/vm_run.go
+++ b/scenarios/gcp/compute/run/vm_run.go
@@ -16,7 +16,7 @@ func VMRun(ctx *pulumi.Context) error {
 		return err
 	}
 
-	vm, err := compute.NewVM(env, "vm")
+	vm, err := compute.NewVM(env, "gcp-vm")
 	if err != nil {
 		return err
 	}

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -5,7 +5,7 @@ from invoke.collection import Collection
 import tasks.ci as ci
 import tasks.setup as setup
 import tasks.test as test
-from tasks import aws, azure
+from tasks import aws, azure, gcp
 from tasks.aks import create_aks, destroy_aks
 from tasks.deploy import check_s3_image_exists
 from tasks.docker import create_docker, destroy_docker
@@ -39,6 +39,7 @@ ns.add_task(retry_job)
 
 ns.add_collection(aws.collection, "aws")
 ns.add_collection(azure.collection, "az")
+ns.add_collection(gcp.collection, "gcp")
 ns.add_collection(ci)
 ns.add_collection(setup)
 ns.add_collection(test)

--- a/tasks/config.py
+++ b/tasks/config.py
@@ -45,6 +45,13 @@ You should consider moving to the agent-sandbox account. Please follow https://d
 
         azure: Optional[Azure] = None
 
+        class GCP(BaseModel, extra=Extra.forbid):
+            _DEFAULT_ACCOUNT = "datadog-agent-sandbox"
+            publicKeyPath: Optional[str] = None
+            account: Optional[str] = _DEFAULT_ACCOUNT
+
+        gcp: Optional[GCP] = None
+
         class Agent(BaseModel, extra=Extra.forbid):
             apiKey: Optional[str]
             appKey: Optional[str]
@@ -82,6 +89,14 @@ You should consider moving to the agent-sandbox account. Please follow https://d
         if self.configParams.azure is None:
             return default
         return self.configParams.azure
+
+    def get_gcp(self) -> Params.GCP:
+        default = Config.Params.GCP(publicKeyPath=None)
+        if self.configParams is None:
+            return default
+        if self.configParams.gcp is None:
+            return default
+        return self.configParams.gcp
 
     def get_aws(self) -> Params.Aws:
         default = Config.Params.Aws(keyPairName=None, publicKeyPath=None, account=None, teamTag=None)

--- a/tasks/gcp/__init__.py
+++ b/tasks/gcp/__init__.py
@@ -1,0 +1,9 @@
+# type: ignore[reportArgumentType]
+
+from invoke.collection import Collection
+
+from tasks.gcp.vm import create_vm, destroy_vm
+
+collection = Collection()
+collection.add_task(destroy_vm)
+collection.add_task(create_vm)

--- a/tasks/gcp/common.py
+++ b/tasks/gcp/common.py
@@ -1,0 +1,57 @@
+from typing import List, Union
+
+
+def get_default_os_family() -> str:
+    return "ubuntu"
+
+
+def get_os_families() -> List[str]:
+    return [
+        get_default_os_family(),
+    ]
+
+
+def get_package_for_os(os: str) -> str:
+    package_map = {
+        get_default_os_family(): "deb",
+    }
+
+    return package_map[os]
+
+
+def get_deploy_job(os: str, arch: Union[str, None], agent_version: Union[str, None] = None) -> str:
+    """
+    Returns the deploy job name within the datadog agent repo that creates
+    images used in create-vm
+    """
+    pkg = get_package_for_os(os)
+    if agent_version is None:
+        v = 'a7'
+    else:
+        major = agent_version.split('.')[0]
+        assert major in ('6', '7'), f'Invalid agent version {agent_version}'
+        v = f'a{major}'
+
+    if arch == 'x86_64':
+        arch = 'x64'
+
+    # Construct job name
+    if os == 'windows':
+        suffix = f'-{v}'
+        assert arch == 'x64', f'Invalid architecture {arch} for Windows'
+    elif os == 'suse':
+        suffix = f'_{arch}-{v}'
+    elif pkg in ('deb', 'rpm'):
+        suffix = f'-{v}_{arch}'
+    else:
+        raise RuntimeError(f'Cannot deduce deploy job from {os}::{arch}')
+
+    return f'deploy_{pkg}_testing{suffix}'
+
+
+def get_architectures() -> List[str]:
+    return [get_default_architecture(), "arm64"]
+
+
+def get_default_architecture() -> str:
+    return "x86_64"

--- a/tasks/gcp/doc.py
+++ b/tasks/gcp/doc.py
@@ -1,0 +1,7 @@
+from .common import get_architectures, get_default_architecture, get_default_os_family, get_os_families
+
+instance_type: str = "The instance type to use (default is e2-medium for GCP)"
+os_family: str = f"The operating system. Possible values are {get_os_families()}. Default '{get_default_os_family()}'"
+architecture: str = (
+    f"The architecture to use. Possible values are {get_architectures()}. Default '{get_default_architecture()}'"
+)

--- a/tasks/gcp/vm.py
+++ b/tasks/gcp/vm.py
@@ -1,0 +1,160 @@
+from typing import Optional, Tuple
+
+from invoke.context import Context
+from invoke.exceptions import Exit
+from invoke.tasks import task
+from pydantic_core._pydantic_core import ValidationError
+
+from tasks import config, doc, tool
+from tasks.config import get_full_profile_path
+from tasks.deploy import deploy
+from tasks.destroy import destroy
+from tasks.gcp import doc as gcp_doc
+from tasks.gcp.common import (
+    get_architectures,
+    get_default_architecture,
+    get_default_os_family,
+    get_deploy_job,
+    get_os_families,
+)
+from tasks.tool import clean_known_hosts as clean_known_hosts_func
+from tasks.tool import get_host, show_connection_message
+
+scenario_name = "gcp/vm"
+remote_hostname = "gcp-vm"
+
+
+@task(
+    help={
+        "config_path": doc.config_path,
+        "install_agent": doc.install_agent,
+        "install_installer": doc.install_installer,
+        "agent_version": doc.agent_version,
+        "stack_name": doc.stack_name,
+        "debug": doc.debug,
+        "interactive": doc.interactive,
+        "ssh_user": doc.ssh_user,
+        "os_family": gcp_doc.os_family,
+        "architecture": gcp_doc.architecture,
+        "instance_type": gcp_doc.instance_type,
+        "os_version": doc.os_version,
+    }
+)
+def create_vm(
+    ctx: Context,
+    config_path: Optional[str] = None,
+    stack_name: Optional[str] = None,
+    install_agent: Optional[bool] = True,
+    install_installer: Optional[bool] = False,
+    agent_version: Optional[str] = None,
+    debug: Optional[bool] = False,
+    interactive: Optional[bool] = True,
+    ssh_user: Optional[str] = None,
+    account: Optional[str] = None,
+    os_family: Optional[str] = None,
+    os_version: Optional[str] = None,
+    architecture: Optional[str] = None,
+    instance_type: Optional[str] = None,
+    deploy_job: Optional[str] = None,
+    no_verify: Optional[bool] = False,
+    use_fakeintake: Optional[bool] = False,
+) -> None:
+    """
+    Create a new virtual machine on gcp.
+    """
+
+    try:
+        cfg = config.get_local_config(config_path)
+    except ValidationError as e:
+        raise Exit(f"Error in config {get_full_profile_path(config_path)}") from e
+
+    if not cfg.get_gcp().publicKeyPath:
+        raise Exit("The field `gcp.publicKeyPath` is required in the config file")
+
+    os_family, os_arch = _get_os_information(os_family, architecture)
+    _deploy_job = None if no_verify else get_deploy_job(os_family, os_arch, agent_version)
+
+    extra_flags = {
+        "ddinfra:env": f"gcp/{account if account else cfg.get_gcp().account}",
+        "ddinfra:gcp/defaultPublicKeyPath": cfg.get_gcp().publicKeyPath,
+        "ddinfra:osDescriptor": f"{os_family}:{os_version if os_version else ''}:{os_arch}",
+    }
+
+    if instance_type:
+        if architecture is None or architecture.lower() == get_default_architecture():
+            extra_flags["ddinfra:gcp/defaultInstanceType"] = instance_type
+        else:
+            extra_flags["ddinfra:gcp/defaultARMInstanceType"] = instance_type
+
+    if ssh_user:
+        extra_flags["ddinfra:sshUser"] = ssh_user
+
+    full_stack_name = deploy(
+        ctx,
+        scenario_name,
+        config_path,
+        stack_name=stack_name,
+        install_agent=install_agent,
+        install_installer=install_installer,
+        agent_version=agent_version,
+        debug=debug,
+        extra_flags=extra_flags,
+        use_fakeintake=use_fakeintake,
+    )
+
+    if interactive:
+        tool.notify(ctx, "Your VM is now created")
+
+    show_connection_message(ctx, remote_hostname, full_stack_name, interactive)
+
+
+@task(
+    help={
+        "config_path": doc.config_path,
+        "stack_name": doc.stack_name,
+        "yes": doc.yes,
+        "clean_known_hosts": doc.clean_known_hosts,
+    }
+)
+def destroy_vm(
+    ctx: Context,
+    config_path: Optional[str] = None,
+    stack_name: Optional[str] = None,
+    yes: Optional[bool] = True,
+    clean_known_hosts: Optional[bool] = True,
+):
+    """
+    Destroy a new virtual machine on gcp.
+    """
+    host = get_host(ctx, remote_hostname, scenario_name, stack_name)
+    destroy(
+        ctx,
+        scenario_name=scenario_name,
+        config_path=config_path,
+        stack=stack_name,
+        force_yes=yes,
+    )
+    if clean_known_hosts:
+        clean_known_hosts_func(host)
+
+
+def _get_os_information(os_family: Optional[str], arch: Optional[str]) -> Tuple[str, Optional[str]]:
+    return _get_os_family(os_family), _get_architecture(arch)
+
+
+def _get_os_family(os_family: Optional[str]) -> str:
+    os_families = get_os_families()
+    if not os_family:
+        os_family = get_default_os_family()
+    if os_family.lower() not in os_families:
+        raise Exit(f"The os family '{os_family}' is not supported. Possibles values are {', '.join(os_families)}")
+    return os_family
+
+
+def _get_architecture(architecture: Optional[str]) -> str:
+    architectures = get_architectures()
+    if not architecture:
+        architecture = get_default_architecture()
+    if architecture.lower() not in architectures:
+        raise Exit(f"The os family '{architecture}' is not supported. Possibles values are {', '.join(architectures)}")
+    return architecture


### PR DESCRIPTION
What does this PR do?
---------------------

Add the tasks to run VMs on GCP

- `inv gcp.create-vm`
- `inv gcp.destroy-vm`

They work the same way Azure and AWS commands work

Which scenarios this will impact?
-------------------

Motivation
----------

GCP is now available

Additional Notes
----------------

To make it work, you need to log in manually for now:

- Run `gcloud auth application-default login`
- or with a service account `export GOOGLE_CREDENTIALS=<path-to-credentials.json>`
