### PR TITLE
Differentiate regions and zones in the GCP config

### DIFF
--- a/resources/gcp/environment.go
+++ b/resources/gcp/environment.go
@@ -21,6 +21,8 @@ const (
 	DDInfraDefaultInstanceTypeParamName    = "gcp/defaultInstanceType"
 	DDInfraDefaultNetworkNameParamName     = "gcp/defaultNetworkName"
 	DDInfraDefaultSubnetNameParamName      = "gcp/defaultSubnet"
+	DDInfraDefaultRegionNameParamName      = "gcp/defaultRegion"
+	DDInfraDefaultZoneNameParamName        = "gcp/defaultZone"
 	DDInfraDefautVMServiceAccountParamName = "gcp/defaultVMServiceAccount"
 )
 
@@ -51,7 +53,8 @@ func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
 
 	gcpProvider, err := gcp.NewProvider(ctx, string(config.ProviderGCP), &gcp.ProviderArgs{
 		Project: pulumi.StringPtr(env.envDefault.gcp.project),
-		Zone:    pulumi.StringPtr(env.envDefault.gcp.region),
+		Region:  pulumi.StringPtr(env.envDefault.gcp.region),
+		Zone:    pulumi.StringPtr(env.envDefault.gcp.zone),
 	})
 	if err != nil {
 		return Environment{}, err
@@ -135,4 +138,14 @@ func (e *Environment) DefaultInstanceType() string {
 
 func (e *Environment) DefaultVMServiceAccount() string {
 	return e.GetStringWithDefault(e.InfraConfig, DDInfraDefautVMServiceAccountParamName, e.envDefault.ddInfra.defaultVMServiceAccount)
+}
+
+// Region returns the default region for the GCP environment
+func (e *Environment) Region() string {
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraDefaultRegionNameParamName, e.envDefault.gcp.region)
+}
+
+// Zone returns the default zone for the GCP environment
+func (e *Environment) Zone() string {
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraDefaultZoneNameParamName, e.envDefault.gcp.zone)
 }

--- a/resources/gcp/environmentDefaults.go
+++ b/resources/gcp/environmentDefaults.go
@@ -13,6 +13,7 @@ type environmentDefault struct {
 type gcpProvider struct {
 	project string
 	region  string
+	zone    string
 }
 
 type ddInfra struct {
@@ -37,7 +38,8 @@ func agentSandboxDefault() environmentDefault {
 	return environmentDefault{
 		gcp: gcpProvider{
 			project: "datadog-agent-sandbox",
-			region:  "us-central1-a",
+			region:  "us-central1",
+			zone:    "us-central1-a",
 		},
 		ddInfra: ddInfra{
 			defaultInstanceType:     "e2-standard-2",
@@ -52,7 +54,8 @@ func agentQaDefault() environmentDefault {
 	return environmentDefault{
 		gcp: gcpProvider{
 			project: "datadog-agent-qa",
-			region:  "us-central1-a",
+			region:  "us-central1",
+			zone:    "us-central1-a",
 		},
 		ddInfra: ddInfra{
 			defaultInstanceType:     "e2-standard-2",


### PR DESCRIPTION
What does this PR do?
---------------------

Differentiate regions and zones in the GCP config

Which scenarios this will impact?
-------------------

Motivation
----------

We currently mix zones and regions in our config

Additional Notes
----------------

https://cloud.google.com/compute/docs/regions-zones