### PR TITLE
Update deploy to copy private key path to pulumi env

### DIFF
--- a/tasks/aws/deploy.py
+++ b/tasks/aws/deploy.py
@@ -11,6 +11,7 @@ from tasks.config import Config, get_full_profile_path
 from tasks.deploy import deploy as common_deploy
 
 default_public_path_key_name = "ddinfra:aws/defaultPublicKeyPath"
+default_private_path_key_name = "ddinfra:aws/defaultPrivateKeyPath"
 
 
 def deploy(
@@ -41,6 +42,10 @@ def deploy(
         raise Exit(f"Error in config {get_full_profile_path(config_path)}") from e
 
     flags[default_public_path_key_name] = _get_public_path_key_name(cfg, public_key_required)
+
+    privateKeyPath = cfg.get_aws().privateKeyPath
+    if privateKeyPath is not None:
+        flags[default_private_path_key_name] = privateKeyPath
 
     awsKeyPairName = cfg.get_aws().keyPairName
 


### PR DESCRIPTION
What does this PR do?
---------------------
Adds defaultPrivateKeyPath to pulumi environment.  

Which scenarios this will impact?
-------------------
On windows caused errors running `inv aws.create-vm`. Could not connect via ssh to provision and setup the VM with the agent.

Motivation
----------
Fixes above problem

Additional Notes
----------------
