### PR TITLE
Add support for Autopilot

### DIFF
--- a/components/datadog/agent/ecs.go
+++ b/components/datadog/agent/ecs.go
@@ -82,7 +82,7 @@ func ecsLinuxAgentSingleContainerDefinition(e config.Env, apiKeySSMParamName pul
 		Essential: pulumi.BoolPtr(true),
 		LinuxParameters: ecs.TaskDefinitionLinuxParametersArgs{
 			Capabilities: ecs.TaskDefinitionKernelCapabilitiesArgs{
-				Add: pulumi.ToStringArray([]string{"SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "NET_RAW", "IPC_LOCK", "CHOWN"}),
+				Add: pulumi.ToStringArray([]string{"SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "NET_RAW", "IPC_LOCK", "CHOWN"}),
 			},
 		},
 		Environment: append(append(append(ecs.TaskDefinitionKeyValuePairArray{

--- a/components/datadog/agent/ecs.go
+++ b/components/datadog/agent/ecs.go
@@ -82,7 +82,7 @@ func ecsLinuxAgentSingleContainerDefinition(e config.Env, apiKeySSMParamName pul
 		Essential: pulumi.BoolPtr(true),
 		LinuxParameters: ecs.TaskDefinitionLinuxParametersArgs{
 			Capabilities: ecs.TaskDefinitionKernelCapabilitiesArgs{
-				Add: pulumi.ToStringArray([]string{"SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "NET_RAW", "IPC_LOCK", "CHOWN"}),
+				Add: pulumi.ToStringArray([]string{"SYS_ADMIN", "SYS_RESOURCE", "SYS_PTRACE", "NET_ADMIN", "NET_BROADCAST", "NET_RAW", "IPC_LOCK", "CHOWN"}),
 			},
 		},
 		Environment: append(append(append(ecs.TaskDefinitionKeyValuePairArray{

--- a/components/datadog/agent/helm/kubernetes_agent.go
+++ b/components/datadog/agent/helm/kubernetes_agent.go
@@ -31,6 +31,7 @@ func NewKubernetesAgent(e config.Env, resourceName string, kubeProvider *kuberne
 			DisableLogsContainerCollectAll: params.DisableLogsContainerCollectAll,
 			OTelAgent:                      params.OTelAgent,
 			OTelConfig:                     params.OTelConfig,
+			GKEAutopilot:                   params.GKEAutopilot,
 		}, pulumiResourceOptions...)
 		if err != nil {
 			return err

--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -136,12 +136,12 @@ func NewHelmInstallation(e config.Env, args HelmInstallationArgs, opts ...pulumi
 	clusterAgentImagePath, clusterAgentImageTag := utils.ParseImageReference(clusterAgentImagePath)
 
 	linuxInstallName := baseName + "-linux"
-	values := HelmValues{}
+	var values HelmValues
+
 	if args.GKEAutopilot {
 		values = buildLinuxHelmValuesAutopilot(baseName, agentImagePath, agentImageTag, clusterAgentImagePath, clusterAgentImageTag, randomClusterAgentToken.Result)
 	} else {
 		values = buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentImagePath, clusterAgentImageTag, randomClusterAgentToken.Result, !args.DisableLogsContainerCollectAll)
-
 	}
 	values.configureImagePullSecret(imgPullSecret)
 	values.configureFakeintake(e, args.Fakeintake, !args.DisableDualShipping)

--- a/components/datadog/kubernetesagentparams/params.go
+++ b/components/datadog/kubernetesagentparams/params.go
@@ -51,6 +51,8 @@ type Params struct {
 	OTelAgent bool
 	// OTelConfig is the OTel configuration to use for the agent installation.
 	OTelConfig string
+	// GKEAutopilot is a flag to deploy the agent with only GKE Autopilot compatible values.
+	GKEAutopilot bool
 }
 
 type Option = func(*Params) error
@@ -155,5 +157,12 @@ func WithOTelConfig(config string) func(*Params) error {
 		var err error
 		p.OTelConfig, err = utils.MergeYAML(p.OTelConfig, config)
 		return err
+	}
+}
+
+func WithGKEAutopilot() func(*Params) error {
+	return func(p *Params) error {
+		p.GKEAutopilot = true
+		return nil
 	}
 }

--- a/resources/gcp/environment.go
+++ b/resources/gcp/environment.go
@@ -24,6 +24,7 @@ const (
 	DDInfraDefaultRegionNameParamName      = "gcp/defaultRegion"
 	DDInfraDefaultZoneNameParamName        = "gcp/defaultZone"
 	DDInfraDefautVMServiceAccountParamName = "gcp/defaultVMServiceAccount"
+	DDInfraGKEEnableAutopilot              = "gcp/gke/enableAutopilot"
 )
 
 type Environment struct {
@@ -138,6 +139,11 @@ func (e *Environment) DefaultInstanceType() string {
 
 func (e *Environment) DefaultVMServiceAccount() string {
 	return e.GetStringWithDefault(e.InfraConfig, DDInfraDefautVMServiceAccountParamName, e.envDefault.ddInfra.defaultVMServiceAccount)
+}
+
+// GKEAutopilot Whether to enable GKE Autopilot or not
+func (e *Environment) GKEAutopilot() bool {
+	return e.GetBoolWithDefault(e.InfraConfig, DDInfraGKEEnableAutopilot, e.envDefault.ddInfra.gke.autopilot)
 }
 
 // Region returns the default region for the GCP environment

--- a/resources/gcp/environmentDefaults.go
+++ b/resources/gcp/environmentDefaults.go
@@ -21,6 +21,11 @@ type ddInfra struct {
 	defaultNetworkName      string
 	defaultSubnetName       string
 	defaultVMServiceAccount string
+	gke                     ddInfraGKE
+}
+
+type ddInfraGKE struct {
+	autopilot bool
 }
 
 func getEnvironmentDefault(envName string) environmentDefault {
@@ -46,6 +51,7 @@ func agentSandboxDefault() environmentDefault {
 			defaultNetworkName:      "datadog-agent-sandbox-us-central1",
 			defaultSubnetName:       "datadog-agent-sandbox-us-central1-private",
 			defaultVMServiceAccount: "vmserviceaccount@datadog-agent-sandbox.iam.gserviceaccount.com",
+			gke:                     ddInfraGKE{autopilot: false},
 		},
 	}
 }
@@ -62,6 +68,7 @@ func agentQaDefault() environmentDefault {
 			defaultNetworkName:      "datadog-agent-qa-us-central1",
 			defaultSubnetName:       "datadog-agent-qa-us-central1-private",
 			defaultVMServiceAccount: "vmserviceaccount@datadog-agent-qa.iam.gserviceaccount.com",
+			gke:                     ddInfraGKE{autopilot: false},
 		},
 	}
 }

--- a/resources/gcp/gke/cluster.go
+++ b/resources/gcp/gke/cluster.go
@@ -11,6 +11,7 @@ func NewCluster(e gcp.Environment, name string, autopilot bool, opts ...pulumi.R
 	opts = append(opts, e.WithProviders(config.ProviderGCP))
 
 	cluster, err := container.NewCluster(e.Ctx(), e.Namer.ResourceName(name), &container.ClusterArgs{
+		InitialNodeCount:   pulumi.Int(1),
 		MinMasterVersion:   pulumi.String(e.KubernetesVersion()),
 		NodeVersion:        pulumi.String(e.KubernetesVersion()),
 		DeletionProtection: pulumi.Bool(false),

--- a/resources/gcp/gke/cluster.go
+++ b/resources/gcp/gke/cluster.go
@@ -7,14 +7,15 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-func NewCluster(e gcp.Environment, name string, opts ...pulumi.ResourceOption) (*container.Cluster, pulumi.StringOutput, error) {
+func NewCluster(e gcp.Environment, name string, autopilot bool, opts ...pulumi.ResourceOption) (*container.Cluster, pulumi.StringOutput, error) {
 	opts = append(opts, e.WithProviders(config.ProviderGCP))
 
 	cluster, err := container.NewCluster(e.Ctx(), e.Namer.ResourceName(name), &container.ClusterArgs{
-		InitialNodeCount:   pulumi.Int(2),
 		MinMasterVersion:   pulumi.String(e.KubernetesVersion()),
 		NodeVersion:        pulumi.String(e.KubernetesVersion()),
 		DeletionProtection: pulumi.Bool(false),
+		EnableAutopilot:    pulumi.Bool(autopilot),
+		NodeLocations:      pulumi.StringArray{pulumi.String(e.Zone())},
 		NodeConfig: &container.ClusterNodeConfigArgs{
 			MachineType: pulumi.String(e.DefaultInstanceType()),
 

--- a/scenarios/gcp/gke/cluster.go
+++ b/scenarios/gcp/gke/cluster.go
@@ -14,6 +14,7 @@ import (
 )
 
 type Params struct {
+	autopilot bool
 }
 
 type Option = func(*Params) error
@@ -23,14 +24,21 @@ func NewParams(options ...Option) (*Params, error) {
 	return common.ApplyOption(params, options)
 }
 
+func WithAutopilot() Option {
+	return func(params *Params) error {
+		params.autopilot = true
+		return nil
+	}
+}
+
 func NewGKECluster(env gcp.Environment, opts ...Option) (*kubeComp.Cluster, error) {
-	_, err := NewParams(opts...)
+	params, err := NewParams(opts...)
 	if err != nil {
 		return nil, err
 	}
 
 	return components.NewComponent(&env, env.Namer.ResourceName("gke"), func(comp *kubeComp.Cluster) error {
-		cluster, kubeConfig, err := gke.NewCluster(env, "gke")
+		cluster, kubeConfig, err := gke.NewCluster(env, "gke", params.autopilot)
 		if err != nil {
 			return err
 		}

--- a/scenarios/gcp/gke/run.go
+++ b/scenarios/gcp/gke/run.go
@@ -48,9 +48,15 @@ func Run(ctx *pulumi.Context) error {
 		)
 
 		if env.GKEAutopilot() {
+			autopilotHelmValues := `
+providers:
+  gke:
+    autopilot: true`
+
 			k8sAgentOptions = append(
 				k8sAgentOptions,
-				kubernetesagentparams.WithNamespace("datadog"),
+				kubernetesagentparams.WithHelmValues(autopilotHelmValues),
+				kubernetesagentparams.WithGKEAutopilot(),
 			)
 		}
 
@@ -80,12 +86,6 @@ func Run(ctx *pulumi.Context) error {
 
 	// Deploy testing workload
 	if env.TestingWorkloadDeploy() {
-		// Deploy standalone dogstatsd
-		if env.DogstatsdDeploy() && !env.GKEAutopilot() {
-			if _, err := dogstatsdstandalone.K8sAppDefinition(&env, cluster.KubeProvider, "dogstatsd-standalone", nil, true, ""); err != nil {
-				return err
-			}
-		}
 
 		if _, err := nginx.K8sAppDefinition(&env, cluster.KubeProvider, "workload-nginx", "", true, dependsOnCrd); err != nil {
 			return err
@@ -95,26 +95,36 @@ func Run(ctx *pulumi.Context) error {
 			return err
 		}
 
-		// dogstatsd clients that report to the Agent
-		if _, err := dogstatsd.K8sAppDefinition(&env, cluster.KubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket", dependsOnCrd); err != nil {
-			return err
-		}
-
-		// dogstatsd clients that report to the dogstatsd standalone deployment
-		if _, err := dogstatsd.K8sAppDefinition(&env, cluster.KubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket, dependsOnCrd); err != nil {
-			return err
-		}
-
-		if _, err := tracegen.K8sAppDefinition(&env, cluster.KubeProvider, "workload-tracegen", dependsOnCrd); err != nil {
-			return err
-		}
-
 		if _, err := prometheus.K8sAppDefinition(&env, cluster.KubeProvider, "workload-prometheus", dependsOnCrd); err != nil {
 			return err
 		}
 
 		if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(&env, cluster.KubeProvider, "workload-mutated", "workload-mutated-lib-injection", dependsOnCrd); err != nil {
 			return err
+		}
+
+		// These workloads cannot be deployed on Autopilot because of the constraints on hostPath volumes
+		if !env.GKEAutopilot() {
+			// Deploy standalone dogstatsd
+			if env.DogstatsdDeploy() {
+				if _, err := dogstatsdstandalone.K8sAppDefinition(&env, cluster.KubeProvider, "dogstatsd-standalone", nil, true, ""); err != nil {
+					return err
+				}
+			}
+
+			// dogstatsd clients that report to the Agent
+			if _, err := dogstatsd.K8sAppDefinition(&env, cluster.KubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket", dependsOnCrd); err != nil {
+				return err
+			}
+
+			// dogstatsd clients that report to the dogstatsd standalone deployment
+			if _, err := dogstatsd.K8sAppDefinition(&env, cluster.KubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket, dependsOnCrd); err != nil {
+				return err
+			}
+
+			if _, err := tracegen.K8sAppDefinition(&env, cluster.KubeProvider, "workload-tracegen", dependsOnCrd); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/tasks/gcp/gke.py
+++ b/tasks/gcp/gke.py
@@ -36,6 +36,7 @@ def create_gke(
     full_image_path: Optional[str] = None,
     cluster_agent_full_image_path: Optional[str] = None,
     use_fakeintake: Optional[bool] = False,
+    use_autopilot: Optional[bool] = False,
 ) -> None:
     """
     Create a new GKE environment.
@@ -49,6 +50,7 @@ def create_gke(
     extra_flags = {
         "ddinfra:env": f"gcp/{account if account else cfg.get_gcp().account}",
         "ddinfra:gcp/defaultPublicKeyPath": cfg.get_gcp().publicKeyPath,
+        "ddinfra:gcp/gke/enableAutopilot": use_autopilot,
     }
 
     full_stack_name = deploy(


### PR DESCRIPTION
What does this PR do?
---------------------

This PR adds a flag and a configmap parameter to use Autopilot on GKE. As a lot of features are not authorized by GKE the default Helm values enable fewer things by default.
It is likely to not work with any custom image as Datadog is granted some exception on Autopilot for its stable images. We'll probably need to request an exception to be able to deploy images built in the pipeline. 

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
