### PR TITLE
Update go.mod - fix command executions on darwin+arm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/test-infra-definitions
 
-go 1.22
+go 1.22.1
 
 require (
 	dario.cat/mergo v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/test-infra-definitions
 
-go 1.22.1
+go 1.22.5
 
 require (
 	dario.cat/mergo v1.0.0


### PR DESCRIPTION
Failing to run on mac M1 invoke commands with the error```error: failed to discover plugin requirements: determining go version: exit status 1```
Fixed by setting a version from which the toolchain can be installed

[link to Go issue
](https://github.com/golang/go/issues/65568)