### PR TITLE
[dockerfile] add parallel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update -y && \
   gnupg \
   software-properties-common \
   wget \
+  parallel \
   unzip && \
   # Get all of the signatures we need all at once.
   curl --retry 10 -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key    | apt-key add - && \


### PR DESCRIPTION
What does this PR do?
---------------------

Install `parallel` into the test-infra docker image

Which scenarios this will impact?
-------------------

None

Motivation
----------

We use `test-infra-definitions` image in `test-infra-cleaner`, where we are having issues running calls to destroy in // sending calls to the background. We suspect this might be because we call pulumi limits running in //. We want to limit to 5 destroys per call, so `parallel` will help us there

Additional Notes
----------------

More details about parallel: https://www.gnu.org/software/parallel/