### PR TITLE
group aws and azure native dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,3 +85,16 @@ updates:
     directory: /components/datadog/apps/cws/images/cws-centos7
     schedule:
       interval: daily
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      aws-sdk-go-v2:
+        patterns:
+          - '^github\.com\/aws\/aws-sdk-go-v2'
+      pulumi-azure-native-sdk:
+        patterns:
+          - '^github\.com\/pulumi\/pulumi-azure-native-sdk'
+      

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,13 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      aws-sdk-go-v2:
+        patterns:
+          - 'github.com/aws/aws-sdk-go-v2*'
+      pulumi-azure-native-sdk:
+        patterns:
+          - 'github.com/pulumi/pulumi-azure-native-sdk*'
 
   - package-ecosystem: pip
     directory: /
@@ -86,15 +93,4 @@ updates:
     schedule:
       interval: daily
 
-  - package-ecosystem: gomod
-    directory: /
-    schedule:
-      interval: weekly
-    groups:
-      aws-sdk-go-v2:
-        patterns:
-          - 'github.com/aws/aws-sdk-go-v2*'
-      pulumi-azure-native-sdk:
-        patterns:
-          - 'github.com/pulumi/pulumi-azure-native-sdk*'
       

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -93,8 +93,8 @@ updates:
     groups:
       aws-sdk-go-v2:
         patterns:
-          - '^github\.com\/aws\/aws-sdk-go-v2'
+          - 'github.com/aws/aws-sdk-go-v2*'
       pulumi-azure-native-sdk:
         patterns:
-          - '^github\.com\/pulumi\/pulumi-azure-native-sdk'
+          - 'github.com/pulumi/pulumi-azure-native-sdk*'
       


### PR DESCRIPTION
What does this PR do?
---------------------

Group together aws-sdk and pulumi-azure-native-sdk dependencies

Which scenarios this will impact?
-------------------

None

Motivation
----------

Prevent pulumi plugins mismatch

Additional Notes
----------------
