### PR TITLE
Fix podman/docker config calling ddtool

### DIFF
--- a/resources/local/podman/vm.go
+++ b/resources/local/podman/vm.go
@@ -20,7 +20,7 @@ type VMArgs struct {
 
 //go:embed data/Dockerfile
 var dockerfileContent string
-var customDockerConfig string = "{}"
+var customDockerConfig = "{}"
 
 func NewInstance(e resourceslocal.Environment, args VMArgs, opts ...pulumi.ResourceOption) (address pulumi.StringOutput, user string, port int, err error) {
 	interpreter := []string{"/bin/bash", "-c"}


### PR DESCRIPTION
What does this PR do?
---------------------

When executing `inv localpodman.create-vm`, it was possible to obtain a timeout on vault with ddtool hook.
Replaced the config by a custom empty config.

> [!NOTE]
> Do we want to be able to customize the config? Maybe it is better to provide an argument to replace by a custom config

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
