### PR TITLE
Set all Go directives to 1.22.0

### DIFF
--- a/components/datadog/apps/dogstatsd/images/dogstatsd/go.mod
+++ b/components/datadog/apps/dogstatsd/images/dogstatsd/go.mod
@@ -1,6 +1,6 @@
 module dogstatsd
 
-go 1.22
+go 1.22.0
 
 require github.com/DataDog/datadog-go/v5 v5.5.0
 

--- a/components/datadog/apps/fips/images/fips-server/go.mod
+++ b/components/datadog/apps/fips/images/fips-server/go.mod
@@ -1,6 +1,6 @@
 module e2e_server
 
-go 1.22.5
+go 1.22.0
 
 require github.com/spf13/cobra v1.8.1
 

--- a/components/datadog/apps/logger/images/logger/go.mod
+++ b/components/datadog/apps/logger/images/logger/go.mod
@@ -1,6 +1,6 @@
 module logger
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/spf13/pflag v1.0.5

--- a/components/datadog/apps/nginx/images/http-client/go.mod
+++ b/components/datadog/apps/nginx/images/http-client/go.mod
@@ -1,3 +1,3 @@
 module nginx-query
 
-go 1.22
+go 1.22.0

--- a/components/datadog/apps/prometheus/images/prometheus/go.mod
+++ b/components/datadog/apps/prometheus/images/prometheus/go.mod
@@ -1,6 +1,6 @@
 module prometheus
 
-go 1.22
+go 1.22.0
 
 require github.com/prometheus/client_golang v1.20.4
 

--- a/components/datadog/apps/redis/images/redis-client/go.mod
+++ b/components/datadog/apps/redis/images/redis-client/go.mod
@@ -1,6 +1,6 @@
 module redis-query
 
-go 1.22
+go 1.22.0
 
 require github.com/redis/go-redis/v9 v9.4.0
 

--- a/components/datadog/apps/tracegen/images/tracegen/go.mod
+++ b/components/datadog/apps/tracegen/images/tracegen/go.mod
@@ -1,6 +1,6 @@
 module tracegen
 
-go 1.22
+go 1.22.0
 
 require (
 	golang.org/x/time v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/test-infra-definitions
 
-go 1.22.5
+go 1.22.0
 
 require (
 	dario.cat/mergo v1.0.1


### PR DESCRIPTION
What does this PR do?
---------------------
Set all Go directives to 1.22.0, as we do in the agent repo.

Which scenarios this will impact?
-------------------
N/A

Motivation
----------
Avoids forcing modules importing the ones in this repo to use a specific version.

Additional Notes
----------------
