### PR TITLE
Add "addspantags" tag to tracegen to optionally set additional tags on all spans emitted

### DIFF
--- a/components/datadog/apps/tracegen/images/tracegen/main.go
+++ b/components/datadog/apps/tracegen/images/tracegen/main.go
@@ -57,7 +57,7 @@ func main() {
 	spt := flag.Uint64("spt", 2, "Number of spans to put in each trace. (>=1)")
 	testDuration := flag.Duration("testtime", 0, "Amount of time to run the test. A value of '0' means the test will continue indefinitely.")
 	additionalSpanTagsFlat := flag.String("addspantags", "", "Comma separated list of additional tags to add to each span.")
-	additionalSpanTags = make(map[string]string, 0)
+	additionalSpanTags = make(map[string]string)
 	flag.Parse()
 
 	var err error


### PR DESCRIPTION
What does this PR do?
---------------------
Adds new flag (`--addspantags`) or ENV var (`TRACEGEN_ADDSPANTAGS=`) to tracegen to tell tracegen to add an arbitrary set of tags to all spans it emits.

Which scenarios this will impact?
-------------------
None will be impacted at first. 

We will be editing the `new-e2e/test/apm/::runTracegenDocker()` function to add this flag for APM tracegen tests.

For those tests, we will add some `peer.*` tags and assert that the resulting stats payloads carry the new tags properly.

Motivation
----------
https://datadoghq.atlassian.net/browse/APMST-1371

Additional Notes
----------------
