### PR TITLE
Remove of unattended-upgrades no longer required

### DIFF
--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -99,16 +99,9 @@ func getSSHKeyPairFiles(m *config.DDMicroVMConfig, arch string) sshKeyPair {
 	return pair
 }
 
-// User data shell scripts must start with the #! characters and the path to the interpreter you want to read the
-// script (commonly /bin/bash).
-const metalUserData = `#!/bin/bash
-apt-get -y remove unattended-upgrades
-`
-
 func buildUserData(instanceEnv *InstanceEnvironment, m *config.DDMicroVMConfig) string {
 	var sb strings.Builder
 
-	sb.WriteString(metalUserData)
 	if instanceEnv.DefaultShutdownBehavior() == "terminate" {
 		shutdownPeriod := time.Duration(m.GetIntWithDefault(m.MicroVMConfig, config.DDMicroVMShutdownPeriod, defaultShutdownPeriod)) * time.Minute
 		sb.WriteString(fmt.Sprintf("sudo shutdown -P +%.0f\n", shutdownPeriod.Minutes()))


### PR DESCRIPTION
What does this PR do?
---------------------
unattended-upgrades has been removed from the underlying AMI by this PR: https://github.com/DataDog/ami-builder/pull/204

Which scenarios this will impact?
-------------------
microvms

Motivation
----------

Additional Notes
----------------
