### PR TITLE
Fix a missing dependency between VPA CRD and CR

### DIFF
--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -38,9 +38,11 @@ func Run(ctx *pulumi.Context) error {
 		return err
 	}
 
-	if _, err := vpa.DeployCRD(&awsEnv, cluster.KubeProvider); err != nil {
+	vpaCrd, err := vpa.DeployCRD(&awsEnv, cluster.KubeProvider)
+	if err != nil {
 		return err
 	}
+	dependsOnVPA := utils.PulumiDependsOn(vpaCrd)
 
 	if awsEnv.InitOnly() {
 		return nil
@@ -110,11 +112,11 @@ func Run(ctx *pulumi.Context) error {
 
 	// Deploy testing workload
 	if awsEnv.TestingWorkloadDeploy() {
-		if _, err := nginx.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-nginx", "", true, utils.PulumiDependsOn(workloadWithCRDDeps...)); err != nil {
+		if _, err := nginx.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-nginx", "", true, utils.PulumiDependsOn(workloadWithCRDDeps...), dependsOnVPA); err != nil {
 			return err
 		}
 
-		if _, err := redis.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-redis", true, utils.PulumiDependsOn(workloadWithCRDDeps...)); err != nil {
+		if _, err := redis.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-redis", true, utils.PulumiDependsOn(workloadWithCRDDeps...), dependsOnVPA); err != nil {
 			return err
 		}
 

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -69,9 +69,11 @@ func Run(ctx *pulumi.Context) error {
 		return err
 	}
 
-	if _, err := vpa.DeployCRD(&awsEnv, kindKubeProvider); err != nil {
+	vpaCrd, err := vpa.DeployCRD(&awsEnv, kindKubeProvider)
+	if err != nil {
 		return err
 	}
+	dependsOnVPA := utils.PulumiDependsOn(vpaCrd)
 
 	var dependsOnCrd pulumi.ResourceOption
 
@@ -203,11 +205,11 @@ spec:
 
 	// Deploy testing workload
 	if awsEnv.TestingWorkloadDeploy() {
-		if _, err := nginx.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-nginx", "", true, dependsOnCrd); err != nil {
+		if _, err := nginx.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-nginx", "", true, dependsOnCrd, dependsOnVPA); err != nil {
 			return err
 		}
 
-		if _, err := redis.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-redis", true, dependsOnCrd); err != nil {
+		if _, err := redis.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-redis", true, dependsOnCrd, dependsOnVPA); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
What does this PR do?
---------------------

Add an explicit dependency between the pulumi resource that creates the VPA CRD and the ones that create VPA CR.

Which scenarios this will impact?
-------------------

* `aws/eks`
* `aws/kind`

Motivation
----------

Avoid possible race conditions where pulumi would try to create a VPA resource before the definition, leading to [errors](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/737239415#L1495) like:
```
Diagnostics:
  kubernetes:autoscaling.k8s.io/v1beta2:VerticalPodAutoscaler (redis):
    error: creation of resource "urn:pulumi:ci-737239415-4670-orch-kind-cluster::e2eci::pulumi:providers:kubernetes$dd:apps$kubernetes:autoscaling.k8s.io/v1beta2:VerticalPodAutoscaler::redis" with kind autoscaling.k8s.io/v1beta2/VerticalPodAutoscaler failed because the Kubernetes API server reported that the apiVersion for this resource does not exist. Verify that any required CRDs have been created: no matches for kind "VerticalPodAutoscaler" in version "autoscaling.k8s.io/v1beta2"
```

Additional Notes
----------------

* Follow-up of #1282.