### PR TITLE
[github] change codeowners to agent devx loops

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 # Rules are matched bottom-to-top, so one team can own subdirectories
 # and another the rest of the directory.
 
-*                                       @DataDog/agent-e2e-testing
+*                                       @DataDog/agent-devx-loops 
 /scenarios/aws/microVMs/                @DataDog/ebpf-platform
 /scenarios/aws/installer/               @DataDog/fleet
 /components/datadog/apps/jmxfetch       @DataDog/agent-metrics-logs


### PR DESCRIPTION
What does this PR do?
---------------------

Change codeowners to `@DataDog/agent-devx-loops`

Which scenarios this will impact?
-------------------

Motivation
----------

Code reviews are currently posted on both e2e support channel and agent-devx-loops-reviews channel, attempt to have them posted only to one channel

Additional Notes
----------------
