### PR TITLE
fix(dogstatsd-external-data-only): fix missing tag

### DIFF
--- a/components/datadog/apps/dogstatsd/images/dogstatsd/main.go
+++ b/components/datadog/apps/dogstatsd/images/dogstatsd/main.go
@@ -63,7 +63,7 @@ func main() {
 		for {
 			for i := uint(0); i < *nbSeries; i++ {
 				value := math.Sin(2 * math.Pi * (float64(time.Now().Unix())/period.Seconds() + float64(i)/float64(*nbSeries)))
-				_, err = conn.Write([]byte(fmt.Sprintf("custom.metric:%f|g|e:%s|series:%d", value, os.Getenv("DD_EXTERNAL_ENV"), i)))
+				_, err = conn.Write([]byte(fmt.Sprintf("custom.metric:%f|g|e:%s|#series:%d", value, os.Getenv("DD_EXTERNAL_ENV"), i)))
 				if err != nil {
 					log.Fatal(err)
 					return


### PR DESCRIPTION
What does this PR do?
---------------------

Fix the missing `series` tag in the for the `dogstatsd-udp-external-data-only` workload.

<img width="2379" alt="image" src="https://github.com/user-attachments/assets/7035ef06-352a-47eb-bbd1-bbf4eecb2738">


Which scenarios this will impact?
-------------------

All Kubernetes scenarions.

Motivation
----------

Additional Notes
----------------
