### PR TITLE
Add the possibility to run tests with an Agent 6 pipeline artefacts

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -64,6 +64,8 @@ const (
 	// Dogstatsd namespace
 	DDDogstatsdDeployParamName        = "deploy"
 	DDDogstatsdFullImagePathParamName = "fullImagePath"
+
+	DefaultMajorVersion = "7"
 )
 
 type CommonEnvironment struct {
@@ -309,7 +311,7 @@ func (e *CommonEnvironment) Site() string {
 }
 
 func (e *CommonEnvironment) MajorVersion() string {
-	return e.GetStringWithDefault(e.AgentConfig, DDAgentMajorVersion, "7")
+	return e.GetStringWithDefault(e.AgentConfig, DDAgentMajorVersion, DefaultMajorVersion)
 }
 
 func (e *CommonEnvironment) AgentExtraEnvVars() map[string]string {

--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -52,6 +52,7 @@ const (
 	DDAgentAPPKeyParamName               = "appKey"
 	DDAgentFakeintake                    = "fakeintake"
 	DDAgentSite                          = "site"
+	DDAgentMajorVersion                  = "majorVersion"
 	DDAgentExtraEnvVars                  = "extraEnvVars" // extraEnvVars is expected in the format: <key1>=<value1>,<key2>=<value2>,...
 
 	// Updater Namespace
@@ -117,6 +118,7 @@ type Env interface {
 	DogstatsdDeploy() bool
 	DogstatsdFullImagePath() string
 	UpdaterDeploy() bool
+	MajorVersion() string
 
 	GetBoolWithDefault(config *sdkconfig.Config, paramName string, defaultValue bool) bool
 	GetStringListWithDefault(config *sdkconfig.Config, paramName string, defaultValue []string) []string
@@ -304,6 +306,14 @@ func (e *CommonEnvironment) AgentUseFakeintake() bool {
 
 func (e *CommonEnvironment) Site() string {
 	return e.AgentConfig.Get(DDAgentSite)
+}
+
+func (e *CommonEnvironment) MajorVersion() string {
+	version := e.AgentConfig.Get(DDAgentMajorVersion)
+	if version == "" {
+		return "7"
+	}
+	return version
 }
 
 func (e *CommonEnvironment) AgentExtraEnvVars() map[string]string {

--- a/components/datadog/agent/host_linuxos.go
+++ b/components/datadog/agent/host_linuxos.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-const DefaultMajorVersion = "7"
 
 type agentLinuxManager struct {
 	targetOS os.OS

--- a/components/datadog/agent/host_linuxos.go
+++ b/components/datadog/agent/host_linuxos.go
@@ -2,16 +2,17 @@ package agent
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/DataDog/test-infra-definitions/components/command"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentparams"
 	"github.com/DataDog/test-infra-definitions/components/os"
 	remoteComp "github.com/DataDog/test-infra-definitions/components/remote"
+	"strings"
 
 	"github.com/pulumi/pulumi-command/sdk/go/command/remote"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
+
+const DefaultMajorVersion = "7"
 
 type agentLinuxManager struct {
 	targetOS os.OS
@@ -22,37 +23,43 @@ func newLinuxManager(host *remoteComp.Host) agentOSManager {
 }
 
 func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersion, _ []string) (string, error) {
+	var commandLine string
+	var majorVersion string
+	testEnvVars := []string{}
+
+	if version.Major != "" {
+		majorVersion = version.Major
+	} else {
+		majorVersion = DefaultMajorVersion
+	}
+
 	if version.PipelineID != "" {
-		testEnvVars := []string{}
 		testEnvVars = append(testEnvVars, "TESTING_APT_URL=apttesting.datad0g.com")
 		// apt testing repo
 		// TESTING_APT_REPO_VERSION="pipeline-xxxxx-a7 7"
-		testEnvVars = append(testEnvVars, fmt.Sprintf(`TESTING_APT_REPO_VERSION="pipeline-%v-a7-%s 7"`, version.PipelineID, am.targetOS.Descriptor().Architecture))
+		testEnvVars = append(testEnvVars, fmt.Sprintf(`TESTING_APT_REPO_VERSION="pipeline-%v-a%v-%s %v"`, version.PipelineID, majorVersion, am.targetOS.Descriptor().Architecture, majorVersion))
 		testEnvVars = append(testEnvVars, "TESTING_YUM_URL=yumtesting.datad0g.com")
 		// yum testing repo
 		// TESTING_YUM_VERSION_PATH="testing/pipeline-xxxxx-a7/7"
-		testEnvVars = append(testEnvVars, fmt.Sprintf("TESTING_YUM_VERSION_PATH=testing/pipeline-%v-a7/7", version.PipelineID))
-		commandLine := strings.Join(testEnvVars, " ")
+		testEnvVars = append(testEnvVars, fmt.Sprintf("TESTING_YUM_VERSION_PATH=testing/pipeline-%v-a%v/%v", version.PipelineID, majorVersion, majorVersion))
+	} else {
+		testEnvVars = append(testEnvVars, fmt.Sprintf("DD_AGENT_MAJOR_VERSION=%v", majorVersion))
 
-		return fmt.Sprintf(
-			`for i in 1 2 3 4 5; do curl -fsSL https://s3.amazonaws.com/dd-agent/scripts/%v -o install-script.sh && break || sleep $((2**$i)); done &&  for i in 1 2 3; do DD_API_KEY=%%s %v DD_INSTALL_ONLY=true bash install-script.sh  && exit 0  || sleep $((2**$i)); done; exit 1`,
-			"install_script_agent7.sh",
-			commandLine), nil
+		if version.Minor != "" {
+			testEnvVars = append(testEnvVars, fmt.Sprintf("DD_AGENT_MINOR_VERSION=%v", version.Minor))
+		}
+
+		if version.Channel != "" && version.Channel != agentparams.StableChannel {
+			testEnvVars = append(testEnvVars, "REPO_URL=datad0g.com")
+			testEnvVars = append(testEnvVars, fmt.Sprintf("DD_AGENT_DIST_CHANNEL=%s", version.Channel))
+		}
 	}
 
-	commandLine := fmt.Sprintf("DD_AGENT_MAJOR_VERSION=%v ", version.Major)
-
-	if version.Minor != "" {
-		commandLine += fmt.Sprintf("DD_AGENT_MINOR_VERSION=%v ", version.Minor)
-	}
-
-	if version.Channel != "" && version.Channel != agentparams.StableChannel {
-		commandLine += fmt.Sprintf("REPO_URL=datad0g.com DD_AGENT_DIST_CHANNEL=%s ", version.Channel)
-	}
+	commandLine = strings.Join(testEnvVars, " ")
 
 	return fmt.Sprintf(
 		`for i in 1 2 3 4 5; do curl -fsSL https://s3.amazonaws.com/dd-agent/scripts/%v -o install-script.sh && break || sleep $((2**$i)); done &&  for i in 1 2 3; do DD_API_KEY=%%s %v DD_INSTALL_ONLY=true bash install-script.sh  && exit 0 || sleep $((2**$i)); done; exit 1`,
-		fmt.Sprintf("install_script_agent%s.sh", version.Major),
+		fmt.Sprintf("install_script_agent%s.sh", majorVersion),
 		commandLine), nil
 }
 

--- a/components/datadog/agent/host_linuxos.go
+++ b/components/datadog/agent/host_linuxos.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-
 type agentLinuxManager struct {
 	targetOS os.OS
 }

--- a/components/datadog/agent/host_windowsos.go
+++ b/components/datadog/agent/host_windowsos.go
@@ -115,7 +115,7 @@ func getAgentURL(version agentparams.PackageVersion) (string, error) {
 	fullVersion := fmt.Sprintf("%v.%v", version.Major, minor)
 
 	if version.PipelineID != "" {
-		return getAgentURLFromPipelineID(version.PipelineID)
+		return getAgentURLFromPipelineID(version.PipelineID, version.Major)
 	}
 
 	if version.Channel == agentparams.BetaChannel {
@@ -150,7 +150,7 @@ func getAgentURL(version agentparams.PackageVersion) (string, error) {
 	return finder.findVersion(fullVersion)
 }
 
-func getAgentURLFromPipelineID(pipelineID string) (string, error) {
+func getAgentURLFromPipelineID(pipelineID string, majorVersion string) (string, error) {
 	// TODO: Replace context.Background() with a Pulumi context.Context.
 	// dd-agent-mstesting is a public bucket so we can use anonymous credentials
 	config, err := awsConfig.LoadDefaultConfig(context.Background(), awsConfig.WithCredentialsProvider(aws.AnonymousCredentials{}))
@@ -162,7 +162,7 @@ func getAgentURLFromPipelineID(pipelineID string) (string, error) {
 
 	result, err := s3Client.ListObjectsV2(context.Background(), &s3.ListObjectsV2Input{
 		Bucket: aws.String("dd-agent-mstesting"),
-		Prefix: aws.String(fmt.Sprintf("pipelines/A7/%v", pipelineID)),
+		Prefix: aws.String(fmt.Sprintf("pipelines/A%v/%v", majorVersion, pipelineID)),
 	})
 	if err != nil {
 		return "", err

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -72,6 +72,11 @@ func NewParams(env config.Env, options ...Option) (*Params, error) {
 	if env.AgentVersion() != "" {
 		defaultVersion = WithVersion(env.AgentVersion())
 	}
+
+	if env.MajorVersion() != "" {
+		options = append([]Option{WithMajorVersion(env.MajorVersion())}, options...)
+	}
+
 	options = append([]Option{defaultVersion}, options...)
 	return common.ApplyOption(p, options)
 }
@@ -109,9 +114,15 @@ func WithVersion(version string) func(*Params) error {
 // WithPipeline use a specific version of the Agent by pipeline id
 func WithPipeline(pipelineID string) func(*Params) error {
 	return func(p *Params) error {
-		p.Version = PackageVersion{
-			PipelineID: pipelineID,
-		}
+		p.Version.PipelineID = pipelineID
+		return nil
+	}
+}
+
+// WithMajorVersion specify the major version of the Agent
+func WithMajorVersion(majorVersion string) func(*Params) error {
+	return func(p *Params) error {
+		p.Version.Major = majorVersion
 		return nil
 	}
 }

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -60,8 +60,6 @@ type Params struct {
 
 type Option = func(*Params) error
 
-const DefaultMajorVersion = "7"
-
 func NewParams(env config.Env, options ...Option) (*Params, error) {
 	p := &Params{
 		Integrations: make(map[string]*FileDefinition),
@@ -75,10 +73,7 @@ func NewParams(env config.Env, options ...Option) (*Params, error) {
 		defaultVersion = WithVersion(env.AgentVersion())
 	}
 
-	if env.MajorVersion() != "" {
-		options = append([]Option{WithMajorVersion(env.MajorVersion())}, options...)
-	}
-
+	options = append([]Option{WithMajorVersion(env.MajorVersion())}, options...)
 	options = append([]Option{defaultVersion}, options...)
 	return common.ApplyOption(p, options)
 }
@@ -117,7 +112,6 @@ func WithVersion(version string) func(*Params) error {
 func WithPipeline(pipelineID string) func(*Params) error {
 	return func(p *Params) error {
 		p.Version.PipelineID = pipelineID
-		p.Version.Major = DefaultMajorVersion
 		return nil
 	}
 }

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -60,6 +60,8 @@ type Params struct {
 
 type Option = func(*Params) error
 
+const DefaultMajorVersion = "7"
+
 func NewParams(env config.Env, options ...Option) (*Params, error) {
 	p := &Params{
 		Integrations: make(map[string]*FileDefinition),
@@ -115,6 +117,7 @@ func WithVersion(version string) func(*Params) error {
 func WithPipeline(pipelineID string) func(*Params) error {
 	return func(p *Params) error {
 		p.Version.PipelineID = pipelineID
+		p.Version.Major = DefaultMajorVersion
 		return nil
 	}
 }

--- a/components/datadog/agentparams/params_test.go
+++ b/components/datadog/agentparams/params_test.go
@@ -33,7 +33,6 @@ func TestParams(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, result.Version, PackageVersion{
 			PipelineID: "16362517",
-			Major:      "7",
 		})
 	})
 	t.Run("WithIntegration should correctly add conf.d/integration/conf.yaml to the path", func(t *testing.T) {

--- a/components/datadog/agentparams/params_test.go
+++ b/components/datadog/agentparams/params_test.go
@@ -33,6 +33,7 @@ func TestParams(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, result.Version, PackageVersion{
 			PipelineID: "16362517",
+			Major:      "7",
 		})
 	})
 	t.Run("WithIntegration should correctly add conf.d/integration/conf.yaml to the path", func(t *testing.T) {


### PR DESCRIPTION
What does this PR do?
---------------------

Add the possibility to run tests with an Agent 6 pipeline artefact. I basically add a parameter that will be passed alongside the `pipeline_id` so we can know where to fetch the artefacts to run the tests

Which scenarios this will impact?
-------------------

All the scenarios in the Agent 6 branch of the agent repository and the people willing to run tests on Agent 6

Motivation
----------

The version 7 is hardcoded is some places. We'll need to modify this to be able to run the tests on Agent 6 artefacts

Additional Notes
----------------

To use it we will also need to do [this](https://github.com/DataDog/datadog-agent/pull/30172) during the test-infra-definitions bump. We will also need to set the the `E2E_MAJOR_VERSION` [here](https://github.com/DataDog/datadog-agent/blob/4c43e2562f5cc38645efc16725db2a05a945aa98/.gitlab/e2e/e2e.yml#L32-L43) in the template to `6` on the Agent 6 branch and that should be it.

https://datadoghq.atlassian.net/browse/ADXT-680
