### PR TITLE
[ecs] Enable process collection on Fargate

### DIFF
--- a/components/datadog/agent/ecsFargate.go
+++ b/components/datadog/agent/ecsFargate.go
@@ -44,6 +44,10 @@ func ECSFargateLinuxContainerDefinition(e config.Env, image string, apiKeySSMPar
 				Name:  pulumi.StringPtr("DD_ECS_TASK_COLLECTION_ENABLED"),
 				Value: pulumi.StringPtr("true"),
 			},
+			ecs.TaskDefinitionKeyValuePairArgs{
+				Name:  pulumi.StringPtr("DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED"),
+				Value: pulumi.StringPtr("true"),
+			},
 		}, ecsFakeintakeAdditionalEndpointsEnv(fakeintake)...), ecsAgentAdditionalEnvFromConfig(e)...),
 		Secrets: ecs.TaskDefinitionSecretArray{
 			ecs.TaskDefinitionSecretArgs{

--- a/tasks/aws/ecs.py
+++ b/tasks/aws/ecs.py
@@ -74,7 +74,7 @@ def create_ecs(
 
 def _show_connection_message(ctx: Context, config_path: Optional[str], full_stack_name: str):
     outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
-    cluster_name = outputs["ecs-cluster-name"]
+    cluster_name = outputs["dd-Cluster-ecs-cluster"]["clusterName"]
 
     try:
         local_config = config.get_local_config(config_path)


### PR DESCRIPTION
What does this PR do?
---------------------
Adds an environment variable config to agents running on Fargate to enable process collection. Tasks are required to have `pidMode: task` set for process collection to work, which was done in https://github.com/DataDog/test-infra-definitions/pull/1063

Also adds a fix to make the ECS cluster connection string display correctly after creating an ECS cluster with the invoke task.

Reference: https://github.com/DataDog/test-infra-definitions/pull/979

Which scenarios this will impact?
-------------------
ECS Fargate

Motivation
----------
Enable process collection on ECS Fargate

Additional Notes
----------------
