### PR TITLE
Add architecture and Descriptor to HostOutput component

### DIFF
--- a/components/remote/component.go
+++ b/components/remote/component.go
@@ -11,12 +11,17 @@ import (
 type HostOutput struct {
 	components.JSONImporter
 
-	Address   string    `json:"address"`
-	Username  string    `json:"username"`
-	Password  string    `json:"password,omitempty"`
-	OSFamily  os.Family `json:"osFamily"`
-	OSFlavor  os.Flavor `json:"osFlavor"`
-	OSVersion string    `json:"osVersion"`
+	Address      string          `json:"address"`
+	Username     string          `json:"username"`
+	Password     string          `json:"password,omitempty"`
+	Architecture os.Architecture `json:"architecture"`
+	OSFamily     os.Family       `json:"osFamily"`
+	OSFlavor     os.Flavor       `json:"osFlavor"`
+	OSVersion    string          `json:"osVersion"`
+}
+
+func (h *HostOutput) Descriptor() os.Descriptor {
+	return os.NewDescriptorWithArch(h.OSFlavor, h.OSVersion, h.Architecture)
 }
 
 // Host represents a remote host (for instance, a VM)


### PR DESCRIPTION
What does this PR do?
---------------------
Add `Architecture` field and `Descriptor` function to HostOutput component.

Which scenarios this will impact?
-------------------

Motivation
----------
Being able to update the environment easily no matter the host (in particular we have similar tests on Linux and Windows):

```go
v.UpdateEnv(awshost.Provisioner(
	awshost.WithEC2InstanceOptions(
		ec2.WithOS(v.Env().RemoteHost.Descriptor()),
		... // <- make your actual change, eg. agent config
	),
))
```

Additional Notes
----------------
I think keeping the OS should actually be done by `UpdateEnv` by default without having to explicitly re-declare your OS/Arch, but as it's not currently the case this is a convenient way to make it simpler. 
