### PR TITLE
Add agent config to scrape custom resource metrics in KSM

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -445,6 +445,48 @@ func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentI
 							},
 							"labels_as_tags":      map[string]interface{}{},
 							"annotations_as_tags": map[string]interface{}{},
+							"custom_resource": map[string]interface{}{
+								"spec": map[string]interface{}{
+									"resources": []map[string]interface{}{
+										{
+											"groupVersionKind": map[string]interface{}{
+												"group":   "datadoghq.com",
+												"kind":    "DatadogMetric",
+												"version": "v1alpha1",
+											},
+											"commonLabels": map[string]interface{}{
+												"cr_type": "ddm",
+											},
+											"labelsFromPath": map[string]interface{}{
+												"ddm_name": []string{
+													"metadata",
+													"name",
+												},
+												"app": []string{
+													"metadata",
+													"labels",
+													"app",
+												},
+											},
+											"metrics": []map[string]interface{}{
+												{
+													"name": "ddm_value",
+													"help": "DatadogMetric value",
+													"each": map[string]interface{}{
+														"type": "gauge",
+														"gauge": map[string]interface{}{
+															"path": []string{
+																"status",
+																"currentValue",
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
 						},
 					},
 				})),


### PR DESCRIPTION
What does this PR do?
---------------------

Add agent configuration for the `kubernetes_state_core` check to scrape metrics from a custom resource (`DatadogMetric` in this case)

Which scenarios this will impact?
-------------------

* `aws/eks`
* `aws/kind`

Motivation
----------

Support of custom resource in `kubernetes_state_core` is very specific and deserve dedicated test.

Additional Notes
----------------
