### PR TITLE
Remove pyyaml 5.4.1 from the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,11 +114,7 @@ RUN --mount=type=secret,id=github_token \
 
 # Install Agent requirements, required to run invoke tests task
 # Remove AWS-related deps as we already install AWS CLI v2
-# Remove PyYAML to workaround issues with cpython 3.0.0
-# https://github.com/yaml/pyyaml/issues/724#issuecomment-1638636728
-RUN pip3 install "cython<3.0.0" && \
-  pip3 install --no-build-isolation PyYAML==5.4.1 && \
-  pip3 install -r https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/requirements/e2e.txt & \
+RUN pip3 install -r https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/requirements/e2e.txt & \
   pip3 install -r /tmp/test-infra/requirements.txt & \
   go install gotest.tools/gotestsum@latest
 


### PR DESCRIPTION
What does this PR do?
---------------------

Remove pyyaml 5.4.1 from the docker image

Which scenarios this will impact?
-------------------

Motivation
----------

We don't use pyyaml 5.4.1 anymore and there's no need to build it with this hack anymore. We now use [6.0.2](https://github.com/DataDog/test-infra-definitions/blob/main/requirements.txt#L3) which pins cython https://github.com/yaml/pyyaml/blob/main/CHANGES#L16

Additional Notes
----------------
