### PR TITLE
feat(dogstatsd): Deactivate client associated to the dogstatsd standalone

### DIFF
--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -114,9 +114,11 @@ func Run(ctx *pulumi.Context) error {
 			return err
 		}
 
-		// dogstatsd clients that report to the dogstatsd standalone deployment
-		if _, err := dogstatsd.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket, utils.PulumiDependsOn(cluster)); err != nil {
-			return err
+		if awsEnv.DogstatsdDeploy() {
+			// dogstatsd clients that report to the dogstatsd standalone deployment
+			if _, err := dogstatsd.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket, utils.PulumiDependsOn(cluster)); err != nil {
+				return err
+			}
 		}
 
 		if _, err := tracegen.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-tracegen", utils.PulumiDependsOn(cluster)); err != nil {

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -187,8 +187,10 @@ agents:
 		}
 
 		// dogstatsd clients that report to the dogstatsd standalone deployment
-		if _, err := dogstatsd.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket); err != nil {
-			return err
+		if awsEnv.DogstatsdDeploy() {
+			if _, err := dogstatsd.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket); err != nil {
+				return err
+			}
 		}
 
 		// for tracegen we can't find the cgroup version as it depends on the underlying version of the kernel

--- a/scenarios/azure/aks/run.go
+++ b/scenarios/azure/aks/run.go
@@ -120,9 +120,11 @@ providers:
 			return err
 		}
 
-		// dogstatsd clients that report to the dogstatsd standalone deployment
-		if _, err := dogstatsd.K8sAppDefinition(&env, aksCluster.KubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket); err != nil {
-			return err
+		if env.DogstatsdDeploy() {
+			// dogstatsd clients that report to the dogstatsd standalone deployment
+			if _, err := dogstatsd.K8sAppDefinition(&env, aksCluster.KubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket); err != nil {
+				return err
+			}
 		}
 
 		if _, err := prometheus.K8sAppDefinition(&env, aksCluster.KubeProvider, "workload-prometheus"); err != nil {

--- a/scenarios/gcp/gke/run.go
+++ b/scenarios/gcp/gke/run.go
@@ -104,15 +104,15 @@ func Run(ctx *pulumi.Context) error {
 				if _, err := dogstatsdstandalone.K8sAppDefinition(&env, cluster.KubeProvider, "dogstatsd-standalone", nil, true, ""); err != nil {
 					return err
 				}
+
+				// dogstatsd clients that report to the dogstatsd standalone deployment
+				if _, err := dogstatsd.K8sAppDefinition(&env, cluster.KubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket, dependsOnCrd); err != nil {
+					return err
+				}
 			}
 
 			// dogstatsd clients that report to the Agent
 			if _, err := dogstatsd.K8sAppDefinition(&env, cluster.KubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket", dependsOnCrd); err != nil {
-				return err
-			}
-
-			// dogstatsd clients that report to the dogstatsd standalone deployment
-			if _, err := dogstatsd.K8sAppDefinition(&env, cluster.KubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket, dependsOnCrd); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
What does this PR do?
---------------------
Deactivate client associated to the dogstatsd standalone

Which scenarios this will impact?
---------------------------------
eks, aks, kindvm, gke

Motivation
----------
In the Agent 6 context, we don't build the dogstatsd standalone. As a consequence we need to deactivate it and the associated clients must not be started. See errors in [this job](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/709085841)
```
* the Kubernetes API server reported that "workload-dogstatsd-standalone/dogstatsd-uds" failed to fully initialize or become live: 'dogstatsd-uds' timed out waiting to be Ready
```

Additional Notes
----------------
