### PR TITLE
Set a missing parameter for ECS

### DIFF
--- a/scenarios/aws/ecs/args.go
+++ b/scenarios/aws/ecs/args.go
@@ -20,6 +20,13 @@ func NewParams(options ...Option) (*Params, error) {
 	return common.ApplyOption(version, options)
 }
 
+func WithFargateCapacityProvider() Option {
+	return func(p *Params) error {
+		p.FargateCapacityProvider = true
+		return nil
+	}
+}
+
 func WithLinuxNodeGroup() Option {
 	return func(p *Params) error {
 		p.LinuxNodeGroup = true
@@ -51,6 +58,9 @@ func WithWindowsNodeGroup() Option {
 func buildClusterOptionsFromConfigMap(e aws.Environment) []Option {
 	clusterOptions := []Option{}
 	// Add the cluster options from the config map
+	if e.ECSFargateCapacityProvider() {
+		clusterOptions = append(clusterOptions, WithFargateCapacityProvider())
+	}
 	if e.ECSWindowsNodeGroup() {
 		clusterOptions = append(clusterOptions, WithWindowsNodeGroup())
 	}


### PR DESCRIPTION
What does this PR do?
---------------------

Set a missing parameter for ECS

Which scenarios this will impact?
-------------------

ECS

Motivation
----------

We forgot it in https://github.com/DataDog/test-infra-definitions/pull/1193 and it breaks the ECS tests on the Agent side when we try to bump the version of test-infra

Additional Notes
----------------
