### PR TITLE
Update `datadog-go` lib in `dogstatsd` app

### DIFF
--- a/components/datadog/apps/dogstatsd/images/dogstatsd/go.mod
+++ b/components/datadog/apps/dogstatsd/images/dogstatsd/go.mod
@@ -2,12 +2,9 @@ module dogstatsd
 
 go 1.22
 
-require github.com/DataDog/datadog-go/v5 v5.5.0
+require github.com/DataDog/datadog-go/v5 v5.6.0
 
 require (
 	github.com/Microsoft/go-winio v0.5.0 // indirect
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
 )
-
-// Temporary replacement of the main branch until https://github.com/DataDog/datadog-go/pull/304 is released
-replace github.com/DataDog/datadog-go/v5 => github.com/DataDog/datadog-go/v5 v5.5.1-0.20240327105053-fa1f6814eaf7

--- a/components/datadog/apps/dogstatsd/images/dogstatsd/go.sum
+++ b/components/datadog/apps/dogstatsd/images/dogstatsd/go.sum
@@ -1,5 +1,5 @@
-github.com/DataDog/datadog-go/v5 v5.5.1-0.20240327105053-fa1f6814eaf7 h1:pOfzUVqO/rT7VTY9L7qK5oeiuBBIiuZgt0Nf7J3ywDQ=
-github.com/DataDog/datadog-go/v5 v5.5.1-0.20240327105053-fa1f6814eaf7/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
+github.com/DataDog/datadog-go/v5 v5.6.0 h1:2oCLxjF/4htd55piM75baflj/KoE6VYS7alEUqFvRDw=
+github.com/DataDog/datadog-go/v5 v5.6.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/Microsoft/go-winio v0.5.0 h1:Elr9Wn+sGKPlkaBvwu4mTrxtmOp3F3yV9qhaHbXGjwU=
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
What does this PR do?
---------------------

Update the `datadog-go` lib now that `v5.6.0` has been released: https://github.com/DataDog/datadog-go/releases/tag/v5.6.0.

Which scenarios this will impact?
-------------------

Motivation
----------

Get rid of `replace` statement in `go.mod`.

It also fixes an issue where container tags are missing from dogstatsd metrics because the library fails to identify the container: 
![image](https://github.com/user-attachments/assets/efa29448-05e0-44bf-a928-93179b17d638)

Additional Notes
----------------
