### PR TITLE
[aws][ec2] query redhat AMIs by version

### DIFF
--- a/components/os/linux_descriptors.go
+++ b/components/os/linux_descriptors.go
@@ -18,7 +18,7 @@ var (
 	AmazonLinuxECS2       = NewDescriptor(AmazonLinuxECS, "2")
 
 	RedHatDefault = RedHat9
-	RedHat9       = NewDescriptor(RedHat, "9.1")
+	RedHat9       = NewDescriptor(RedHat, "9")
 
 	SuseDefault = Suse15
 	Suse15      = NewDescriptor(Suse, "15-sp4")

--- a/scenarios/aws/ec2/os_resolver.go
+++ b/scenarios/aws/ec2/os_resolver.go
@@ -159,7 +159,9 @@ func resolveRedHatAMI(e aws.Environment, osInfo *os.Descriptor) (string, error) 
 		osInfo.Version = os.RedHatDefault.Version
 	}
 
-	return ec2.SearchAMI(e, "309956199498", fmt.Sprintf("RHEL-%s*_HVM-*-2-Hourly2-GP2", osInfo.Version), string(osInfo.Architecture))
+	// Use recommended name query filter by RedHat https://access.redhat.com/solutions/15356
+	redhatOwner := "309956199498"
+	return ec2.SearchAMI(e, redhatOwner, fmt.Sprintf("RHEL-%s*", osInfo.Version), string(osInfo.Architecture))
 }
 
 func resolveSuseAMI(e aws.Environment, osInfo *os.Descriptor) (string, error) {


### PR DESCRIPTION
What does this PR do?
---------------------

Change the Redhat AMIs query to be more resilient to descriptor changes. 

Which scenarios this will impact?
-------------------

aws ec2 on redhat

Motivation
----------

redhat changed the inner version id on AMIs, breaking tests running on redhat as the old query was not matching any AMI. Using the [official Redhat support suggestion](https://access.redhat.com/solutions/15356) querying by `RHEL-<version>*` on owner redhat 

Additional Notes
----------------
