### PR TITLE
[aws][fakeintake] log on fakeintake errors while waiting for a healthy task 

### DIFF
--- a/scenarios/aws/fakeintake/fakeintake.go
+++ b/scenarios/aws/fakeintake/fakeintake.go
@@ -115,11 +115,12 @@ func fargateSvcNoLB(e aws.Environment, namer namer.Namer, taskDef *awsxEcs.Farga
 			return err
 		}, backoff.WithMaxRetries(backoff.NewConstantBackOff(sleepInterval), maxRetries))
 		if err != nil {
+			e.Ctx().Log.Warn(fmt.Sprintf("error while waiting for fakeintake task private ip: %v", err), nil)
 			return nil, err
 		}
 
 		// fail the deployment if the fakeintake is not healthy
-		e.Ctx().Log.Info(fmt.Sprintf("Waiting for fakeintake at %s to be healthy", ipAddress), nil)
+		e.Ctx().Log.Info(fmt.Sprintf("waiting for fakeintake at %s to be healthy", ipAddress), nil)
 		healthURL := buildFakeIntakeURL("http", ipAddress, "/fakeintake/health", httpPort)
 		err = backoff.Retry(func() error {
 			e.Ctx().Log.Debug(fmt.Sprintf("getting fakeintake health at %s", healthURL), nil)
@@ -135,8 +136,10 @@ func fargateSvcNoLB(e aws.Environment, namer namer.Namer, taskDef *awsxEcs.Farga
 			return nil
 		}, backoff.WithMaxRetries(backoff.NewConstantBackOff(sleepInterval), maxRetries))
 		if err != nil {
+			e.Ctx().Log.Warn(fmt.Sprintf("error while waiting for fakeintake at %s: %v", ipAddress, err), nil)
 			return nil, err
 		}
+		e.Ctx().Log.Info(fmt.Sprintf("fakeintake healthy at %s", ipAddress), nil)
 
 		return []string{ipAddress, buildFakeIntakeURL("http", ipAddress, "", httpPort)}, nil
 	}).(pulumi.StringArrayOutput)


### PR DESCRIPTION
What does this PR do?
---------------------

Add logs when we fail waiting for healthy fakeintake on ECS without load balancer

Which scenarios this will impact?
-------------------

VM

Motivation
----------

#incident-30445

[ADXT-572](https://datadoghq.atlassian.net/browse/ADXT-572)
[ADXT-574
](https://datadoghq.atlassian.net/browse/ADXT-575)[ADXT-575](https://datadoghq.atlassian.net/browse/ADXT-575)

We had a [bunch of errors](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/633325738) related to unhealthy fakeintake tasks yesterday, adding more logs to make sure the fakeintake is healthy

Additional Notes
----------------


[ADXT-572]: https://datadoghq.atlassian.net/browse/ADXT-572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ADXT-575]: https://datadoghq.atlassian.net/browse/ADXT-575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ