### PR TITLE
Handle naming for kind the same way as for EKS

### DIFF
--- a/components/datadog/kubernetesagentparams/params.go
+++ b/components/datadog/kubernetesagentparams/params.go
@@ -68,6 +68,8 @@ func NewParams(options ...Option) (*Params, error) {
 }
 
 // WithClusterName sets the name of the cluster. Should only be used if you know what you are doing. Must no be necessary in most cases.
+// Mainly used to set the clusterName when the agent is installed on Kind clusters. Because the agent is not able to detect the cluster name.
+// It takes a pulumi.StringOutput as input to be able to use the pulumi output of the cluster name.
 func WithClusterName(clusterName pulumi.StringOutput) func(*Params) error {
 	return func(p *Params) error {
 		values := pulumi.Sprintf(`

--- a/components/datadog/kubernetesagentparams/params.go
+++ b/components/datadog/kubernetesagentparams/params.go
@@ -67,6 +67,21 @@ func NewParams(options ...Option) (*Params, error) {
 	return common.ApplyOption(version, options)
 }
 
+// WithClusterName sets the name of the cluster. Should only be used if you know what you are doing. Must no be necessary in most cases.
+func WithClusterName(clusterName pulumi.StringOutput) func(*Params) error {
+	return func(p *Params) error {
+		values := pulumi.Sprintf(`
+datadog:
+  clusterName: %s
+`, clusterName)
+
+		p.HelmValues = append(p.HelmValues, values.ApplyT(func(clusterName string) (pulumi.Asset, error) {
+			return pulumi.NewStringAsset(clusterName), nil
+		}).(pulumi.AssetOutput))
+		return nil
+	}
+}
+
 // WithAgentFullImagePath sets the full path of the agent image to use.
 func WithAgentFullImagePath(fullImagePath string) func(*Params) error {
 	return func(p *Params) error {

--- a/components/kubernetes/kind.go
+++ b/components/kubernetes/kind.go
@@ -29,7 +29,7 @@ var kindClusterConfig string
 // Install Kind on a Linux virtual machine.
 func NewKindCluster(env config.Env, vm *remote.Host, name string, kubeVersion string, opts ...pulumi.ResourceOption) (*Cluster, error) {
 	return components.NewComponent(env, name, func(clusterComp *Cluster) error {
-		kindClusterName := env.CommonNamer().DisplayName(50) // We can have some issues if the name is longer than 50 characters
+		kindClusterName := env.CommonNamer().DisplayName(49) // We can have some issues if the name is longer than 50 characters
 		opts = utils.MergeOptions[pulumi.ResourceOption](opts, pulumi.Parent(clusterComp))
 		runner := vm.OS.Runner()
 		commonEnvironment := env
@@ -112,7 +112,7 @@ func NewKindCluster(env config.Env, vm *remote.Host, name string, kubeVersion st
 
 func NewLocalKindCluster(env config.Env, name string, kubeVersion string, opts ...pulumi.ResourceOption) (*Cluster, error) {
 	return components.NewComponent(env, name, func(clusterComp *Cluster) error {
-		kindClusterName := env.CommonNamer().DisplayName(50) // We can have some issues if the name is longer than 50 characters
+		kindClusterName := env.CommonNamer().DisplayName(49) // We can have some issues if the name is longer than 50 characters
 		opts = utils.MergeOptions[pulumi.ResourceOption](opts, pulumi.Parent(clusterComp))
 		commonEnvironment := env
 

--- a/components/kubernetes/kind.go
+++ b/components/kubernetes/kind.go
@@ -27,10 +27,10 @@ const (
 var kindClusterConfig string
 
 // Install Kind on a Linux virtual machine.
-func NewKindCluster(env config.Env, vm *remote.Host, resourceName, kindClusterName string, kubeVersion string, opts ...pulumi.ResourceOption) (*Cluster, error) {
-	return components.NewComponent(env, resourceName, func(clusterComp *Cluster) error {
+func NewKindCluster(env config.Env, vm *remote.Host, name string, kubeVersion string, opts ...pulumi.ResourceOption) (*Cluster, error) {
+	return components.NewComponent(env, name, func(clusterComp *Cluster) error {
+		kindClusterName := env.CommonNamer().DisplayName(50) // We can have some issues if the name is longer than 50 characters
 		opts = utils.MergeOptions[pulumi.ResourceOption](opts, pulumi.Parent(clusterComp))
-
 		runner := vm.OS.Runner()
 		commonEnvironment := env
 		packageManager := vm.OS.PackageManager()
@@ -65,7 +65,7 @@ func NewKindCluster(env config.Env, vm *remote.Host, resourceName, kindClusterNa
 			return err
 		}
 
-		clusterConfigFilePath := fmt.Sprintf("/tmp/kind-cluster-%s.yaml", kindClusterName)
+		clusterConfigFilePath := fmt.Sprintf("/tmp/kind-cluster-%s.yaml", name)
 		clusterConfig, err := vm.OS.FileManager().CopyInlineFile(
 			pulumi.String(kindClusterConfig),
 			clusterConfigFilePath, opts...)
@@ -75,7 +75,7 @@ func NewKindCluster(env config.Env, vm *remote.Host, resourceName, kindClusterNa
 
 		nodeImage := fmt.Sprintf("%s/%s:%s", env.InternalDockerhubMirror(), kindNodeImageName, kindVersionConfig.nodeImageVersion)
 		createCluster, err := runner.Command(
-			commonEnvironment.CommonNamer().ResourceName("kind-create-cluster", resourceName),
+			commonEnvironment.CommonNamer().ResourceName("kind-create-cluster"),
 			&command.Args{
 				Create:   pulumi.Sprintf("kind create cluster --name %s --config %s --image %s --wait %s", kindClusterName, clusterConfigFilePath, nodeImage, kindReadinessWait),
 				Delete:   pulumi.Sprintf("kind delete cluster --name %s", kindClusterName),
@@ -88,7 +88,7 @@ func NewKindCluster(env config.Env, vm *remote.Host, resourceName, kindClusterNa
 		}
 
 		kubeConfigCmd, err := runner.Command(
-			commonEnvironment.CommonNamer().ResourceName("kind-kubeconfig", resourceName),
+			commonEnvironment.CommonNamer().ResourceName("kind-kubeconfig"),
 			&command.Args{
 				Create: pulumi.Sprintf("kind get kubeconfig --name %s", kindClusterName),
 			},
@@ -104,14 +104,15 @@ func NewKindCluster(env config.Env, vm *remote.Host, resourceName, kindClusterNa
 			allowInsecure := regexp.MustCompile("certificate-authority-data:.+").ReplaceAllString(args[0].(string), "insecure-skip-tls-verify: true")
 			return strings.ReplaceAll(allowInsecure, "0.0.0.0", args[1].(string))
 		}).(pulumi.StringOutput)
-		clusterComp.ClusterName = pulumi.String(kindClusterName).ToStringOutput()
+		clusterComp.ClusterName = kindClusterName.ToStringOutput()
 
 		return nil
 	}, opts...)
 }
 
-func NewLocalKindCluster(env config.Env, resourceName, kindClusterName string, kubeVersion string, opts ...pulumi.ResourceOption) (*Cluster, error) {
-	return components.NewComponent(env, resourceName, func(clusterComp *Cluster) error {
+func NewLocalKindCluster(env config.Env, name string, kubeVersion string, opts ...pulumi.ResourceOption) (*Cluster, error) {
+	return components.NewComponent(env, name, func(clusterComp *Cluster) error {
+		kindClusterName := env.CommonNamer().DisplayName(50) // We can have some issues if the name is longer than 50 characters
 		opts = utils.MergeOptions[pulumi.ResourceOption](opts, pulumi.Parent(clusterComp))
 		commonEnvironment := env
 
@@ -125,7 +126,7 @@ func NewLocalKindCluster(env config.Env, resourceName, kindClusterName string, k
 			OSCommand: command.NewUnixOSCommand(),
 		})
 
-		clusterConfigFilePath := fmt.Sprintf("/tmp/kind-cluster-%s.yaml", kindClusterName)
+		clusterConfigFilePath := fmt.Sprintf("/tmp/kind-cluster-%s.yaml", name)
 		clusterConfig, err := runner.Command("kind-config", &command.Args{
 			Create: pulumi.Sprintf("cat - | tee %s > /dev/null", clusterConfigFilePath),
 			Delete: pulumi.Sprintf("rm -f %s", clusterConfigFilePath),
@@ -137,7 +138,7 @@ func NewLocalKindCluster(env config.Env, resourceName, kindClusterName string, k
 
 		nodeImage := fmt.Sprintf("%s/%s:%s", env.InternalDockerhubMirror(), kindNodeImageName, kindVersionConfig.nodeImageVersion)
 		createCluster, err := runner.Command(
-			commonEnvironment.CommonNamer().ResourceName("kind-create-cluster", resourceName),
+			commonEnvironment.CommonNamer().ResourceName("kind-create-cluster"),
 			&command.Args{
 				Create:   pulumi.Sprintf("kind create cluster --name %s --config %s --image %s --wait %s", kindClusterName, clusterConfigFilePath, nodeImage, kindReadinessWait),
 				Delete:   pulumi.Sprintf("kind delete cluster --name %s", kindClusterName),
@@ -150,7 +151,7 @@ func NewLocalKindCluster(env config.Env, resourceName, kindClusterName string, k
 		}
 
 		kubeConfigCmd, err := runner.Command(
-			commonEnvironment.CommonNamer().ResourceName("kind-kubeconfig", resourceName),
+			commonEnvironment.CommonNamer().ResourceName("kind-kubeconfig"),
 			&command.Args{
 				Create: pulumi.Sprintf("kind get kubeconfig --name %s", kindClusterName),
 			},
@@ -161,7 +162,7 @@ func NewLocalKindCluster(env config.Env, resourceName, kindClusterName string, k
 		}
 
 		clusterComp.KubeConfig = kubeConfigCmd.Stdout
-		clusterComp.ClusterName = pulumi.String(kindClusterName).ToStringOutput()
+		clusterComp.ClusterName = kindClusterName.ToStringOutput()
 
 		return nil
 	}, opts...)


### PR DESCRIPTION
What does this PR do?
---------------------

Naming was a mess on kind. Furthermore there is a trick on kind because the agent cannot determine alone the name of the cluster. A new flag allows us to pass the cluster name to the agent from the Kubernetes cluster output so it remains coherent

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
