### PR TITLE
Configure the CI to run tests on GCP

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,6 +57,9 @@ integration-testing:
   rules:
     - when: on_success
   before_script:
+    # Setup GCP credentials. https://www.pulumi.com/registry/packages/gcp/installation-configuration/
+    # The service account is called `agent-e2e-tests`
+    - export GOOGLE_CREDENTIALS=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.gcp_credentials --with-decryption --query "Parameter.Value" --out text)
     # Setup Azure credentials. https://www.pulumi.com/registry/packages/azure-native/installation-configuration/#set-configuration-using-pulumi-config
     # The app is called `agent-e2e-tests`
     - export ARM_CLIENT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_id --with-decryption --query "Parameter.Value" --out text)


### PR DESCRIPTION
What does this PR do?
---------------------

Configure the CI to run tests on GCP

Which scenarios this will impact?
-------------------

Motivation
----------

We're adding support for GCP

Additional Notes
----------------

- https://www.pulumi.com/registry/packages/gcp/service-account/
- I manually created the secret the same way the other credentials are configured