### PR TITLE
Add flavor to Agent PackageVersion

### DIFF
--- a/components/datadog/agent/host_linuxos.go
+++ b/components/datadog/agent/host_linuxos.go
@@ -46,6 +46,14 @@ func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersio
 		}
 	}
 
+	if version.Flavor == "" {
+		version.Flavor = agentparams.DefaultFlavor
+	}
+	switch version.Flavor {
+	case agentparams.FIPSFlavor:
+		// TODO: Add FIPS support
+	}
+
 	commandLine = strings.Join(testEnvVars, " ")
 
 	return fmt.Sprintf(

--- a/components/datadog/agent/host_windowsos.go
+++ b/components/datadog/agent/host_windowsos.go
@@ -111,6 +111,9 @@ while ($tries -lt 5) {
 }
 
 func getAgentURL(version agentparams.PackageVersion) (string, error) {
+	if version.Flavor == "" {
+		version.Flavor = agentparams.DefaultFlavor
+	}
 	minor := strings.ReplaceAll(version.Minor, "~", "-")
 	fullVersion := fmt.Sprintf("%v.%v", version.Major, minor)
 
@@ -119,7 +122,7 @@ func getAgentURL(version agentparams.PackageVersion) (string, error) {
 	}
 
 	if version.Channel == agentparams.BetaChannel {
-		finder, err := newAgentURLFinder("https://s3.amazonaws.com/dd-agent-mstesting/builds/beta/installers_v2.json")
+		finder, err := newAgentURLFinder("https://s3.amazonaws.com/dd-agent-mstesting/builds/beta/installers_v2.json", version.Flavor)
 		if err != nil {
 			return "", err
 		}
@@ -134,7 +137,7 @@ func getAgentURL(version agentparams.PackageVersion) (string, error) {
 		return url, nil
 	}
 
-	finder, err := newAgentURLFinder("https://ddagent-windows-stable.s3.amazonaws.com/installers_v2.json")
+	finder, err := newAgentURLFinder("https://ddagent-windows-stable.s3.amazonaws.com/installers_v2.json", version.Flavor)
 	if err != nil {
 		return "", err
 	}
@@ -151,6 +154,43 @@ func getAgentURL(version agentparams.PackageVersion) (string, error) {
 }
 
 func getAgentURLFromPipelineID(version agentparams.PackageVersion) (string, error) {
+	productName, err := getFlavorProductName(version.Flavor)
+	if err != nil {
+		return "", err
+	}
+
+	url, err := getPipelineArtifact(version.PipelineID, "dd-agent-mstesting", version.Major, func(artifact string) bool {
+		if !strings.Contains(artifact, fmt.Sprintf("%s-%s", productName, version.Major)) {
+			return false
+		}
+		if !strings.HasSuffix(artifact, ".msi") {
+			return false
+		}
+
+		return true
+	})
+
+	return url, nil
+}
+
+func getFlavorProductName(flavor string) (string, error) {
+	switch flavor {
+	case "":
+		return "datadog-agent", nil
+	case "base":
+		return "datadog-agent", nil
+	case "fips":
+		return "datadog-fips-agent", nil
+	default:
+		return "", fmt.Errorf("unknown flavor %v", flavor)
+	}
+}
+
+// getPipelineArtifact searches a public S3 bucket for a given artifact from a Gitlab pipeline
+// majorVersion = [6,7]
+// predicate = A function taking the artifact name (from github.com/aws/aws-sdk-go-v2/service/s3/types.Object.Key)
+// and that returns true when the artifact matches.
+func getPipelineArtifact(pipelineID, bucket, majorVersion string, predicate func(string) bool) (string, error) {
 	// TODO: Replace context.Background() with a Pulumi context.Context.
 	// dd-agent-mstesting is a public bucket so we can use anonymous credentials
 	config, err := awsConfig.LoadDefaultConfig(context.Background(), awsConfig.WithCredentialsProvider(aws.AnonymousCredentials{}))
@@ -160,19 +200,29 @@ func getAgentURLFromPipelineID(version agentparams.PackageVersion) (string, erro
 
 	s3Client := s3.NewFromConfig(config)
 
+	// Manual URL example: https://s3.amazonaws.com/dd-agent-mstesting?prefix=pipelines/A7/25309493
 	result, err := s3Client.ListObjectsV2(context.Background(), &s3.ListObjectsV2Input{
-		Bucket: aws.String("dd-agent-mstesting"),
-		Prefix: aws.String(fmt.Sprintf("pipelines/A%v/%v", version.Major, version.PipelineID)),
+		Bucket: aws.String(bucket),
+		Prefix: aws.String(fmt.Sprintf("pipelines/A%s/%s", majorVersion, pipelineID)),
 	})
+
 	if err != nil {
 		return "", err
 	}
 
 	if len(result.Contents) <= 0 {
-		return "", fmt.Errorf("no agent MSI found for pipeline %v", version.PipelineID)
+		return "", fmt.Errorf("no artifact found for pipeline %v", pipelineID)
 	}
 
-	return "https://s3.amazonaws.com/dd-agent-mstesting/" + *result.Contents[0].Key, nil
+	for _, obj := range result.Contents {
+		if !predicate(*obj.Key) {
+			continue
+		}
+
+		return fmt.Sprintf("https://s3.amazonaws.com/%s/%s", bucket, *obj.Key), nil
+	}
+
+	return "", fmt.Errorf("no agent artifact found for pipeline %v", pipelineID)
 }
 
 type agentURLFinder struct {
@@ -180,7 +230,7 @@ type agentURLFinder struct {
 	installerURL string
 }
 
-func newAgentURLFinder(installerURL string) (*agentURLFinder, error) {
+func newAgentURLFinder(installerURL string, flavor string) (*agentURLFinder, error) {
 	resp, err := http.Get(installerURL)
 	if err != nil {
 		return nil, err
@@ -195,7 +245,17 @@ func newAgentURLFinder(installerURL string) (*agentURLFinder, error) {
 		return nil, err
 	}
 
-	versions, err := getKey[map[string]interface{}](values, "datadog-agent")
+	var productName string
+	switch flavor {
+	case agentparams.BaseFlavor:
+		productName = "datadog-agent"
+	case agentparams.FIPSFlavor:
+		productName = "datadog-fips-agent"
+	default:
+		return nil, fmt.Errorf("unsupported flavor %v", flavor)
+	}
+
+	versions, err := getKey[map[string]interface{}](values, productName)
 	if err != nil {
 		return nil, err
 	}

--- a/components/datadog/agent/host_windowsos.go
+++ b/components/datadog/agent/host_windowsos.go
@@ -243,14 +243,9 @@ func newAgentURLFinder(installerURL string, flavor string) (*agentURLFinder, err
 		return nil, err
 	}
 
-	var productName string
-	switch flavor {
-	case agentparams.BaseFlavor:
-		productName = "datadog-agent"
-	case agentparams.FIPSFlavor:
-		productName = "datadog-fips-agent"
-	default:
-		return nil, fmt.Errorf("unsupported flavor %v", flavor)
+	productName, err := getFlavorProductName(flavor)
+	if err != nil {
+		return nil, err
 	}
 
 	versions, err := getKey[map[string]interface{}](values, productName)

--- a/components/datadog/agent/host_windowsos.go
+++ b/components/datadog/agent/host_windowsos.go
@@ -172,12 +172,13 @@ func getAgentURLFromPipelineID(version agentparams.PackageVersion) (string, erro
 }
 
 func getFlavorProductName(flavor string) (string, error) {
+	if flavor == "" {
+		flavor = agentparams.DefaultFlavor
+	}
 	switch flavor {
-	case "":
+	case agentparams.BaseFlavor:
 		return "datadog-agent", nil
-	case "base":
-		return "datadog-agent", nil
-	case "fips":
+	case agentparams.FIPSFlavor:
 		return "datadog-fips-agent", nil
 	default:
 		return "", fmt.Errorf("unknown flavor %v", flavor)

--- a/components/datadog/agent/host_windowsos.go
+++ b/components/datadog/agent/host_windowsos.go
@@ -129,9 +129,7 @@ func getAgentURL(version agentparams.PackageVersion) (string, error) {
 
 		url, err := finder.findVersion(fullVersion)
 		if err != nil {
-			// Try to handle custom build
-			minor = strings.TrimSuffix(minor, "-1")
-			return fmt.Sprintf("https://s3.amazonaws.com/dd-agent-mstesting/builds/beta/ddagent-cli-%v.%v.msi", version.Major, minor), nil
+			return "", err
 		}
 
 		return url, nil

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -108,6 +108,13 @@ func WithVersion(version string) func(*Params) error {
 	}
 }
 
+func WithFlavor(flavor string) func(*Params) error {
+	return func(p *Params) error {
+		p.Version.Flavor = flavor
+		return nil
+	}
+}
+
 // WithPipeline use a specific version of the Agent by pipeline id
 func WithPipeline(pipelineID string) func(*Params) error {
 	return func(p *Params) error {

--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -108,6 +108,7 @@ func WithVersion(version string) func(*Params) error {
 	}
 }
 
+// WithFlavor use a specific flavor of the Agent. For example: `fips`
 func WithFlavor(flavor string) func(*Params) error {
 	return func(p *Params) error {
 		p.Version.Flavor = flavor

--- a/components/datadog/agentparams/version.go
+++ b/components/datadog/agentparams/version.go
@@ -8,9 +8,16 @@ const (
 	NightlyChannel channel = "nightly"
 )
 
+const (
+	DefaultFlavor = BaseFlavor
+	BaseFlavor    = "base"
+	FIPSFlavor    = "fips"
+)
+
 type PackageVersion struct {
 	Major      string
 	Minor      string // Empty means latest
 	Channel    channel
 	PipelineID string
+	Flavor     string // Empty means default (base)
 }


### PR DESCRIPTION
What does this PR do?
---------------------
Add `flavor` to Agent `PackageVersion` and agent params

Which scenarios this will impact?
-------------------
Agent Linux + Windows host/vm tests

Motivation
----------
https://datadoghq.atlassian.net/browse/WINA-1222

Additional Notes
----------------
Draft until receive env vars for Linux install script