### PR TITLE
[ec2] reset password on Windows VMs

### DIFF
--- a/scenarios/aws/ec2/vm.go
+++ b/scenarios/aws/ec2/vm.go
@@ -60,7 +60,7 @@ func NewVM(e aws.Environment, name string, params ...VMOption) (*remote.Host, er
 			return err
 		}
 
-		var password pulumi.StringOutput
+		password := pulumi.String("").ToStringOutput()
 		if vmArgs.osInfo.Family() == os.WindowsFamily {
 			randomPassword, err := random.NewRandomString(e.Ctx(), e.Namer.ResourceName(name, "win-admin-password"), &random.RandomStringArgs{
 				Length:  pulumi.Int(20),

--- a/scenarios/aws/ec2/vm.go
+++ b/scenarios/aws/ec2/vm.go
@@ -83,7 +83,7 @@ func NewVM(e aws.Environment, name string, params ...VMOption) (*remote.Host, er
 			_, err = c.OS.Runner().Command(
 				e.CommonNamer().ResourceName("reset-admin-password"),
 				&command.Args{
-					Create: pulumi.Sprintf("$Password = ConvertTo-SecureString -String %s -AsPlainText -Force; Get-LocalUser -Name \"Administrator\" | Set-LocalUser -Password $Password", c.Password),
+					Create: pulumi.Sprintf("$Password = ConvertTo-SecureString -String \"%s\" -AsPlainText -Force; Get-LocalUser -Name \"Administrator\" | Set-LocalUser -Password $Password", c.Password),
 				}, pulumi.Parent(c))
 
 			if err != nil {


### PR DESCRIPTION
What does this PR do?
---------------------

Reset password and configure it to a random string at init time

Which scenarios this will impact?
-------------------

EC2 on Windows

Motivation
----------

EC2 configures Windows hosts with a random password. The password is base64 encrypted with the public SSH key, to decrypt it we would need to first decrypt the private SSH key that is passphrase protected on our laptops, then decrypt the key. As this has multiple potential points of failure, and it would require storing the private key password somewhere accessible, it is quicker to reset the password through SSH once we are connected to the VM, at init time. 

This allows for any code creating a `NewVM` on Windows to have a proper, accessible password in the `RemoteHost` output.

It is safe to print it in our CI logs as the instance is protected behind our network.

Additional Notes
----------------

[Tested on datadog-agent](https://github.com/DataDog/datadog-agent/pull/29622), the only failure is not related to the change, the test failed on `main` too
