### PR TITLE
Give enough CPU and memory to Windows

### DIFF
--- a/components/datadog/apps/aspnetsample/ecs.go
+++ b/components/datadog/apps/aspnetsample/ecs.go
@@ -47,8 +47,8 @@ func FargateAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, apiK
 			)),
 			"com.datadoghq.ad.tags": pulumi.String("[\"ecs_launch_type:fargate\"]"),
 		},
-		Cpu:       pulumi.IntPtr(1024),
-		Memory:    pulumi.IntPtr(2048),
+		Cpu:       pulumi.IntPtr(4096),
+		Memory:    pulumi.IntPtr(8192),
 		Essential: pulumi.BoolPtr(true),
 		DependsOn: ecs.TaskDefinitionContainerDependencyArray{
 			ecs.TaskDefinitionContainerDependencyArgs{
@@ -59,7 +59,7 @@ func FargateAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, apiK
 		PortMappings: ecs.TaskDefinitionPortMappingArray{},
 	}
 
-	serverTaskDef, err := ecsClient.FargateWindowsTaskDefinitionWithAgent(e, "aspnet-fg-server", pulumi.String("aspnet-fg"), 1024, 2048, map[string]ecs.TaskDefinitionContainerDefinitionArgs{"aspnetsample": *serverContainer}, apiKeySSMParamName, fakeIntake, "", opts...)
+	serverTaskDef, err := ecsClient.FargateWindowsTaskDefinitionWithAgent(e, "aspnet-fg-server", pulumi.String("aspnet-fg"), 4096, 8192, map[string]ecs.TaskDefinitionContainerDefinitionArgs{"aspnetsample": *serverContainer}, apiKeySSMParamName, fakeIntake, "", opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
What does this PR do?
---------------------

Give enough CPU and memory to Windows to avoid datadog agent starvation.

Which scenarios this will impact?
-------------------

* `aws/ecs`

Motivation
----------

Fix [incident-31678](https://app.datadoghq.com/incidents/31678).

Additional Notes
----------------

[`TestECSSuite/Test00UpAndRunning/ECS_tasks_are_ready` e2e test is very flaky](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Adatadog-agent%20%40git.branch%3Amain%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22%20%40test.name%3ATestECSSuite%2FTest00UpAndRunning%2FECS_tasks_are_ready&agg_m=count&agg_m_source=base&agg_t=count&citest_explorer_sort=time%2Cdesc&currentTab=overview&eventStack=AgAAAZK0uvuw2-LLvgAAAAAAAAAYAAAAAEFaSzB1dnV3QUFDa0JtQk9pZE9lSFZ5ZwAAACQAAAAAMDE5MmI0YmQtZjE3ZS00NzcyLThjM2EtMzdkMmFiNjI4Y2Y2&fromUser=false&graphType=flamegraph&index=citest&mode=sliding&saved-view-id=2236559&testId=AgAAAZK0uvuw2-LLvgAAAAAAAAAYAAAAAEFaSzB1dnV3QUFDa0JtQk9pZE9lSFZ5ZwAAACQAAAAAMDE5MmI0YmQtZjE3ZS00NzcyLThjM2EtMzdkMmFiNjI4Y2Y2&trace=AgAAAZK0uvuw2-LLvgAAAAAAAAAYAAAAAEFaSzB1dnV3QUFDa0JtQk9pZE9lSFZ5ZwAAACQAAAAAMDE5MmI0YmQtZjE3ZS00NzcyLThjM2EtMzdkMmFiNjI4Y2Y2&start=1729022549304&end=1729627349304&paused=false) because the `ci-…-aspnetsample-fg` ECS task takes ages to start and remains in “unhealthy” state forever.

The reason why the task remains in “unhealthy” state forever is because the command used to probe the health is dead slow to respond:
![image](https://github.com/user-attachments/assets/79ea85f2-562a-4c70-a63b-12b630fc0bb5)

`agent health` is supposed to respond almost instantaneously.
Answering in 20s looks like a CPU starvation issue.

Trying the next tee-shirt size (2 vCPU) for the Fargate task shows an improvement:
![image](https://github.com/user-attachments/assets/d0883dbf-fae2-4ccb-9b6c-1be6f3a9576e)

Yet the next tee-shirt size (4 vCPU) for the Fargate task shows reasonable execution time for `agent health`:
![image](https://github.com/user-attachments/assets/e00cdca5-2e2b-4a6c-a8bf-28bbaba6aca1)

As the figures above are showing, giving enough CPU to Windows should fix the test without requiring to increase the times-out that are currently breached ([the time-out for health probe command execution](https://github.com/DataDog/test-infra-definitions/blob/4c541f69f7dfbe355f78856938fa2db56f6728e6/components/datadog/agent/ecsFargate.go#L127) and [the time-out for tasks to become ready](https://github.com/DataDog/datadog-agent/blob/e79e0622abc05885bd2b0f9c2b96e245781e3c01/test/new-e2e/tests/containers/ecs_test.go#L195)).