### PR TITLE
[aws][ec2] update fedora ami query

### DIFF
--- a/components/os/linux_descriptors.go
+++ b/components/os/linux_descriptors.go
@@ -23,8 +23,8 @@ var (
 	SuseDefault = Suse15
 	Suse15      = NewDescriptor(Suse, "15-sp4")
 
-	FedoraDefault = Fedora37
-	Fedora37      = NewDescriptor(Fedora, "37")
+	FedoraDefault = Fedora40
+	Fedora40      = NewDescriptor(Fedora, "40")
 
 	CentOSDefault = CentOS7
 	CentOS7       = NewDescriptor(CentOS, "7")

--- a/scenarios/aws/ec2/os_resolver.go
+++ b/scenarios/aws/ec2/os_resolver.go
@@ -181,7 +181,7 @@ func resolveFedoraAMI(e aws.Environment, osInfo *os.Descriptor) (string, error) 
 		osInfo.Version = os.FedoraDefault.Version
 	}
 
-	return ec2.SearchAMI(e, "125523088429", fmt.Sprintf("Fedora-Cloud-Base-%s-*", osInfo.Version), string(osInfo.Architecture))
+	return ec2.SearchAMI(e, "125523088429", fmt.Sprintf("Fedora-Cloud-Base*-%s-*", osInfo.Version), string(osInfo.Architecture))
 }
 
 func resolveCentOSAMI(e aws.Environment, osInfo *os.Descriptor) (string, error) {


### PR DESCRIPTION
What does this PR do?
---------------------

* Update query for Fedora AMIs
* Bump Fedora default version to 40

Which scenarios this will impact?
-------------------

EC2 on Fedora

Motivation
----------

The query was not returning any AMI, and version 37 does not exist anymore on AWS

Additional Notes
----------------
