### PR TITLE
Add a field containing a cloud provider identifier on remote Host

### DIFF
--- a/components/component.go
+++ b/components/component.go
@@ -9,6 +9,14 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
+type CloudProviderIdentifier string
+
+const (
+	CloudProviderAWS   CloudProviderIdentifier = "aws"
+	CloudProviderAzure CloudProviderIdentifier = "azure"
+	CloudProviderGCP   CloudProviderIdentifier = "gcp"
+)
+
 // Importable needs to be implemented by the fully resolved type used outside of Pulumi
 type Importable interface {
 	SetKey(string)

--- a/components/remote/component.go
+++ b/components/remote/component.go
@@ -11,6 +11,8 @@ import (
 type HostOutput struct {
 	components.JSONImporter
 
+	CloudProvider components.CloudProviderIdentifier `json:"cloudProvider"`
+
 	Address   string    `json:"address"`
 	Username  string    `json:"username"`
 	Password  string    `json:"password,omitempty"`
@@ -26,13 +28,14 @@ type Host struct {
 
 	OS os.OS
 
-	Address      pulumi.StringOutput `pulumi:"address"`
-	Username     pulumi.StringOutput `pulumi:"username"`
-	Password     pulumi.StringOutput `pulumi:"password"`
-	Architecture pulumi.StringOutput `pulumi:"architecture"`
-	OSFamily     pulumi.IntOutput    `pulumi:"osFamily"`
-	OSFlavor     pulumi.IntOutput    `pulumi:"osFlavor"`
-	OSVersion    pulumi.StringOutput `pulumi:"osVersion"`
+	CloudProvider components.CloudProviderIdentifier `pulumi:"cloudProvider"`
+	Address       pulumi.StringOutput                `pulumi:"address"`
+	Username      pulumi.StringOutput                `pulumi:"username"`
+	Password      pulumi.StringOutput                `pulumi:"password"`
+	Architecture  pulumi.StringOutput                `pulumi:"architecture"`
+	OSFamily      pulumi.IntOutput                   `pulumi:"osFamily"`
+	OSFlavor      pulumi.IntOutput                   `pulumi:"osFlavor"`
+	OSVersion     pulumi.StringOutput                `pulumi:"osVersion"`
 }
 
 func (h *Host) Export(ctx *pulumi.Context, out *HostOutput) error {

--- a/components/remote/component.go
+++ b/components/remote/component.go
@@ -28,14 +28,14 @@ type Host struct {
 
 	OS os.OS
 
-	CloudProvider components.CloudProviderIdentifier `pulumi:"cloudProvider"`
-	Address       pulumi.StringOutput                `pulumi:"address"`
-	Username      pulumi.StringOutput                `pulumi:"username"`
-	Password      pulumi.StringOutput                `pulumi:"password"`
-	Architecture  pulumi.StringOutput                `pulumi:"architecture"`
-	OSFamily      pulumi.IntOutput                   `pulumi:"osFamily"`
-	OSFlavor      pulumi.IntOutput                   `pulumi:"osFlavor"`
-	OSVersion     pulumi.StringOutput                `pulumi:"osVersion"`
+	CloudProvider pulumi.StringOutput `pulumi:"cloudProvider"`
+	Address       pulumi.StringOutput `pulumi:"address"`
+	Username      pulumi.StringOutput `pulumi:"username"`
+	Password      pulumi.StringOutput `pulumi:"password"`
+	Architecture  pulumi.StringOutput `pulumi:"architecture"`
+	OSFamily      pulumi.IntOutput    `pulumi:"osFamily"`
+	OSFlavor      pulumi.IntOutput    `pulumi:"osFlavor"`
+	OSVersion     pulumi.StringOutput `pulumi:"osVersion"`
 }
 
 func (h *Host) Export(ctx *pulumi.Context, out *HostOutput) error {

--- a/scenarios/aws/ec2/vm.go
+++ b/scenarios/aws/ec2/vm.go
@@ -43,6 +43,8 @@ func NewVM(e aws.Environment, name string, params ...VMOption) (*remote.Host, er
 
 	// Create the EC2 instance
 	return components.NewComponent(&e, e.Namer.ResourceName(name), func(c *remote.Host) error {
+		c.CloudProvider = components.CloudProviderAWS
+
 		instanceArgs := ec2.InstanceArgs{
 			AMI:             amiInfo.id,
 			InstanceType:    vmArgs.instanceType,

--- a/scenarios/aws/ec2/vm.go
+++ b/scenarios/aws/ec2/vm.go
@@ -43,7 +43,7 @@ func NewVM(e aws.Environment, name string, params ...VMOption) (*remote.Host, er
 
 	// Create the EC2 instance
 	return components.NewComponent(&e, e.Namer.ResourceName(name), func(c *remote.Host) error {
-		c.CloudProvider = components.CloudProviderAWS
+		c.CloudProvider = pulumi.String(components.CloudProviderAWS).ToStringOutput()
 
 		instanceArgs := ec2.InstanceArgs{
 			AMI:             amiInfo.id,

--- a/scenarios/azure/compute/vm.go
+++ b/scenarios/azure/compute/vm.go
@@ -35,6 +35,7 @@ func NewVM(e azure.Environment, name string, params ...VMOption) (*remote.Host, 
 	// Create the Azure VM instance
 	return components.NewComponent(&e, e.Namer.ResourceName(name), func(c *remote.Host) error {
 		// Create the Azure instance
+		c.CloudProvider = components.CloudProviderAzure
 		var err error
 		var privateIP pulumi.StringOutput
 		var password pulumi.StringOutput

--- a/scenarios/azure/compute/vm.go
+++ b/scenarios/azure/compute/vm.go
@@ -35,7 +35,7 @@ func NewVM(e azure.Environment, name string, params ...VMOption) (*remote.Host, 
 	// Create the Azure VM instance
 	return components.NewComponent(&e, e.Namer.ResourceName(name), func(c *remote.Host) error {
 		// Create the Azure instance
-		c.CloudProvider = components.CloudProviderAzure
+		c.CloudProvider = pulumi.String(components.CloudProviderAzure).ToStringOutput()
 		var err error
 		var privateIP pulumi.StringOutput
 		var password pulumi.StringOutput

--- a/scenarios/gcp/compute/vm.go
+++ b/scenarios/gcp/compute/vm.go
@@ -29,7 +29,7 @@ func NewVM(e gcp.Environment, name string, option ...VMOption) (*remote.Host, er
 	}
 
 	return components.NewComponent(&e, name, func(h *remote.Host) error {
-		h.CloudProvider = components.CloudProviderGCP
+		h.CloudProvider = pulumi.String(components.CloudProviderGCP).ToStringOutput()
 		vm, err := compute.NewLinuxInstance(e, e.Namer.ResourceName(name), imageInfo.name, params.instanceType, pulumi.Parent(h))
 		if err != nil {
 			return err

--- a/scenarios/gcp/compute/vm.go
+++ b/scenarios/gcp/compute/vm.go
@@ -29,7 +29,7 @@ func NewVM(e gcp.Environment, name string, option ...VMOption) (*remote.Host, er
 	}
 
 	return components.NewComponent(&e, name, func(h *remote.Host) error {
-
+		h.CloudProvider = components.CloudProviderGCP
 		vm, err := compute.NewLinuxInstance(e, e.Namer.ResourceName(name), imageInfo.name, params.instanceType, pulumi.Parent(h))
 		if err != nil {
 			return err


### PR DESCRIPTION
What does this PR do?
---------------------

Add a CloudProvider identifier on Host component. So we can know where the component is living. Which can be useful on datadog-agent side when dealing with multi-cloud resources

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
