### PR TITLE
[PROCS-4402] Add stress-ng Fargate workload app

### DIFF
--- a/components/datadog/apps/cpustress/ecs.go
+++ b/components/datadog/apps/cpustress/ecs.go
@@ -14,7 +14,7 @@ type EcsComponent struct {
 }
 
 func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...pulumi.ResourceOption) (*ecsComp.Workload, error) {
-	namer := e.Namer.WithPrefix("cpustress")
+	namer := e.Namer.WithPrefix("cpustress").WithPrefix("ec2")
 	opts = append(opts, e.WithProviders(config.ProviderAWS, config.ProviderAWSX))
 
 	ecsComponent := &ecsComp.Workload{}

--- a/components/datadog/apps/cpustress/ecsFargate.go
+++ b/components/datadog/apps/cpustress/ecsFargate.go
@@ -1,0 +1,68 @@
+package cpustress
+
+import (
+	"github.com/DataDog/test-infra-definitions/common/config"
+	fakeintakeComp "github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
+	ecsComp "github.com/DataDog/test-infra-definitions/components/ecs"
+	"github.com/DataDog/test-infra-definitions/resources/aws"
+	ecsClient "github.com/DataDog/test-infra-definitions/resources/aws/ecs"
+	classicECS "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ecs"
+	"github.com/pulumi/pulumi-awsx/sdk/v2/go/awsx/ecs"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func FargateAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, apiKeySSMParamName pulumi.StringInput, fakeIntake *fakeintakeComp.Fakeintake, opts ...pulumi.ResourceOption) (*ecsComp.Workload, error) {
+	namer := e.Namer.WithPrefix("cpustress").WithPrefix("fg")
+	opts = append(opts, e.WithProviders(config.ProviderAWS, config.ProviderAWSX))
+
+	ecsFargateComponent := &ecsComp.Workload{}
+	if err := e.Ctx().RegisterComponentResource("dd:apps", namer.ResourceName("grp"), ecsFargateComponent, opts...); err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, pulumi.Parent(ecsFargateComponent))
+
+	stressContainer := &ecs.TaskDefinitionContainerDefinitionArgs{
+		Name:  pulumi.String("stress-ng"),
+		Image: pulumi.String(getStressNGImage()),
+		DockerLabels: pulumi.StringMap{
+			"com.datadoghq.ad.tags": pulumi.String("[\"ecs_launch_type:fargate\"]"),
+		},
+		Command: pulumi.StringArray{
+			pulumi.String("--cpu=1"),
+			pulumi.String("--cpu-load=15"),
+		},
+		Cpu:    pulumi.IntPtr(200),
+		Memory: pulumi.IntPtr(64),
+	}
+
+	stressTaskDef, err := ecsClient.FargateTaskDefinitionWithAgent(e, "stress-ng", pulumi.String("stress-ng"), 1024, 2048,
+		map[string]ecs.TaskDefinitionContainerDefinitionArgs{
+			"stress-ng": *stressContainer,
+		},
+		apiKeySSMParamName,
+		fakeIntake,
+		opts...,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := ecs.NewFargateService(e.Ctx(), namer.ResourceName("stress-ng"), &ecs.FargateServiceArgs{
+		Name:         e.CommonNamer().DisplayName(255, pulumi.String("stress-ng"), pulumi.String("fg")),
+		Cluster:      clusterArn,
+		DesiredCount: pulumi.IntPtr(1),
+		NetworkConfiguration: classicECS.ServiceNetworkConfigurationArgs{
+			AssignPublicIp: pulumi.BoolPtr(e.ECSServicePublicIP()),
+			SecurityGroups: pulumi.ToStringArray(e.DefaultSecurityGroups()),
+			Subnets:        e.RandomSubnets(),
+		},
+		TaskDefinition:            stressTaskDef.TaskDefinition.Arn(),
+		EnableExecuteCommand:      pulumi.BoolPtr(true),
+		ContinueBeforeSteadyState: pulumi.BoolPtr(true),
+	}, opts...); err != nil {
+		return nil, err
+	}
+
+	return ecsFargateComponent, nil
+}

--- a/components/datadog/apps/cpustress/ecsFargate.go
+++ b/components/datadog/apps/cpustress/ecsFargate.go
@@ -36,7 +36,7 @@ func FargateAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, apiK
 		Memory: pulumi.IntPtr(64),
 	}
 
-	stressTaskDef, err := ecsClient.FargateTaskDefinitionWithAgent(e, "stress-ng", pulumi.String("stress-ng"), 1024, 2048,
+	stressTaskDef, err := ecsClient.FargateTaskDefinitionWithAgent(e, "stress-ng-fg", pulumi.String("stress-ng-fg"), 1024, 2048,
 		map[string]ecs.TaskDefinitionContainerDefinitionArgs{
 			"stress-ng": *stressContainer,
 		},

--- a/components/datadog/apps/cpustress/ecsFargate.go
+++ b/components/datadog/apps/cpustress/ecsFargate.go
@@ -42,6 +42,7 @@ func FargateAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, apiK
 		},
 		apiKeySSMParamName,
 		fakeIntake,
+		"",
 		opts...,
 	)
 	if err != nil {


### PR DESCRIPTION
What does this PR do?
---------------------
Adds a Fargate version of the stress-ng workload which will be used for e2e testing [here](https://github.com/DataDog/datadog-agent/pull/30282).

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
