### PR TITLE
Use a public ecr image for aws fluent bit

### DIFF
--- a/resources/aws/ecs/fargateService.go
+++ b/resources/aws/ecs/fargateService.go
@@ -107,7 +107,7 @@ func FargateFirelensContainerDefinition() *ecs.TaskDefinitionContainerDefinition
 		Cpu:       pulumi.IntPtr(0),
 		User:      pulumi.StringPtr("0"),
 		Name:      pulumi.String("log_router"),
-		Image:     pulumi.String("amazon/aws-for-fluent-bit:stable"),
+		Image:     pulumi.String("public.ecr.aws/aws-observability/aws-for-fluent-bit:stable"),
 		Essential: pulumi.BoolPtr(true),
 		FirelensConfiguration: ecs.TaskDefinitionFirelensConfigurationArgs{
 			Type: pulumi.String("fluentbit"),


### PR DESCRIPTION
What does this PR do?
---------------------

Use public ecr image instead of Dockerhub image.

Which scenarios this will impact?
-------------------

Motivation
----------

I saw some Dockerhub rate limit error on fakeintake task when we observe high fakeintake timeout failures. This is a test to see if it could be the cause of the timeouts

Additional Notes
----------------
