### PR TITLE
Limit to 63 character for resource name on GCP and add NAT tag

### DIFF
--- a/resources/gcp/compute/vm.go
+++ b/resources/gcp/compute/vm.go
@@ -24,7 +24,7 @@ func NewLinuxInstance(e gcp.Environment, name string, imageName string, instance
 				Subnetwork: pulumi.String(e.DefaultSubnet()),
 			},
 		},
-		Name:        e.Namer.DisplayName(255, pulumi.String(name)),
+		Name:        e.Namer.DisplayName(64, pulumi.String(name)),
 		MachineType: pulumi.String(instanceType),
 		Tags: pulumi.StringArray{
 			pulumi.String("appgate-gateway"),

--- a/resources/gcp/compute/vm.go
+++ b/resources/gcp/compute/vm.go
@@ -28,6 +28,7 @@ func NewLinuxInstance(e gcp.Environment, name string, imageName string, instance
 		MachineType: pulumi.String(instanceType),
 		Tags: pulumi.StringArray{
 			pulumi.String("appgate-gateway"),
+			pulumi.String("nat-us-central1"),
 		},
 		BootDisk: &compute.InstanceBootDiskArgs{
 			InitializeParams: &compute.InstanceBootDiskInitializeParamsArgs{

--- a/resources/gcp/compute/vm.go
+++ b/resources/gcp/compute/vm.go
@@ -24,7 +24,7 @@ func NewLinuxInstance(e gcp.Environment, name string, imageName string, instance
 				Subnetwork: pulumi.String(e.DefaultSubnet()),
 			},
 		},
-		Name:        e.Namer.DisplayName(64, pulumi.String(name)),
+		Name:        e.Namer.DisplayName(63, pulumi.String(name)),
 		MachineType: pulumi.String(instanceType),
 		Tags: pulumi.StringArray{
 			pulumi.String("appgate-gateway"),


### PR DESCRIPTION
What does this PR do?
---------------------

Limit the maximum number of characters for VM resource on Azure to 63, otherwise it fails.
Add a tags to VM instances that is required to have then accessing the NAT Gateway. With that we should be able to run e2e tests from datadog-agent CI

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
