### PR TITLE
[aws][ec2] add  support for imds2 in ec2 resource

### DIFF
--- a/resources/aws/ec2/vm.go
+++ b/resources/aws/ec2/vm.go
@@ -21,11 +21,19 @@ type InstanceArgs struct {
 	InstanceProfile string
 
 	// Optional
-	UserData string
+	UserData           string
+	HTTPTokensRequired bool
 }
 
 func NewInstance(e aws.Environment, name string, args InstanceArgs, opts ...pulumi.ResourceOption) (*ec2.Instance, error) {
 	defaultInstanceArgs(e, &args)
+
+	var metadataOptions *ec2.InstanceMetadataOptionsArgs
+	if args.HTTPTokensRequired {
+		metadataOptions = &ec2.InstanceMetadataOptionsArgs{
+			HttpTokens: pulumi.String("required"),
+		}
+	}
 
 	instance, err := ec2.NewInstance(e.Ctx(), e.Namer.ResourceName(name), &ec2.InstanceArgs{
 		Ami:                     pulumi.StringPtr(args.AMI),
@@ -44,7 +52,9 @@ func NewInstance(e aws.Environment, name string, args InstanceArgs, opts ...pulu
 			"Name": e.Namer.DisplayName(255, pulumi.String(name)),
 		},
 		InstanceInitiatedShutdownBehavior: pulumi.String(e.DefaultShutdownBehavior()),
+		MetadataOptions:                   ec2.InstanceMetadataOptionsPtr(metadataOptions),
 	}, utils.MergeOptions(opts, e.WithProviders(config.ProviderAWS))...)
+
 	return instance, err
 }
 

--- a/scenarios/aws/ec2/vm.go
+++ b/scenarios/aws/ec2/vm.go
@@ -44,10 +44,11 @@ func NewVM(e aws.Environment, name string, params ...VMOption) (*remote.Host, er
 	// Create the EC2 instance
 	return components.NewComponent(&e, e.Namer.ResourceName(name), func(c *remote.Host) error {
 		instanceArgs := ec2.InstanceArgs{
-			AMI:             amiInfo.id,
-			InstanceType:    vmArgs.instanceType,
-			UserData:        vmArgs.userData,
-			InstanceProfile: vmArgs.instanceProfile,
+			AMI:                amiInfo.id,
+			InstanceType:       vmArgs.instanceType,
+			UserData:           vmArgs.userData,
+			InstanceProfile:    vmArgs.instanceProfile,
+			HTTPTokensRequired: vmArgs.httpTokensRequired,
 		}
 
 		// Create the EC2 instance

--- a/scenarios/aws/ec2/vmargs.go
+++ b/scenarios/aws/ec2/vmargs.go
@@ -25,6 +25,8 @@ type vmArgs struct {
 	userData        string
 	instanceType    string
 	instanceProfile string
+
+	httpTokensRequired bool
 }
 
 type VMOption = func(*vmArgs) error
@@ -78,6 +80,13 @@ func WithUserData(userData string) VMOption {
 func WithInstanceProfile(instanceProfile string) VMOption {
 	return func(p *vmArgs) error {
 		p.instanceProfile = instanceProfile
+		return nil
+	}
+}
+
+func WithHTTPTokensRequired() VMOption {
+	return func(p *vmArgs) error {
+		p.httpTokensRequired = true
 		return nil
 	}
 }

--- a/scenarios/aws/ec2/vmargs.go
+++ b/scenarios/aws/ec2/vmargs.go
@@ -84,7 +84,7 @@ func WithInstanceProfile(instanceProfile string) VMOption {
 	}
 }
 
-func WithHTTPTokensRequired() VMOption {
+func WithIMDSv1Disable() VMOption {
 	return func(p *vmArgs) error {
 		p.httpTokensRequired = true
 		return nil


### PR DESCRIPTION
What does this PR do?
---------------------

This PR adds the possibility to enable/disable IMDSv1 when creating an ec2 instance.
It adds the HttpToken setting for metadata option for ec2 instance. If http tokens are required then every call to IMDSv1 will fail since only IMDSv2 requires http token to perform.

Which scenarios this will impact?
-------------------

This parameter force the usage of IMDSv2 or the usage of the OS Hostname instead of the instance ID

Motivation
----------

This will help IMDSv2 tests before the transition between IMDSv1 and IMDSv2

Additional Notes
----------------
