### PR TITLE
Simplify authentication with GOOGLE_APPLICATION_CREDENTIALS env var

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ build-pulumi-go-main:
   rules:
     - when: on_success
   script:
-    - go build -o dist/main -gcflags="all=-c=6" main.go 
+    - go build -o dist/main -gcflags="all=-c=6" main.go
   artifacts:
     paths:
       - dist/main
@@ -57,9 +57,9 @@ integration-testing:
   rules:
     - when: on_success
   before_script:
-    # Setup GCP credentials. https://www.pulumi.com/registry/packages/gcp/installation-configuration/
-    # The service account is called `agent-e2e-tests`
-    - export GOOGLE_CREDENTIALS=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.gcp_credentials --with-decryption --query "Parameter.Value" --out text)
+    # Setup GCP credentials https://cloud.google.com/docs/authentication/application-default-credentials#GAC
+    - aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.gcp_credentials --with-decryption --query "Parameter.Value" --out text > ~/gcp-credentials.json || exit $?
+    - export GOOGLE_APPLICATION_CREDENTIALS=~/gcp-credentials.json
     # Setup Azure credentials. https://www.pulumi.com/registry/packages/azure-native/installation-configuration/#set-configuration-using-pulumi-config
     # The app is called `agent-e2e-tests`
     - export ARM_CLIENT_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.azure_client_id --with-decryption --query "Parameter.Value" --out text)
@@ -130,7 +130,6 @@ bump-version-on-datadog-agent:
     - git add test/new-e2e/go.mod test/new-e2e/go.sum .gitlab/common/test_infra_version.yml
     - git commit -m "[test-infra-definitions][automated] Bump test-infra-definitions to $CI_COMMIT_SHORT_SHA"
     - git push -f origin auto-bump/bump-test-infra-$CI_COMMIT_SHORT_SHA
-    - popd 
+    - popd
     - pip install -r requirements.txt
     - inv ci.create-bump-pr-and-close-stale-ones-on-datadog-agent --branch auto-bump/bump-test-infra-$CI_COMMIT_SHORT_SHA --new-commit-sha $CI_COMMIT_SHA --old-commit-sha $PREVIOUS_SHA
-

--- a/resources/gcp/environment.go
+++ b/resources/gcp/environment.go
@@ -37,7 +37,7 @@ type Environment struct {
 }
 
 var _ config.Env = (*Environment)(nil)
-var pulumiEnvVariables = []string{"GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CREDENTIALS"}
+var pulumiEnvVariables = []string{"GOOGLE_APPLICATION_CREDENTIALS"}
 
 func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
 	env := Environment{

--- a/resources/gcp/environment.go
+++ b/resources/gcp/environment.go
@@ -37,7 +37,7 @@ type Environment struct {
 }
 
 var _ config.Env = (*Environment)(nil)
-var pulumiEnvVariables = []string{"GOOGLE_CREDENTIALS"}
+var pulumiEnvVariables = []string{"GOOGLE_APPLICATION_CREDENTIALS"}
 
 func NewEnvironment(ctx *pulumi.Context) (Environment, error) {
 	env := Environment{
@@ -77,15 +77,6 @@ func logIn(ctx *pulumi.Context) {
 		}
 	}
 
-	// Environment variable provided in the CI, to activate the service-account authentication
-	if os.Getenv("GOOGLE_CREDENTIALS_FILE") != "" {
-		fmt.Println("GOOGLE_CREDENTIALS_FILE environment detected, activating service account authentication")
-		cmd := exec.Command("gcloud", "auth", "activate-service-account", "--key-file", os.Getenv("GOOGLE_CREDENTIALS_FILE"))
-		if err := cmd.Run(); err != nil {
-			ctx.Log.Error(fmt.Sprintf("Error running `gcloud auth activate-service-account --key-file $GOOGLE_CREDENTIALS_FILE`: %v", err), nil)
-		}
-	}
-
 	if envVariablesSet {
 		return
 	}
@@ -100,19 +91,6 @@ func logIn(ctx *pulumi.Context) {
 
 		if err != nil {
 			ctx.Log.Error(fmt.Sprintf("Error running `gcloud auth application-default login`: %v", err), nil)
-		}
-	}
-
-	cmd = exec.Command("gcloud", "auth", "print-access-token")
-
-	// There's no error if the token exists and is still valid
-	if err := cmd.Run(); err != nil {
-		// Login if the token is not valid anymore
-		cmd = exec.Command("gcloud", "auth", "login")
-		_, err := cmd.Output()
-
-		if err != nil {
-			ctx.Log.Error(fmt.Sprintf("Error running `gcloud auth login`: %v", err), nil)
 		}
 	}
 }


### PR DESCRIPTION
What does this PR do?
---------------------

`GOOGLE_CREDENTIALS` env var setup is not enough to have gcloud CLI working. We need to execute another command to enable service-account authentication for the CLI.
We need the CLI because the Pulumi Kubernetes provder rely on gcloud CLI to get authentication token for GKE cluster

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
