### PR TITLE
fix(k8s): fix workloads with admission controller dependency

### DIFF
--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -110,7 +110,7 @@ func Run(ctx *pulumi.Context) error {
 		}
 
 		// dogstatsd clients that report to the Agent
-		if _, err := dogstatsd.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket", utils.PulumiDependsOn(cluster)); err != nil {
+		if _, err := dogstatsd.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket", utils.PulumiDependsOn(workloadWithCRDDeps...)); err != nil {
 			return err
 		}
 
@@ -127,7 +127,7 @@ func Run(ctx *pulumi.Context) error {
 			return err
 		}
 
-		if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-mutated", "workload-mutated-lib-injection", utils.PulumiDependsOn(cluster)); err != nil {
+		if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-mutated", "workload-mutated-lib-injection", utils.PulumiDependsOn(workloadWithCRDDeps...)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
What does this PR do?
---------------------

Fixes workloads that depends on the Datadog Cluster Agent Admission Controller being ready.

Which scenarios this will impact?
-------------------

All Kubernetes scenarios.

Motivation
----------

Needed to have E2E tests depending on Admission Controller features.

Additional Notes
----------------
