### PR TITLE
🐛[ec2] separate userdata scripts with new line

### DIFF
--- a/scenarios/aws/ec2/vm.go
+++ b/scenarios/aws/ec2/vm.go
@@ -1,6 +1,8 @@
 package ec2
 
 import (
+	"strings"
+
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/components"
@@ -142,9 +144,9 @@ func defaultVMArgs(e aws.Environment, vmArgs *vmArgs) error {
 		if err != nil {
 			return err
 		}
-		vmArgs.userData = vmArgs.userData + sshUserData
+		vmArgs.userData = strings.Join([]string{vmArgs.userData, sshUserData}, "\n")
 	} else if vmArgs.osInfo.Flavor == os.Ubuntu || vmArgs.osInfo.Flavor == os.Debian {
-		vmArgs.userData = vmArgs.userData + os.DebianDisableUnattendedUpgradesScriptContent
+		vmArgs.userData = strings.Join([]string{vmArgs.userData, os.DebianDisableUnattendedUpgradesScriptContent}, "\n")
 	}
 
 	return nil


### PR DESCRIPTION
What does this PR do?
---------------------

Separate userdata from default userdata with a newline

Which scenarios this will impact?
-------------------

ec2

Motivation
----------

Custom Userdata is currently broken as it results in having the last line suffixed by the shebang comment

```
#!/bin/bash
<custom userdata>#!/bin/bash
<default userdata>
```

This was introduced in ubuntu with https://github.com/DataDog/test-infra-definitions/pull/1207, breaking on e2e pre test

Additional Notes
----------------
Tested this fix locally, the test now passes