### PR TITLE
kmt: validate downloaded images

### DIFF
--- a/scenarios/aws/microVMs/microvms/files/download-vm-images.py
+++ b/scenarios/aws/microVMs/microvms/files/download-vm-images.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def usage():
+    print(f"Usage: {sys.argv[0]} <data-file>")
+
+
+def main(data_file):
+    with open(data_file) as f:
+        download_data = json.load(f)
+
+    images_to_download = []
+
+    for image in download_data:
+        checksum_file = Path(image["checksum_path"])
+        if not check_integrity(checksum_file):
+            print(f"Integrity check failed for checksum file: {checksum_file}, downloading image")
+            images_to_download.append(image)
+
+    curl_args = ["curl", "--no-progress-meter", "--fail", "--show-error", "--retry", "3", "--parallel"]
+    for image in images_to_download:
+        curl_args += [image["image_source"], "-o", image["image_path"]]
+        curl_args += [image["checksum_source"], "-o", image["checksum_path"]]
+
+    try:
+        subprocess.run(curl_args, check=True)
+    except subprocess.CalledProcessError:
+        print("Failed to download images")
+        sys.exit(1)
+
+    failed_integrity = False
+    for image in images_to_download:
+        if not check_integrity(Path(image["checksum_path"])):
+            print(f"Integrity check failed for downloaded image: {image['download_path']}")
+            failed_integrity = True
+
+    if failed_integrity:
+        print("Some images failed integrity check")
+        sys.exit(1)
+
+
+def check_integrity(checksum_file: Path) -> bool:
+    checksum_dir = checksum_file.parent
+
+    try:
+        subprocess.run(["sha256sum", "--strict", "--check", checksum_file], cwd=checksum_dir, check=True)
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        usage()
+        sys.exit(1)
+
+    if sys.argv[1] in ("-h", "--help"):
+        usage()
+        sys.exit(0)
+
+    main(sys.argv[1])

--- a/scenarios/aws/microVMs/microvms/files/download-vm-images.py
+++ b/scenarios/aws/microVMs/microvms/files/download-vm-images.py
@@ -31,7 +31,9 @@ def main(data_file):
         "3",
         "--parallel",
         "-w",
-        "'file: %{url_effective}'\n",
+        "'file: %{url_effective}'\n",  # Better output so we know which file actually failed
+        "--parallel-max",
+        str(len(images_to_download)),
     ]
     for image in images_to_download:
         source, path = image["image_source"], image["image_path"]

--- a/scenarios/aws/microVMs/microvms/files/download-vm-images.py
+++ b/scenarios/aws/microVMs/microvms/files/download-vm-images.py
@@ -32,7 +32,7 @@ def main(data_file):
         "--parallel",
         "-w",
         "'file: %{url_effective}'\n",  # Better output so we know which file actually failed
-        "--parallel-max",
+        "--parallel-max",  # Default is 50, we want just one thread per download
         str(len(images_to_download)),
     ]
     for image in images_to_download:

--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -245,7 +245,7 @@ func downloadAndCheckImage(runner *Runner, fsImage *filesystemImage, namer namer
 	checksumTargetDir := filepath.Dir(fsImage.checksumPath())
 
 	checkCmd := fmt.Sprintf("cd %s && sha256sum --strict --check %s", checksumTargetDir, fsImage.checksumPath())
-	curlArgs := "--silent --show-error --retry 3 --parallel "
+	curlArgs := "--no-progress-meter --fail --show-error --retry 3 --parallel"
 	clearPreviousFiles := fmt.Sprintf("rm -f %s %s", fsImage.downloadPath(), fsImage.checksumPath())
 	downloadCmd := fmt.Sprintf("curl %s %s -o %s %s -o %s", curlArgs, fsImage.imageSource, fsImage.downloadPath(), fsImage.checksumSource(), fsImage.checksumPath())
 	args := command.Args{

--- a/scenarios/aws/microVMs/microvms/libvirt_fs.go
+++ b/scenarios/aws/microVMs/microvms/libvirt_fs.go
@@ -1,6 +1,7 @@
 package microvms
 
 import (
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"net/url"

--- a/scenarios/aws/microVMs/microvms/volume.go
+++ b/scenarios/aws/microVMs/microvms/volume.go
@@ -42,15 +42,11 @@ func (fsi *filesystemImage) downloadPath() string {
 
 // checksumSource returns the source URL of the checksum file for the image.
 func (fsi *filesystemImage) checksumSource() string {
-	if fsi.isCompressed() {
-		return strings.Replace(fsi.imageSource, ".xz", ".sum", 1)
-	}
 	return fsi.imageSource + ".sum"
 }
 
 // checksumPath returns the path where the checksum file will be downloaded to on the target filesystem.
 func (fsi *filesystemImage) checksumPath() string {
-	// Download paths never end with .xz, so we can safely append .sum to the download path.
 	return fsi.imagePath + ".sum"
 }
 

--- a/scenarios/aws/microVMs/microvms/volume.go
+++ b/scenarios/aws/microVMs/microvms/volume.go
@@ -51,20 +51,20 @@ func (fsi *filesystemImage) checksumPath() string {
 }
 
 type filesystemImageDownload struct {
-	ImageName string `json:"image_name"`
-	ImagePath string `json:"image_path"`
-	ImageSource string `json:"image_source"`
+	ImageName      string `json:"image_name"`
+	ImagePath      string `json:"image_path"`
+	ImageSource    string `json:"image_source"`
 	ChecksumSource string `json:"checksum_source"`
-	ChecksumPath string `json:"checksum_path"`
+	ChecksumPath   string `json:"checksum_path"`
 }
 
 func (fsi *filesystemImage) toDownloadSpec() filesystemImageDownload {
 	return filesystemImageDownload{
-		ImageName: fsi.imageName,
-		ImagePath: fsi.downloadPath(),
-		ImageSource: fsi.imageSource,
+		ImageName:      fsi.imageName,
+		ImagePath:      fsi.downloadPath(),
+		ImageSource:    fsi.imageSource,
 		ChecksumSource: fsi.checksumSource(),
-		ChecksumPath: fsi.checksumPath(),
+		ChecksumPath:   fsi.checksumPath(),
 	}
 }
 

--- a/scenarios/aws/microVMs/microvms/volume.go
+++ b/scenarios/aws/microVMs/microvms/volume.go
@@ -2,6 +2,7 @@ package microvms
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/DataDog/test-infra-definitions/common/namer"
 	"github.com/DataDog/test-infra-definitions/components/command"
@@ -20,9 +21,37 @@ type LibvirtVolume interface {
 }
 
 type filesystemImage struct {
-	imageName   string
-	imagePath   string
-	imageSource string
+	imageName   string // name of the image
+	imagePath   string // path on the image in the target filesystem after download and decompression if needed
+	imageSource string // source URL of the image. Can end with .xz to indicate compression, image will be decompressed on download.
+}
+
+func (fsi *filesystemImage) isCompressed() bool {
+	return strings.HasSuffix(fsi.imageSource, ".xz")
+}
+
+// downloadPath returns the path where the image will be downloaded to on the target filesystem.
+// If the image is compressed, the path will have a .xz extension and it will be an intermediate file
+// until it is decompressed.
+func (fsi *filesystemImage) downloadPath() string {
+	if fsi.isCompressed() {
+		return fsi.imagePath + ".xz"
+	}
+	return fsi.imagePath
+}
+
+// checksumSource returns the source URL of the checksum file for the image.
+func (fsi *filesystemImage) checksumSource() string {
+	if fsi.isCompressed() {
+		return strings.Replace(fsi.imageSource, ".xz", ".sum", 1)
+	}
+	return fsi.imageSource + ".sum"
+}
+
+// checksumPath returns the path where the checksum file will be downloaded to on the target filesystem.
+func (fsi *filesystemImage) checksumPath() string {
+	// Download paths never end with .xz, so we can safely append .sum to the download path.
+	return fsi.imagePath + ".sum"
 }
 
 type volume struct {

--- a/scenarios/aws/microVMs/microvms/volume.go
+++ b/scenarios/aws/microVMs/microvms/volume.go
@@ -61,7 +61,7 @@ type filesystemImageDownload struct {
 func (fsi *filesystemImage) toDownloadSpec() filesystemImageDownload {
 	return filesystemImageDownload{
 		ImageName: fsi.imageName,
-		ImagePath: fsi.imagePath,
+		ImagePath: fsi.downloadPath(),
 		ImageSource: fsi.imageSource,
 		ChecksumSource: fsi.checksumSource(),
 		ChecksumPath: fsi.checksumPath(),

--- a/scenarios/aws/microVMs/microvms/volume.go
+++ b/scenarios/aws/microVMs/microvms/volume.go
@@ -50,6 +50,24 @@ func (fsi *filesystemImage) checksumPath() string {
 	return fsi.imagePath + ".sum"
 }
 
+type filesystemImageDownload struct {
+	ImageName string `json:"image_name"`
+	ImagePath string `json:"image_path"`
+	ImageSource string `json:"image_source"`
+	ChecksumSource string `json:"checksum_source"`
+	ChecksumPath string `json:"checksum_path"`
+}
+
+func (fsi *filesystemImage) toDownloadSpec() filesystemImageDownload {
+	return filesystemImageDownload{
+		ImageName: fsi.imageName,
+		ImagePath: fsi.imagePath,
+		ImageSource: fsi.imageSource,
+		ChecksumSource: fsi.checksumSource(),
+		ChecksumPath: fsi.checksumPath(),
+	}
+}
+
 type volume struct {
 	filesystemImage
 	pool        LibvirtPool


### PR DESCRIPTION
What does this PR do?
---------------------

Modifies the download process of VM images by adding a Python script that performs the download based on a JSON file with instructions:

1. It first checks the checksum before downloading the image. This allows us to avoid downloads of existing images, but also force a re-download if the image is corrupt.
2. Once the script checks which images need to be downloaded, it will do so with `curl`.
3. After the download, the 	checksum is checked to ensure the image is not corrupted.

Which scenarios this will impact?
-------------------

microVMs

Motivation
----------

The purpose of these changes is to make retries more consistent and correct.

Additional Notes
----------------

Tested in https://github.com/DataDog/datadog-agent/pull/29472 - pipeline https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/45694168
