### PR TITLE
[ADXT-514] Setup for GCP

### DIFF
--- a/tasks/config.py
+++ b/tasks/config.py
@@ -46,7 +46,7 @@ You should consider moving to the agent-sandbox account. Please follow https://d
         azure: Optional[Azure] = None
 
         class GCP(BaseModel, extra=Extra.forbid):
-            _DEFAULT_ACCOUNT = "datadog-agent-sandbox"
+            _DEFAULT_ACCOUNT = "agent-sandbox"
             publicKeyPath: Optional[str] = None
             account: Optional[str] = _DEFAULT_ACCOUNT
 

--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -40,6 +40,9 @@ def setup(
         error("Gcloud CLI not found, please install it: https://cloud.google.com/sdk/docs/install")
         raise Exit(code=1)
 
+    # Ensure gke-gcloud-auth-plugin is installed
+    _install_gcloud_auth_plugin(ctx)
+
     pulumi_version, pulumi_up_to_date = _pulumi_version(ctx)
     if pulumi_up_to_date:
         info(f"Pulumi is up to date: {pulumi_version}")
@@ -112,6 +115,22 @@ def _install_pulumi(ctx: Context):
         elif is_linux():
             path = Path().home().joinpath(".pulumi", "bin")
             os.environ["PATH"] = f"{os.environ['PATH']}:{path}"
+
+
+# Check if gke-gcloud-auth-plugin is installed and install it if not
+def _install_gcloud_auth_plugin(ctx):
+    res = ctx.run("gcloud components list --format=json --filter 'name: gke-gcloud-auth-plugin'", hide=True)
+    installed_component = json.loads(res.stdout)
+    if installed_component[0]["state"]["name"] == "Installed":
+        print("✅ gke-gcloud-auth-plugin is already installed")
+        return
+    print("🤖 Installing gke-gcloud-auth-plugin")
+    install = ctx.run("gcloud components install -q gke-gcloud-auth-plugin", hide=True)
+    if install is None:
+        raise Exit("Failed to install gke-gcloud-auth-plugin")
+    if install.exited != 0:
+        raise Exit(f"Failed to install gke-gcloud-auth-plugin: {install.stderr}")
+    print("✅ gke-gcloud-auth-plugin installed")
 
 
 def _check_config(config: Config):


### PR DESCRIPTION
What does this PR do?
---------------------

Add a step in the setup to make sure `gke-gcloud-auth-plugin` is installed. This is required to run creation of GKE cluster
It also fixes default account for GKE that should be `agent-sandbox`

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
