### PR TITLE
Revert "Revert "Make restart-service more robust to avoid weird test flakiness""

### DIFF
--- a/components/datadog/agent/host_windowsos.go
+++ b/components/datadog/agent/host_windowsos.go
@@ -80,8 +80,26 @@ func (am *agentWindowsManager) getAgentConfigFolder() string {
 func (am *agentWindowsManager) restartAgentServices(transform command.Transformer, opts ...pulumi.ResourceOption) (*remote.Command, error) {
 	// TODO: When we introduce Namer in components, we should use it here.
 	cmdName := am.host.Name() + "-" + "restart-agent"
+	// Retry restart several time, workaround to https://datadoghq.atlassian.net/browse/WINA-747
+	cmd := `
+$tries = 0
+$sleepTime = 1
+while ($tries -lt 5) {
+ & "$($env:ProgramFiles)\Datadog\Datadog Agent\bin\agent.exe" restart-service 2>>stderr.txt
+ $exitCode = $LASTEXITCODE
+ if ($exitCode -eq 0) {
+	   break
+ }
+ Start-Sleep -Seconds $sleepTime
+ $sleepTime = $sleepTime * 2
+ $tries++ 
+ }
+ Get-Content stderr.txt
+ Exit $exitCode
+ `
+
 	cmdArgs := command.Args{
-		Create: pulumi.String(`Start-Process "$($env:ProgramFiles)\Datadog\Datadog Agent\bin\agent.exe" -Wait -ArgumentList restart-service`),
+		Create: pulumi.String(cmd),
 	}
 
 	// If a transform is provided, use it to modify the command name and args


### PR DESCRIPTION
Reverts DataDog/test-infra-definitions#824 because the feature is still flaky

See WINA-1014 for more details