### PR TITLE
DDA w/operator component cleanups 

### DIFF
--- a/components/datadog/agentwithoperatorparams/params.go
+++ b/components/datadog/agentwithoperatorparams/params.go
@@ -20,9 +20,7 @@ type Params struct {
 type Option = func(*Params) error
 
 func NewParams(options ...Option) (*Params, error) {
-	version := &Params{
-		Namespace: "datadog",
-	}
+	version := &Params{}
 	return common.ApplyOption(version, options)
 }
 

--- a/components/datadog/apps/dda/datadogagent.go
+++ b/components/datadog/apps/dda/datadogagent.go
@@ -84,12 +84,17 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 		configureImagePullSecret(ddaConfig, imagePullSecret)
 	}
 
+	ddaName := "datadog-agent"
+	if e.PipelineID() != "" {
+		ddaName = fmt.Sprintf("datadog-agent-%s", e.PipelineID())
+	}
+
 	_, err = apiextensions.NewCustomResource(e.Ctx(), "datadog-agent", &apiextensions.CustomResourceArgs{
 		ApiVersion: pulumi.String("datadoghq.com/v2alpha1"),
 		Kind:       pulumi.String("DatadogAgent"),
 		Metadata: &metav1.ObjectMetaArgs{
-			Name:      pulumi.String("datadog"),
-			Namespace: pulumi.String("datadog"),
+			Name:      pulumi.String(ddaName),
+			Namespace: pulumi.String(namespace),
 		},
 		OtherFields: ddaConfig,
 	}, opts...)

--- a/components/datadog/operatorparams/params.go
+++ b/components/datadog/operatorparams/params.go
@@ -24,10 +24,7 @@ type Params struct {
 type Option = func(*Params) error
 
 func NewParams(e config.Env, options ...Option) (*Params, error) {
-	version := &Params{
-		Namespace:             "datadog",
-		OperatorFullImagePath: "gcr.io/datadoghq/operator:latest",
-	}
+	version := &Params{}
 
 	if e.PipelineID() != "" && e.CommitSHA() != "" {
 		options = append(options, WithOperatorFullImagePath(utils.BuildDockerImagePath(fmt.Sprintf("%s/operator", e.InternalRegistry()), fmt.Sprintf("%s-%s", e.PipelineID(), e.CommitSHA()))))


### PR DESCRIPTION
What does this PR do?
---------------------
* Remove hardcoded values such as `namespace` and operator image path in `agentwithoperatorparams` and  `operatorparams`
* Fix creation of the `KubernetesAgentObjRef`--they should only be created if the DatadogAgent component is created successfully

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
