### PR TITLE
[CONTP-437] Add check_cardinality to nginx

### DIFF
--- a/components/datadog/apps/nginx/k8s.go
+++ b/components/datadog/apps/nginx/k8s.go
@@ -93,7 +93,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 							map[string]interface{}{
 								"nginx": map[string]interface{}{
 									"init_config":           map[string]interface{}{},
-									"check_tag_cardinality": "low",
+									"check_tag_cardinality": "high",
 									"instances": []map[string]interface{}{
 										{
 											"nginx_status_url": "http://%%host%%/nginx_status",

--- a/components/datadog/apps/nginx/k8s.go
+++ b/components/datadog/apps/nginx/k8s.go
@@ -92,7 +92,8 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 						"ad.datadoghq.com/nginx.checks": pulumi.String(utils.JSONMustMarshal(
 							map[string]interface{}{
 								"nginx": map[string]interface{}{
-									"init_config": map[string]interface{}{},
+									"init_config":           map[string]interface{}{},
+									"check_tag_cardinality": "low",
 									"instances": []map[string]interface{}{
 										{
 											"nginx_status_url": "http://%%host%%/nginx_status",


### PR DESCRIPTION
What does this PR do?
---------------------
A follow up for recent feature in 7.60: https://github.com/DataDog/datadog-agent/pull/29984
which allows user to configure the cardinality of check instance via annotation check config.

This PR set nginx check cardinality to high.

Which scenarios this will impact?
-------------------
New test metric "nginx.net.connections" will be added https://github.com/DataDog/datadog-agent/pull/35995
for testing additional tags like container id, name etc. 

Motivation
----------

Additional Notes
----------------
