### PR TITLE
[fargate] revert task pid mode on windows tasks

### DIFF
--- a/resources/aws/ecs/fargateService.go
+++ b/resources/aws/ecs/fargateService.go
@@ -61,8 +61,7 @@ func FargateWindowsTaskDefinitionWithAgent(
 		TaskRole: &awsx.DefaultRoleWithPolicyArgs{
 			RoleArn: pulumi.StringPtr(e.ECSTaskRole()),
 		},
-		Family:  e.CommonNamer().DisplayName(255, family),
-		PidMode: pulumi.StringPtr("task"),
+		Family: e.CommonNamer().DisplayName(255, family),
 		RuntimePlatform: classicECS.TaskDefinitionRuntimePlatformArgs{
 			OperatingSystemFamily: pulumi.String("WINDOWS_SERVER_2022_CORE"),
 		},


### PR DESCRIPTION
What does this PR do?
---------------------

Remove `task` pid mode for windows fargate tasks

Which scenarios this will impact?
-------------------

ECS

Motivation
----------

This is breaking the creation of Windows tasks

Additional Notes
----------------
