### PR TITLE
Update default OTel Agent image to nightly build

### DIFF
--- a/components/datadog/agent/docker_image.go
+++ b/components/datadog/agent/docker_image.go
@@ -13,7 +13,8 @@ const (
 	defaultAgentImageRepo        = "gcr.io/datadoghq/agent"
 	defaultClusterAgentImageRepo = "gcr.io/datadoghq/cluster-agent"
 	defaultAgentImageTag         = "latest"
-	defaultOTAgentImageTag       = "7-ot-beta"
+	defaultOTAgentImageRepo      = "datadog/agent-dev"
+	defaultOTAgentImageTag       = "nightly-ot-beta-main"
 )
 
 func dockerAgentFullImagePath(e config.Env, repositoryPath, imageTag string, otel bool) string {
@@ -34,6 +35,10 @@ func dockerAgentFullImagePath(e config.Env, repositoryPath, imageTag string, ote
 			panic(fmt.Sprintf("image %s/agent:%s not found in the internal registry", e.InternalRegistry(), tag))
 		}
 		return utils.BuildDockerImagePath(fmt.Sprintf("%s/agent", e.InternalRegistry()), tag)
+	}
+
+	if repositoryPath == "" && otel {
+		repositoryPath = defaultOTAgentImageRepo
 	}
 
 	if repositoryPath == "" {


### PR DESCRIPTION
What does this PR do?
---------------------
This PR changes the default OTel Agent image from `gcr.io/datadoghq/agent:7-ot-beta` to `datadog/agent-dev:nightly-ot-beta-main`.

Which scenarios this will impact?
-------------------
Local e2e test runs for OTel Agent tests.

Motivation
----------
Since the OTel Agent is currently in beta, we need more frequent builds to test with locally.

Additional Notes
----------------
