### PR TITLE
feat(origin detection): make unified setting as default and implement external-data E2E test

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -223,6 +223,9 @@ func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentI
 			"namespaceLabelsAsTags": pulumi.Map{
 				"related_team": pulumi.String("team"),
 			},
+			"originDetectionUnified": pulumi.Map{
+				"enabled": pulumi.Bool(true),
+			},
 			"namespaceAnnotationsAsTags": pulumi.Map{
 				"related_email": pulumi.String("email"), // should be overridden by kubernetesResourcesAnnotationsAsTags
 			},

--- a/components/datadog/apps/dogstatsd/k8s.go
+++ b/components/datadog/apps/dogstatsd/k8s.go
@@ -298,5 +298,77 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 		return nil, err
 	}
 
+	if _, err := appsv1.NewDeployment(e.Ctx(), fmt.Sprintf("dogstatsd-udp-external-data-only-%d", statsdPort), &appsv1.DeploymentArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.String("dogstatsd-udp-external-data-only"),
+			Namespace: pulumi.String(namespace),
+			Labels: pulumi.StringMap{
+				"app": pulumi.String("dogstatsd-udp-external-data-only"),
+			},
+		},
+		Spec: &appsv1.DeploymentSpecArgs{
+			Replicas: pulumi.Int(1),
+			Selector: &metav1.LabelSelectorArgs{
+				MatchLabels: pulumi.StringMap{
+					"app": pulumi.String("dogstatsd-udp-external-data-only"),
+				},
+			},
+			Template: &corev1.PodTemplateSpecArgs{
+				Metadata: &metav1.ObjectMetaArgs{
+					Labels: pulumi.StringMap{
+						"app":                             pulumi.String("dogstatsd-udp-external-data-only"),
+						"admission.datadoghq.com/enabled": pulumi.String("true"),
+					},
+				},
+				Spec: &corev1.PodSpecArgs{
+					Containers: corev1.ContainerArray{
+						&corev1.ContainerArgs{
+							Name:  pulumi.String("dogstatsd"),
+							Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:main"),
+							Env: &corev1.EnvVarArray{
+								&corev1.EnvVarArgs{
+									Name: pulumi.String("HOST_IP"),
+									ValueFrom: &corev1.EnvVarSourceArgs{
+										FieldRef: &corev1.ObjectFieldSelectorArgs{
+											FieldPath: pulumi.String("status.hostIP"),
+										},
+									},
+								},
+								&corev1.EnvVarArgs{
+									Name:  pulumi.String("STATSD_URL"),
+									Value: pulumi.Sprintf("$(HOST_IP):%d", statsdPort),
+								},
+								&corev1.EnvVarArgs{
+									Name: pulumi.String("DD_ENTITY_ID"),
+									ValueFrom: &corev1.EnvVarSourceArgs{
+										FieldRef: &corev1.ObjectFieldSelectorArgs{
+											FieldPath: pulumi.String("metadata.uid"),
+										},
+									},
+								},
+								&corev1.EnvVarArgs{
+									Name:  pulumi.String("DD_EXTERNAL_DATA_ONLY"),
+									Value: pulumi.String("true"),
+								},
+							},
+							Resources: &corev1.ResourceRequirementsArgs{
+								Limits: pulumi.StringMap{
+									"cpu":    pulumi.String("10m"),
+									"memory": pulumi.String("32Mi"),
+								},
+								Requests: pulumi.StringMap{
+									"cpu":    pulumi.String("2m"),
+									"memory": pulumi.String("32Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, opts...); err != nil {
+		return nil, err
+	}
+
 	return k8sComponent, nil
 }


### PR DESCRIPTION
What does this PR do?
---------------------

This PR enables `originDetectionUnified` and implement the External Data only E2E test.

<img width="2379" alt="image" src="https://github.com/user-attachments/assets/de8b6584-81e4-4344-a34d-b3a978fd0d4c">

This test was made with a different image using the same code.

Which scenarios this will impact?
-------------------
All Kubernetes scenarios.

Motivation
----------
This is needed to effectively tests the newest solution for Origin Detection.

Additional Notes
----------------
