### PR TITLE
fix(kind): fix workloads with admission controller dependency

### DIFF
--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -182,7 +182,7 @@ agents:
 		}
 
 		// dogstatsd clients that report to the Agent
-		if _, err := dogstatsd.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket"); err != nil {
+		if _, err := dogstatsd.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket", dependsOnCrd); err != nil {
 			return err
 		}
 
@@ -200,7 +200,7 @@ agents:
 			return err
 		}
 
-		if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-mutated", "workload-mutated-lib-injection"); err != nil {
+		if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-mutated", "workload-mutated-lib-injection", dependsOnCrd); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
What does this PR do?
---------------------

Fixes workloads that depends on the Datadog Cluster Agent Admission Controller being ready.

Which scenarios this will impact?
-------------------

Kind scenario.

Motivation
----------

Needed to have E2E tests depending on Admission Controller features.

Additional Notes
----------------

<img width="1333" alt="image" src="https://github.com/user-attachments/assets/55377166-f617-4130-9ffa-a3c0335aaeaa">
