### PR TITLE
Revert "Sanitize the dependencies between K8s fake app pulumi components and the agent"

### DIFF
--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -58,8 +58,7 @@ func Run(ctx *pulumi.Context) error {
 			return err
 		}
 	}
-
-	var dependsOnDDAgent pulumi.ResourceOption
+	workloadWithCRDDeps := make([]pulumi.Resource, 0)
 	if awsEnv.AgentDeploy() {
 		k8sAgentOptions := make([]kubernetesagentparams.Option, 0)
 		k8sAgentOptions = append(
@@ -86,51 +85,51 @@ func Run(ctx *pulumi.Context) error {
 			return err
 		}
 
-		dependsOnDDAgent = utils.PulumiDependsOn(k8sAgentComponent)
-	}
+		workloadWithCRDDeps = append(workloadWithCRDDeps, k8sAgentComponent)
 
+	}
 	// Deploy standalone dogstatsd
 	if awsEnv.DogstatsdDeploy() {
-		if _, err := dogstatsdstandalone.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "dogstatsd-standalone", fakeIntake, true, ""); err != nil {
+		if _, err := dogstatsdstandalone.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "dogstatsd-standalone", fakeIntake, true, "", utils.PulumiDependsOn(cluster)); err != nil {
 			return err
 		}
 	}
 
 	// Deploy testing workload
 	if awsEnv.TestingWorkloadDeploy() {
-		if _, err := nginx.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-nginx", "", true, dependsOnDDAgent /* for DDM */); err != nil {
+		if _, err := nginx.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-nginx", "", true, utils.PulumiDependsOn(workloadWithCRDDeps...)); err != nil {
 			return err
 		}
 
-		if _, err := redis.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-redis", true, dependsOnDDAgent /* for DDM */); err != nil {
+		if _, err := redis.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-redis", true, utils.PulumiDependsOn(workloadWithCRDDeps...)); err != nil {
 			return err
 		}
 
-		if _, err := cpustress.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-cpustress"); err != nil {
+		if _, err := cpustress.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-cpustress", utils.PulumiDependsOn(cluster)); err != nil {
 			return err
 		}
 
 		// dogstatsd clients that report to the Agent
-		if _, err := dogstatsd.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket", dependsOnDDAgent /* for admission */); err != nil {
+		if _, err := dogstatsd.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket", utils.PulumiDependsOn(workloadWithCRDDeps...)); err != nil {
 			return err
 		}
 
 		if awsEnv.DogstatsdDeploy() {
 			// dogstatsd clients that report to the dogstatsd standalone deployment
-			if _, err := dogstatsd.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket, dependsOnDDAgent /* for admission */); err != nil {
+			if _, err := dogstatsd.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket, utils.PulumiDependsOn(cluster)); err != nil {
 				return err
 			}
 		}
 
-		if _, err := tracegen.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-tracegen"); err != nil {
+		if _, err := tracegen.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-tracegen", utils.PulumiDependsOn(cluster)); err != nil {
 			return err
 		}
 
-		if _, err := prometheus.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-prometheus"); err != nil {
+		if _, err := prometheus.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-prometheus", utils.PulumiDependsOn(cluster)); err != nil {
 			return err
 		}
 
-		if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-mutated", "workload-mutated-lib-injection", dependsOnDDAgent /* for admission */); err != nil {
+		if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-mutated", "workload-mutated-lib-injection", utils.PulumiDependsOn(workloadWithCRDDeps...)); err != nil {
 			return err
 		}
 	}

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -67,6 +67,8 @@ func Run(ctx *pulumi.Context) error {
 		return err
 	}
 
+	var dependsOnCrd pulumi.ResourceOption
+
 	var fakeIntake *fakeintakeComp.Fakeintake
 	if awsEnv.AgentUseFakeintake() {
 		fakeIntakeOptions := []fakeintake.Option{
@@ -84,8 +86,6 @@ func Run(ctx *pulumi.Context) error {
 			return err
 		}
 	}
-
-	var dependsOnDDAgent pulumi.ResourceOption
 
 	// Deploy the agent
 	if awsEnv.AgentDeploy() && !awsEnv.AgentDeployWithOperator() {
@@ -121,7 +121,7 @@ agents:
 			return err
 		}
 
-		dependsOnDDAgent = utils.PulumiDependsOn(k8sAgentComponent)
+		dependsOnCrd = utils.PulumiDependsOn(k8sAgentComponent)
 	}
 
 	// Deploy the operator
@@ -152,7 +152,7 @@ agents:
 			return err
 		}
 
-		dependsOnDDAgent = utils.PulumiDependsOn(operatorAgentComponent)
+		dependsOnCrd = utils.PulumiDependsOn(operatorAgentComponent)
 
 		if err := operatorAgentComponent.Export(awsEnv.Ctx(), nil); err != nil {
 			return err
@@ -169,11 +169,11 @@ agents:
 
 	// Deploy testing workload
 	if awsEnv.TestingWorkloadDeploy() {
-		if _, err := nginx.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-nginx", "", true, dependsOnDDAgent /* for DDM */); err != nil {
+		if _, err := nginx.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-nginx", "", true, dependsOnCrd); err != nil {
 			return err
 		}
 
-		if _, err := redis.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-redis", true, dependsOnDDAgent /* for DDM */); err != nil {
+		if _, err := redis.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-redis", true, dependsOnCrd); err != nil {
 			return err
 		}
 
@@ -182,13 +182,13 @@ agents:
 		}
 
 		// dogstatsd clients that report to the Agent
-		if _, err := dogstatsd.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket", dependsOnDDAgent /* for admission */); err != nil {
+		if _, err := dogstatsd.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket"); err != nil {
 			return err
 		}
 
 		// dogstatsd clients that report to the dogstatsd standalone deployment
 		if awsEnv.DogstatsdDeploy() {
-			if _, err := dogstatsd.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket, dependsOnDDAgent /* for admission */); err != nil {
+			if _, err := dogstatsd.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket); err != nil {
 				return err
 			}
 		}
@@ -202,7 +202,7 @@ agents:
 			return err
 		}
 
-		if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-mutated", "workload-mutated-lib-injection", dependsOnDDAgent /* for admission */); err != nil {
+		if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-mutated", "workload-mutated-lib-injection"); err != nil {
 			return err
 		}
 	}

--- a/scenarios/azure/aks/run.go
+++ b/scenarios/azure/aks/run.go
@@ -38,7 +38,7 @@ func Run(ctx *pulumi.Context) error {
 		return err
 	}
 
-	var dependsOnDDAgent pulumi.ResourceOption
+	var dependsOnCrd pulumi.ResourceOption
 
 	// Deploy the agent
 	if env.AgentDeploy() {
@@ -87,7 +87,7 @@ providers:
 			return err
 		}
 
-		dependsOnDDAgent = utils.PulumiDependsOn(k8sAgentComponent)
+		dependsOnCrd = utils.PulumiDependsOn(k8sAgentComponent)
 	}
 
 	// Deploy standalone dogstatsd
@@ -99,15 +99,15 @@ providers:
 
 	// Deploy testing workload
 	if env.TestingWorkloadDeploy() {
-		if _, err := nginx.K8sAppDefinition(&env, aksCluster.KubeProvider, "workload-nginx", "", true, dependsOnDDAgent /* for DDM */); err != nil {
+		if _, err := nginx.K8sAppDefinition(&env, aksCluster.KubeProvider, "workload-nginx", "", true, dependsOnCrd); err != nil {
 			return err
 		}
 
-		if _, err := nginx.K8sAppDefinition(&env, aksCluster.KubeProvider, "workload-nginx-kata", kataRuntimeClass, true, dependsOnDDAgent /* for DDM */); err != nil {
+		if _, err := nginx.K8sAppDefinition(&env, aksCluster.KubeProvider, "workload-nginx-kata", kataRuntimeClass, true, dependsOnCrd); err != nil {
 			return err
 		}
 
-		if _, err := redis.K8sAppDefinition(&env, aksCluster.KubeProvider, "workload-redis", true, dependsOnDDAgent /* for DDM */); err != nil {
+		if _, err := redis.K8sAppDefinition(&env, aksCluster.KubeProvider, "workload-redis", true, dependsOnCrd); err != nil {
 			return err
 		}
 
@@ -116,13 +116,13 @@ providers:
 		}
 
 		// dogstatsd clients that report to the Agent
-		if _, err := dogstatsd.K8sAppDefinition(&env, aksCluster.KubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket", dependsOnDDAgent /* for admission */); err != nil {
+		if _, err := dogstatsd.K8sAppDefinition(&env, aksCluster.KubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket"); err != nil {
 			return err
 		}
 
 		if env.DogstatsdDeploy() {
 			// dogstatsd clients that report to the dogstatsd standalone deployment
-			if _, err := dogstatsd.K8sAppDefinition(&env, aksCluster.KubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket, dependsOnDDAgent /* for admission */); err != nil {
+			if _, err := dogstatsd.K8sAppDefinition(&env, aksCluster.KubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket); err != nil {
 				return err
 			}
 		}
@@ -131,7 +131,7 @@ providers:
 			return err
 		}
 
-		if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(&env, aksCluster.KubeProvider, "workload-mutated", "workload-mutated-lib-injection", dependsOnDDAgent /* for admission */); err != nil {
+		if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(&env, aksCluster.KubeProvider, "workload-mutated", "workload-mutated-lib-injection"); err != nil {
 			return err
 		}
 	}

--- a/scenarios/gcp/gke/run.go
+++ b/scenarios/gcp/gke/run.go
@@ -37,7 +37,7 @@ func Run(ctx *pulumi.Context) error {
 		return err
 	}
 
-	var dependsOnDDAgent pulumi.ResourceOption
+	var dependsOnCrd pulumi.ResourceOption
 
 	// Deploy the agent
 	if env.AgentDeploy() {
@@ -75,25 +75,25 @@ func Run(ctx *pulumi.Context) error {
 			return err
 		}
 
-		dependsOnDDAgent = utils.PulumiDependsOn(k8sAgentComponent)
+		dependsOnCrd = utils.PulumiDependsOn(k8sAgentComponent)
 	}
 
 	// Deploy testing workload
 	if env.TestingWorkloadDeploy() {
 
-		if _, err := nginx.K8sAppDefinition(&env, cluster.KubeProvider, "workload-nginx", "", true, dependsOnDDAgent /* for DDM */); err != nil {
+		if _, err := nginx.K8sAppDefinition(&env, cluster.KubeProvider, "workload-nginx", "", true, dependsOnCrd); err != nil {
 			return err
 		}
 
-		if _, err := cpustress.K8sAppDefinition(&env, cluster.KubeProvider, "workload-cpustress"); err != nil {
+		if _, err := cpustress.K8sAppDefinition(&env, cluster.KubeProvider, "workload-cpustress", dependsOnCrd); err != nil {
 			return err
 		}
 
-		if _, err := prometheus.K8sAppDefinition(&env, cluster.KubeProvider, "workload-prometheus"); err != nil {
+		if _, err := prometheus.K8sAppDefinition(&env, cluster.KubeProvider, "workload-prometheus", dependsOnCrd); err != nil {
 			return err
 		}
 
-		if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(&env, cluster.KubeProvider, "workload-mutated", "workload-mutated-lib-injection", dependsOnDDAgent /* for admission */); err != nil {
+		if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(&env, cluster.KubeProvider, "workload-mutated", "workload-mutated-lib-injection", dependsOnCrd); err != nil {
 			return err
 		}
 
@@ -106,17 +106,17 @@ func Run(ctx *pulumi.Context) error {
 				}
 
 				// dogstatsd clients that report to the dogstatsd standalone deployment
-				if _, err := dogstatsd.K8sAppDefinition(&env, cluster.KubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket, dependsOnDDAgent /* for admission */); err != nil {
+				if _, err := dogstatsd.K8sAppDefinition(&env, cluster.KubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket, dependsOnCrd); err != nil {
 					return err
 				}
 			}
 
 			// dogstatsd clients that report to the Agent
-			if _, err := dogstatsd.K8sAppDefinition(&env, cluster.KubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket", dependsOnDDAgent /* for admission */); err != nil {
+			if _, err := dogstatsd.K8sAppDefinition(&env, cluster.KubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket", dependsOnCrd); err != nil {
 				return err
 			}
 
-			if _, err := tracegen.K8sAppDefinition(&env, cluster.KubeProvider, "workload-tracegen"); err != nil {
+			if _, err := tracegen.K8sAppDefinition(&env, cluster.KubeProvider, "workload-tracegen", dependsOnCrd); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Reverts DataDog/test-infra-definitions#1261

This is currently breaking two e2e tests on `datadog-agent`