### PR TITLE
Updating docker image checks to make sure JMX image available and used for pipelines

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -137,6 +137,8 @@ type CloudEnv interface {
 	InternalRegistry() string
 	// InternalRegistryImageTagExists returns true if the image tag exists in the internal registry.
 	InternalRegistryImageTagExists(image, tag string) (bool, error)
+	// InternalRegistryFullImagePathExists returns true if the image and tag exists in the internal registry.
+	InternalRegistryFullImagePathExists(fullImagePath string) (bool, error)
 }
 
 func NewCommonEnvironment(ctx *pulumi.Context) (CommonEnvironment, error) {

--- a/common/utils/docker.go
+++ b/common/utils/docker.go
@@ -10,15 +10,21 @@ func BuildDockerImagePath(dockerRepository string, imageVersion string) string {
 }
 
 func ParseImageReference(imageRef string) (imagePath string, tag string) {
-	tagSepIdx := strings.LastIndex(imageRef, ":")
-	if tagSepIdx == -1 {
-		// no tag, tag is latest
+	lastColonIdx := strings.LastIndex(imageRef, ":")
+	if lastColonIdx > 0 &&
+		lastColonIdx < len(imageRef)-1 &&
+		// Check not part of registry address (e.g., "registry:5000/image")
+		!strings.Contains(imageRef[lastColonIdx:], "/") {
+		imagePath = imageRef[:lastColonIdx]
+		tag = imageRef[lastColonIdx+1:]
+	} else {
 		imagePath = imageRef
 		tag = "latest"
-		return
 	}
 
-	imagePath = imageRef[0:tagSepIdx]
-	tag = imageRef[tagSepIdx+1:]
+	// Remove trailing ":" if image name has one.
+	if imagePath[len(imagePath)-1:] == ":" {
+		imagePath = imagePath[:len(imagePath)-1]
+	}
 	return
 }

--- a/common/utils/docker_test.go
+++ b/common/utils/docker_test.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseImageReference(t *testing.T) {
+
+	tests := []struct {
+		fullImagePath string
+		expectedTag   string
+		expectedImage string
+	}{
+		{
+			fullImagePath: "nginx",
+			expectedImage: "nginx",
+			expectedTag:   "latest",
+		},
+		{
+			fullImagePath: "nginx:latest",
+			expectedImage: "nginx",
+			expectedTag:   "latest",
+		},
+		{
+			fullImagePath: "example.com:5000/myimage",
+			expectedImage: "example.com:5000/myimage",
+			expectedTag:   "latest",
+		},
+		{
+			fullImagePath: "example.com:5000/myimage:1.0",
+			expectedImage: "example.com:5000/myimage",
+			expectedTag:   "1.0",
+		},
+		{
+			fullImagePath: "example.com:5000/myimage:",
+			expectedImage: "example.com:5000/myimage",
+			expectedTag:   "latest",
+		},
+		{
+			fullImagePath: "example.com/datadog/agent-dev:abcdefg",
+			expectedImage: "example.com/datadog/agent-dev",
+			expectedTag:   "abcdefg",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.fullImagePath, func(t *testing.T) {
+			imagePath, tag := ParseImageReference(test.fullImagePath)
+			assert.Equal(t, test.expectedImage, imagePath)
+			assert.Equal(t, test.expectedTag, tag)
+		})
+	}
+}

--- a/components/datadog/agent/docker.go
+++ b/components/datadog/agent/docker.go
@@ -45,7 +45,17 @@ func NewDockerAgent(e config.Env, vm *remoteComp.Host, manager *docker.Manager, 
 		if err != nil {
 			return err
 		}
+
 		defaultAgentParams(params)
+
+		// Check FullImagePath exists in internal registry
+		exists, err := e.InternalRegistryFullImagePathExists(params.FullImagePath)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("image %q not found in the internal registry", params.FullImagePath)
+		}
 
 		// We can have multiple compose files in compose.
 		composeContents := []docker.ComposeInlineManifest{dockerAgentComposeManifest(params.FullImagePath, e.AgentAPIKey(), params.AgentServiceEnvironment)}

--- a/components/datadog/agent/docker.go
+++ b/components/datadog/agent/docker.go
@@ -117,6 +117,13 @@ func dockerAgentComposeManifest(agentImagePath string, apiKey pulumi.StringInput
 }
 
 func defaultAgentParams(params *dockeragentparams.Params) {
+	// After setting params.FullImagePath check if you need to use JMX Docker image
+	defer func(p *dockeragentparams.Params) {
+		if p.JMX {
+			p.FullImagePath = fmt.Sprintf("%s-jmx", p.FullImagePath)
+		}
+	}(params)
+
 	if params.FullImagePath != "" {
 		return
 	}
@@ -128,8 +135,4 @@ func defaultAgentParams(params *dockeragentparams.Params) {
 		params.ImageTag = defaultAgentImageTag
 	}
 	params.FullImagePath = utils.BuildDockerImagePath(params.Repository, params.ImageTag)
-
-	if params.JMX {
-		params.FullImagePath = fmt.Sprintf("%s-jmx", params.FullImagePath)
-	}
 }

--- a/components/datadog/dockeragentparams/params.go
+++ b/components/datadog/dockeragentparams/params.go
@@ -60,17 +60,10 @@ func NewParams(e config.Env, options ...Option) (*Params, error) {
 	}
 
 	if e.PipelineID() != "" && e.CommitSHA() != "" {
-		baseTag := fmt.Sprintf("%s-%s", e.PipelineID(), e.CommitSHA())
-		for _, tag := range []string{baseTag, fmt.Sprintf("%s-jmx", baseTag)} {
-			exists, err := e.InternalRegistryImageTagExists(fmt.Sprintf("%s/agent", e.InternalRegistry()), tag)
-			if err != nil {
-				return nil, err
-			}
-			if !exists {
-				return nil, fmt.Errorf("image %s/agent:%s not found in the internal registry", e.InternalRegistry(), tag)
-			}
-		}
-		options = append(options, WithFullImagePath(utils.BuildDockerImagePath("669783387624.dkr.ecr.us-east-1.amazonaws.com/agent", baseTag)))
+		options = append(options,
+			WithFullImagePath(utils.BuildDockerImagePath(
+				"669783387624.dkr.ecr.us-east-1.amazonaws.com/agent",
+				fmt.Sprintf("%s-%s", e.PipelineID(), e.CommitSHA()))))
 	}
 
 	return common.ApplyOption(version, options)

--- a/resources/aws/environment.go
+++ b/resources/aws/environment.go
@@ -187,6 +187,27 @@ func (e *Environment) InternalRegistryImageTagExists(image, tag string) (bool, e
 	return true, nil
 }
 
+func (e *Environment) InternalRegistryFullImagePathExists(fullImagePath string) (bool, error) {
+	var image, tag string
+	lastColonIdx := strings.LastIndex(fullImagePath, ":")
+	if lastColonIdx > 0 &&
+		lastColonIdx < len(fullImagePath)-1 &&
+		// Check not part of registry address (e.g., "registry:5000/image")
+		!strings.Contains(fullImagePath[lastColonIdx:], "/") {
+		image = fullImagePath[:lastColonIdx]
+		tag = fullImagePath[lastColonIdx+1:]
+	} else {
+		image = fullImagePath
+		tag = "latest"
+	}
+
+	// Remove trailing ":" if image name has one.
+	if image[len(image)-1:] == ":" {
+		image = image[:len(image)-1]
+	}
+	return e.InternalRegistryImageTagExists(image, tag)
+}
+
 // Common
 func (e *Environment) Region() string {
 	return e.GetStringWithDefault(e.awsConfig, awsRegionParamName, e.envDefault.aws.region)

--- a/resources/azure/environment.go
+++ b/resources/azure/environment.go
@@ -84,6 +84,10 @@ func (e *Environment) InternalRegistryImageTagExists(_, _ string) (bool, error) 
 	return true, nil
 }
 
+func (e *Environment) InternalRegistryFullImagePathExists(_ string) (bool, error) {
+	return true, nil
+}
+
 // Common
 
 func (e *Environment) DefaultSubscriptionID() string {

--- a/resources/gcp/environment.go
+++ b/resources/gcp/environment.go
@@ -119,6 +119,10 @@ func (e *Environment) InternalRegistryImageTagExists(_, _ string) (bool, error) 
 	return true, nil
 }
 
+func (e *Environment) InternalRegistryFullImagePathExists(_ string) (bool, error) {
+	return true, nil
+}
+
 // Common
 
 func (e *Environment) DefaultPublicKeyPath() string {

--- a/resources/hyperv/environment.go
+++ b/resources/hyperv/environment.go
@@ -53,6 +53,10 @@ func (e *Environment) InternalRegistryImageTagExists(_, _ string) (bool, error) 
 	return true, nil
 }
 
+func (e *Environment) InternalRegistryFullImagePathExists(_ string) (bool, error) {
+	return true, nil
+}
+
 // Common
 func (e *Environment) DefaultPublicKeyPath() string {
 	return e.InfraConfig.Get(DDInfraDefaultPublicKeyPath)

--- a/resources/local/environment.go
+++ b/resources/local/environment.go
@@ -53,6 +53,11 @@ func (e *Environment) InternalRegistryImageTagExists(_, _ string) (bool, error) 
 	return true, nil
 }
 
+// InternalRegistryFullImagePathExists returns true if the image and tag exists in the internal registry.
+func (e *Environment) InternalRegistryFullImagePathExists(_ string) (bool, error) {
+	return true, nil
+}
+
 // Common
 func (e *Environment) DefaultPublicKeyPath() string {
 	return e.InfraConfig.Get(DDInfraDefaultPublicKeyPath)


### PR DESCRIPTION
What does this PR do?
---------------------

Added a check to make sure [JMX image](https://docs.datadoghq.com/integrations/java/?tab=docker) of the Agent is deployed by adding a new function called `InternalRegistryFullImagePathExists` that allows me to use a computed Docker image path. This means that tests that don't care about the JMX image won't have to rely on that job in the gitlab pipeline and we check the the image for the given test.

Also added a check on ECR to make sure we don't check for none ECR images + a unit test for parsing Docker image tags.

Which scenarios this will impact?
-------------------

Docker end to end test, particularly the one created for JMXFetch [here](https://github.com/DataDog/datadog-agent/pull/31320). I've temporarily bumped the version of `test-infra-definitions` in that PR so that I can validate the changes work.

Motivation
----------

To run e2e tests for JMXFetch we need the Docker image with Java published.
