### PR TITLE
[vm] disable unattended upgrades on debian/ubuntu on EC2

### DIFF
--- a/components/os/debian_disable_upgrades.go
+++ b/components/os/debian_disable_upgrades.go
@@ -1,0 +1,8 @@
+package os
+
+import (
+	_ "embed"
+)
+
+//go:embed scripts/debian-disable-unattended-upgrades.sh
+var DebianDisableUnattendedUpgradesScriptContent string

--- a/components/os/scripts/debian-disable-unattended-upgrades.sh
+++ b/components/os/scripts/debian-disable-unattended-upgrades.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+apt-get -y remove unattended-upgrades

--- a/components/os/windows_setup_ssh.go
+++ b/components/os/windows_setup_ssh.go
@@ -5,4 +5,4 @@ import (
 )
 
 //go:embed scripts/setup-ssh.ps1
-var SetupSSHScriptContent string
+var WindowsSetupSSHScriptContent string

--- a/resources/azure/compute/vm.go
+++ b/resources/azure/compute/vm.go
@@ -105,7 +105,7 @@ func NewWindowsInstance(e azure.Environment, name, imageUrn, instanceType string
 		AsyncExecution:    pulumi.Bool(false),
 		RunCommandName:    pulumi.String("InitVM"),
 		Source: compute.VirtualMachineRunCommandScriptSourceArgs{
-			Script: pulumi.String(strings.Join([]string{setupSSHParamScriptContent, componentsos.SetupSSHScriptContent}, "\n\n")),
+			Script: pulumi.String(strings.Join([]string{setupSSHParamScriptContent, componentsos.WindowsSetupSSHScriptContent}, "\n\n")),
 		},
 		Parameters: compute.RunCommandInputParameterArray{
 			compute.RunCommandInputParameterArgs{

--- a/scenarios/aws/ec2/os_win.go
+++ b/scenarios/aws/ec2/os_win.go
@@ -15,7 +15,7 @@ func getWindowsOpenSSHUserData(publicKeyPath string) (string, error) {
 	}
 
 	return buildAWSPowerShellUserData(
-			componentsos.SetupSSHScriptContent,
+			componentsos.WindowsSetupSSHScriptContent,
 			windowsPowerShellArgument{name: "authorizedKey", value: string(publicKey)},
 		),
 		nil

--- a/scenarios/aws/ec2/vm.go
+++ b/scenarios/aws/ec2/vm.go
@@ -142,8 +142,9 @@ func defaultVMArgs(e aws.Environment, vmArgs *vmArgs) error {
 		if err != nil {
 			return err
 		}
-
 		vmArgs.userData = vmArgs.userData + sshUserData
+	} else if vmArgs.osInfo.Flavor == os.Ubuntu || vmArgs.osInfo.Flavor == os.Debian {
+		vmArgs.userData = vmArgs.userData + os.DebianDisableUnattendedUpgradesScriptContent
 	}
 
 	return nil


### PR DESCRIPTION
What does this PR do?
---------------------

Disable apt unattended upgrades at startup through userdata

Which scenarios this will impact?
-------------------

aws debian and ubuntu

Motivation
----------

[ADXT-686](https://datadoghq.atlassian.net/browse/ADXT-686)

Additional Notes
----------------


[ADXT-686]: https://datadoghq.atlassian.net/browse/ADXT-686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ