### PR TITLE
Update EKS config map to allow account-admin and read-only SSO roles

### DIFF
--- a/resources/aws/environment.go
+++ b/resources/aws/environment.go
@@ -61,6 +61,8 @@ const (
 	DDInfraEksLinuxARMNodeGroup            = "aws/eks/linuxARMNodeGroup"
 	DDInfraEksLinuxBottlerocketNodeGroup   = "aws/eks/linuxBottlerocketNodeGroup"
 	DDInfraEksWindowsNodeGroup             = "aws/eks/windowsNodeGroup"
+	DDInfraEksAccountAdminSSORole          = "aws/eks/accountAdminSSORole"
+	DDInfraEksReadOnlySSORole              = "aws/eks/readOnlySSORole"
 )
 
 type Environment struct {
@@ -366,6 +368,13 @@ func (e *Environment) EKSWindowsNodeGroup() bool {
 	return e.GetBoolWithDefault(e.InfraConfig, DDInfraEksWindowsNodeGroup, e.envDefault.ddInfra.eks.windowsLTSCNodeGroup)
 }
 
+func (e *Environment) EKSAccountAdminSSORole() string {
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraEksAccountAdminSSORole, e.envDefault.ddInfra.eks.accountAdminSSORole)
+}
+
+func (e *Environment) EKSReadOnlySSORole() string {
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraEksReadOnlySSORole, e.envDefault.ddInfra.eks.readOnlySSORole)
+}
 func (e *Environment) GetCommonEnvironment() *config.CommonEnvironment {
 	return e.CommonEnvironment
 }

--- a/resources/aws/environmentDefaults.go
+++ b/resources/aws/environmentDefaults.go
@@ -58,6 +58,8 @@ type ddInfraECS struct {
 }
 
 type ddInfraEKS struct {
+	accountAdminSSORole          string
+	readOnlySSORole              string
 	podSubnets                   []DDInfraEKSPodSubnets
 	allowedInboundSecurityGroups []string
 	allowedInboundPrefixList     []string
@@ -168,6 +170,8 @@ func agentSandboxDefault() environmentDefault {
 			},
 
 			eks: ddInfraEKS{
+				readOnlySSORole:     "arn:aws:iam::376334461865:role/AWSReservedSSO_read-only_14b5d3ee971c41e7",
+				accountAdminSSORole: "arn:aws:iam::376334461865:role/AWSReservedSSO_account-admin_6b545a7026a0a2d4",
 				podSubnets: []DDInfraEKSPodSubnets{
 					{
 						AZ:       "us-east-1a",
@@ -230,6 +234,8 @@ func agentQADefault() environmentDefault {
 			},
 
 			eks: ddInfraEKS{
+				readOnlySSORole:     "arn:aws:iam::669783387624:role/AWSReservedSSO_read-only_e9a50f8c3009a8ce",
+				accountAdminSSORole: "arn:aws:iam::669783387624:role/AWSReservedSSO_account-admin_2730b1ac7bbae8eb",
 				podSubnets: []DDInfraEKSPodSubnets{
 					{
 						AZ:       "us-east-1a",

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -28,6 +28,9 @@ import (
 	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
 	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
 	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+
+	v1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/rbac/v1"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -115,6 +118,21 @@ func Run(ctx *pulumi.Context) error {
 			ProviderCredentialOpts: &eks.KubeconfigOptionsArgs{
 				ProfileName: pulumi.String(awsEnv.Profile()),
 			},
+			// Add account-admin role mapping to the cluster, which make investigations on cluster created in the CI easier.
+			RoleMappings: eks.RoleMappingArray{
+				eks.RoleMappingArgs{
+					RoleArn: pulumi.String(awsEnv.EKSAccountAdminSSORole()),
+					Groups: pulumi.StringArray{
+						pulumi.String("system:masters"),
+					},
+				},
+				eks.RoleMappingArgs{
+					RoleArn: pulumi.String(awsEnv.EKSReadOnlySSORole()),
+					Groups: pulumi.StringArray{
+						pulumi.String("read-only"),
+					},
+				},
+			},
 		}, pulumi.Timeouts(&pulumi.CustomTimeouts{
 			Create: "30m",
 			Update: "30m",
@@ -149,6 +167,21 @@ func Run(ctx *pulumi.Context) error {
 		// Deps for nodes and workloads
 		nodeDeps := make([]pulumi.Resource, 0)
 		workloadDeps := make([]pulumi.Resource, 0)
+
+		v1.NewClusterRoleBinding(awsEnv.Ctx(), awsEnv.Namer.ResourceName("eks-cluster-role-binding-read-only"), &v1.ClusterRoleBindingArgs{
+			RoleRef: v1.RoleRefArgs{
+				ApiGroup: pulumi.String("rbac.authorization.k8s.io"),
+				Kind:     pulumi.String("ClusterRole"),
+				Name:     pulumi.String("view"),
+			},
+			Subjects: v1.SubjectArray{
+				v1.SubjectArgs{
+					Kind:      pulumi.String("Group"),
+					Name:      pulumi.String("read-only"),
+					Namespace: pulumi.String(""),
+				},
+			},
+		}, pulumi.Provider(eksKubeProvider))
 
 		// Create configuration for POD subnets if any
 		if podSubnets := awsEnv.EKSPODSubnets(); len(podSubnets) > 0 {

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -168,7 +168,7 @@ func Run(ctx *pulumi.Context) error {
 		nodeDeps := make([]pulumi.Resource, 0)
 		workloadDeps := make([]pulumi.Resource, 0)
 
-		v1.NewClusterRoleBinding(awsEnv.Ctx(), awsEnv.Namer.ResourceName("eks-cluster-role-binding-read-only"), &v1.ClusterRoleBindingArgs{
+		_, err = v1.NewClusterRoleBinding(awsEnv.Ctx(), awsEnv.Namer.ResourceName("eks-cluster-role-binding-read-only"), &v1.ClusterRoleBindingArgs{
 			RoleRef: v1.RoleRefArgs{
 				ApiGroup: pulumi.String("rbac.authorization.k8s.io"),
 				Kind:     pulumi.String("ClusterRole"),
@@ -182,6 +182,9 @@ func Run(ctx *pulumi.Context) error {
 				},
 			},
 		}, pulumi.Provider(eksKubeProvider))
+		if err != nil {
+			return err
+		}
 
 		// Create configuration for POD subnets if any
 		if podSubnets := awsEnv.EKSPODSubnets(); len(podSubnets) > 0 {


### PR DESCRIPTION
What does this PR do?
---------------------

It allows our roles to access clusters that are created in the CI. By default only the role that created the cluster can access it. This is a bit blocking when you want to inspect clusters created by the CI. With that change `account-admin` role will always get full access to the EKS cluster and `read-only` will be able to view resources inside the cluster.
It also "repair" the console so that we can see the resources directly in the `Resources` panel on the EKS page

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
