### PR TITLE
[windows] install ssh through msi

### DIFF
--- a/components/os/scripts/setup-ssh.ps1
+++ b/components/os/scripts/setup-ssh.ps1
@@ -3,15 +3,27 @@ $service = Get-Service -Name sshd -ErrorAction SilentlyContinue
 if ($service -ne $null) {
   Write-Host "Stop sshd service"
   Stop-Service sshd
-} 
-
-if (-not (Get-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0  | Where-Object { $_.State -eq 'Installed' })) {
-  Write-Host "Add OpenSSH Server capability"
-  Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
 } else {
-  Write-Host "OpenSSH Server capability already installed"
+  Write-Host "sshd service not found, installing OpenSSH Server"
+    # Add-WindowsCapability does NOT install a consistent version across Windows versions, this lead to
+    # compatability issues (different command line quoting rules).
+    # Prefer installing sshd via MSI  
+    start-process -passthru -wait msiexec.exe -args '/i https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.5.0.0p1-Beta/OpenSSH-Win64-v9.5.0.0.msi /qn'
+    # Confirm the Firewall rule is configured. It should be created automatically by setup. Run the following to verify
+    if (!(Get-NetFirewallRule -Name "OpenSSH-Server-In-TCP" -ErrorAction SilentlyContinue | Select-Object Name, Enabled)) {
+          Write-Output "Firewall Rule 'OpenSSH-Server-In-TCP' does not exist, creating it..."
+          New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
+    } else {
+          Write-Output "Firewall rule 'OpenSSH-Server-In-TCP' has been created and exists."
+    }
+    # Set powershell default shell
+    New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -PropertyType String -Force
+    # Set sshd service to start automatically
+    Set-Service -Name sshd -StartupType Automatic
 }
-Set-Service -Name sshd -StartupType Automatic
+
+
+# Reset the authorized_keys file
 if (Test-Path $env:ProgramData\ssh\administrators_authorized_keys) { 
   Write-Host "Remove existing administrators_authorized_keys file"
   Remove-Item $env:ProgramData\ssh\administrators_authorized_keys
@@ -19,6 +31,6 @@ if (Test-Path $env:ProgramData\ssh\administrators_authorized_keys) {
 New-Item -Path $env:ProgramData\ssh -Name administrators_authorized_keys -ItemType file
 Add-Content -Path $env:ProgramData\ssh\administrators_authorized_keys -Value $authorizedKey
 icacls.exe ""$env:ProgramData\ssh\administrators_authorized_keys"" /inheritance:r /grant ""Administrators:F"" /grant ""SYSTEM:F""
-New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -PropertyType String -Force
+# Start sshd service
 Start-Service sshd
 Write-Host "OpenSSH configured."

--- a/components/os/scripts/setup-ssh.ps1
+++ b/components/os/scripts/setup-ssh.ps1
@@ -5,35 +5,103 @@ if ($service -ne $null) {
   Stop-Service sshd
 } else {
   Write-Host "sshd service not found, installing OpenSSH Server"
-    # Add-WindowsCapability does NOT install a consistent version across Windows versions, this lead to
-    # compatability issues (different command line quoting rules).
-    # Prefer installing sshd via MSI  
-    $p=start-process -passthru -wait msiexec.exe -args '/i https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.5.0.0p1-Beta/OpenSSH-Win64-v9.5.0.0.msi /qn'
-    if ($p.ExitCode -ne 0) {
-        throw "SSH install failed: $($p.ExitCode)"
+  # Add-WindowsCapability does NOT install a consistent version across Windows versions, this lead to
+  # compatability issues (different command line quoting rules).
+  # Prefer installing sshd via MSI  
+  $res = start-process -passthru -wait msiexec.exe -args '/i https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.5.0.0p1-Beta/OpenSSH-Win64-v9.5.0.0.msi /qn'
+  if ($res.ExitCode -ne 0) {
+    throw "SSH install failed: $($res.ExitCode)"
+  }
+  Write-Host "OpenSSH Server installed"
+  $retries = 0
+  # Confirm the Firewall rule is configured. It should be created automatically by setup. Run the following to verify
+  while (!(Get-NetFirewallRule -Name "OpenSSH-Server-In-TCP" -ErrorAction SilentlyContinue).Enabled) {
+    if ($retries -ge 10) {
+      throw "Firewall rule 'OpenSSH-Server-In-TCP' not found after 10 retries"
     }
-    # Confirm the Firewall rule is configured. It should be created automatically by setup. Run the following to verify
-    if (!(Get-NetFirewallRule -Name "OpenSSH-Server-In-TCP" -ErrorAction SilentlyContinue | Select-Object Name, Enabled)) {
-          Write-Output "Firewall Rule 'OpenSSH-Server-In-TCP' does not exist, creating it..."
-          New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
-    } else {
-          Write-Output "Firewall rule 'OpenSSH-Server-In-TCP' has been created and exists."
+    if ($retries -gt 0) {
+      Start-Sleep -Seconds 5
     }
-    # Set powershell default shell
-    New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -PropertyType String -Force
-    # Set sshd service to start automatically
+    Write-Output "Firewall Rule 'OpenSSH-Server-In-TCP' does not exist, creating it..."
+    New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
+    $retries++
+  } 
+  Write-Output "Firewall rule 'OpenSSH-Server-In-TCP' created."
+  $powershellPath = "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
+  $retries = 0
+  $res = Get-ItemProperty "HKLM:\SOFTWARE\OpenSSH"
+  while ((Get-ItemProperty "HKLM:\SOFTWARE\OpenSSH").DefaultShell -ne $powershellPath) {
+    if ($retries -ge 10) {
+      throw "Failed to set powershell as default shell for sshd after 10 retries"
+    }
+    if ($retries -gt 0) {
+      Start-Sleep -Seconds 5
+    }
+    Write-Host "Set powershell as default shell for sshd"
+    New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value $powershellPath -PropertyType String -Force 
+    $retries++
+  }
+  $retries = 0
+  while (((Get-Service -Name sshd -ErrorAction SilentlyContinue) -eq $null) -and ($waitLeft -gt 0)) {
+    if ($retries -ge 10) {
+      throw "Failed to find sshd service after 10 retries, 5 seconds interval"
+    }
+    Write-Host "Waiting for sshd service to exist"
+    Start-Sleep -Seconds 5
+    $retries++
+  }
+  $retries = 0
+  while ((Get-Service -Name sshd -ErrorAction SilentlyContinue).StartType -ne "Automatic") {
+    if ($retries -ge 10) {
+      throw "Failed to set sshd service to start automatically after 10 retries"
+    }
+    if ($retries -gt 0) {
+      Start-Sleep -Seconds 5
+    }
+    Write-Host "Set sshd service to start automatically"
     Set-Service -Name sshd -StartupType Automatic
+    $retries++
+  }
 }
 
-
-# Reset the authorized_keys file
-if (Test-Path $env:ProgramData\ssh\administrators_authorized_keys) { 
+Write-Host "Resetting ssh authorized keys"
+$retries = 0
+while (Test-Path $env:ProgramData\ssh\administrators_authorized_keys) { 
+  if ($retries -ge 10) {
+    throw "Failed to remove existing administrators_authorized_keys file after 10 retries"
+  }
+  if ($retries -gt 0) {
+    Start-Sleep -Seconds 1
+  }
   Write-Host "Remove existing administrators_authorized_keys file"
   Remove-Item $env:ProgramData\ssh\administrators_authorized_keys
+  $retries++
 }
-New-Item -Path $env:ProgramData\ssh -Name administrators_authorized_keys -ItemType file
+
+$retries = 0
+while (!Test-Path $env:ProgramData\ssh\administrators_authorized_keys) { 
+  if ($retries -ge 10) {
+    throw "Failed to create administrators_authorized_keys file after 10 retries"
+  }
+  if ($retries -gt 0) {
+    Start-Sleep -Seconds 1
+  }
+  Write-Host "Creating administrators_authorized_keys file"
+  New-Item -Path $env:ProgramData\ssh -Name administrators_authorized_keys -ItemType file
+  $retries++
+}
 Add-Content -Path $env:ProgramData\ssh\administrators_authorized_keys -Value $authorizedKey
 icacls.exe ""$env:ProgramData\ssh\administrators_authorized_keys"" /inheritance:r /grant ""Administrators:F"" /grant ""SYSTEM:F""
 # Start sshd service
-Start-Service sshd
-Write-Host "OpenSSH configured."
+$retries = 0
+while ((Get-Service -Name sshd -ErrorAction SilentlyContinue).Status -ne "Running") {
+  if ($retries -ge 10) {
+    throw "Failed to start sshd service after 10 retries"
+  }
+  if ($retries -gt 0) {
+    Start-Sleep -Seconds 5
+  }
+  Write-Host "Starting sshd service"
+  Start-Service sshd
+  $retries++
+}

--- a/components/os/scripts/setup-ssh.ps1
+++ b/components/os/scripts/setup-ssh.ps1
@@ -8,7 +8,10 @@ if ($service -ne $null) {
     # Add-WindowsCapability does NOT install a consistent version across Windows versions, this lead to
     # compatability issues (different command line quoting rules).
     # Prefer installing sshd via MSI  
-    start-process -passthru -wait msiexec.exe -args '/i https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.5.0.0p1-Beta/OpenSSH-Win64-v9.5.0.0.msi /qn'
+    $p=start-process -passthru -wait msiexec.exe -args '/i https://github.com/PowerShell/Win32-OpenSSH/releases/download/v9.5.0.0p1-Beta/OpenSSH-Win64-v9.5.0.0.msi /qn'
+    if ($p.ExitCode -ne 0) {
+        throw "SSH install failed: $($p.ExitCode)"
+    }
     # Confirm the Firewall rule is configured. It should be created automatically by setup. Run the following to verify
     if (!(Get-NetFirewallRule -Name "OpenSSH-Server-In-TCP" -ErrorAction SilentlyContinue | Select-Object Name, Enabled)) {
           Write-Output "Firewall Rule 'OpenSSH-Server-In-TCP' does not exist, creating it..."


### PR DESCRIPTION
What does this PR do?
---------------------

Install SSH on Windows Azure and AWS instances through the MSI

Which scenarios this will impact?
-------------------

Windows

Motivation
----------

Ensure compatibility across Windows versions, as `Add-WindowsCapability` installs different version depending on the windows version (Windows Server 2019 vs 2022)

Additional Notes
----------------

Suggested by @clarkb7 

Tested with:

- Windows Server 2019 ECS
- Windows latest
- Azure latest
