### PR TITLE
[gitlab] add manual trigger for bump in datadog-agent

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,7 +100,21 @@ release-runner-image:
     - if: $CI_COMMIT_BRANCH == "main"
       when: on_success
 
-.bump-version-on-datadog-agent:
+bump-version-on-datadog-agent:
+  stage: post-release
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64:v48815877-9bfad02c
+  tags: ["arch:amd64"]
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+      needs: ["release-runner-image"]
+      when: on_success
+    - if: $CI_COMMIT_BRANCH =~ /^mq-working-branch-/
+      when: never
+    - when: manual
+      needs: ["build-runner-image"]
+      allow_failure: true
+      variables:
+        EXTRA_UPDATE_ARGS: "--is-dev-image"
   variables:
     EXTRA_UPDATE_ARGS: ""
   before_script:
@@ -129,28 +143,3 @@ release-runner-image:
     - popd
     - pip install -r requirements.txt
     - inv ci.create-bump-pr-and-close-stale-ones-on-datadog-agent --branch auto-bump/bump-test-infra-$CI_COMMIT_SHORT_SHA --new-commit-sha $CI_COMMIT_SHA --old-commit-sha $PREVIOUS_SHA
-
-bump-version-on-datadog-agent-dev:
-  extends: .bump-version-on-datadog-agent
-  stage: post-release
-  image: ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA}
-  tags: ["arch:amd64"]
-  needs: ["build-runner-image"]
-  rules:
-    - if: $CI_COMMIT_BRANCH == "main"
-      when: never
-    - when: manual
-      allow_failure: true
-  variables:
-    EXTRA_UPDATE_ARGS: "--is-dev-image"
-
-bump-version-on-datadog-agent:
-  extends: .bump-version-on-datadog-agent
-  stage: post-release
-  image: ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA}
-  tags: ["arch:amd64"]
-  needs: ["release-runner-image"]
-  rules:
-    - if: $CI_COMMIT_BRANCH == "main"
-      when: on_success
-  

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,7 +102,7 @@ release-runner-image:
 
 bump-version-on-datadog-agent:
   stage: post-release
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64:v48815877-9bfad02c
+  image: ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA}
   tags: ["arch:amd64"]
   rules:
     - if: $CI_COMMIT_BRANCH == "main"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,7 +122,8 @@ release-runner-image:
     - git checkout -b auto-bump/bump-test-infra-$CI_COMMIT_SHORT_SHA
     - export PREVIOUS_SHA=$(cat .gitlab/common/test_infra_version.yml | grep 'TEST_INFRA_DEFINITIONS_BUILDIMAGES:' | awk -F " " '{print $NF}')
     - inv -e buildimages.update-test-infra-definitions --commit-sha $CI_COMMIT_SHA $EXTRA_UPDATE_ARGS
-    - git add test/new-e2e/go.mod test/new-e2e/go.sum .gitlab/common/test_infra_version.yml
+    - inv -e tidy
+    - git add -u
     - git commit -m "[test-infra-definitions][automated] Bump test-infra-definitions to $CI_COMMIT_SHORT_SHA"
     - git push -f origin auto-bump/bump-test-infra-$CI_COMMIT_SHORT_SHA
     - popd

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,14 +100,9 @@ release-runner-image:
     - if: $CI_COMMIT_BRANCH == "main"
       when: on_success
 
-bump-version-on-datadog-agent:
-  stage: post-release
-  image: ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA}
-  tags: ["arch:amd64"]
-  needs: ["release-runner-image"]
-  rules:
-    - if: $CI_COMMIT_BRANCH == "main"
-      when: on_success
+.bump-version-on-datadog-agent:
+  variables:
+    EXTRA_UPDATE_ARGS: ""
   before_script:
     - set +x
     - export GITHUB_APP_USER_ID=153269286 # Can be found on https://api.github.com/users/agent-platform-auto-pr[bot]
@@ -126,10 +121,35 @@ bump-version-on-datadog-agent:
     - pushd datadog-agent
     - git checkout -b auto-bump/bump-test-infra-$CI_COMMIT_SHORT_SHA
     - export PREVIOUS_SHA=$(cat .gitlab/common/test_infra_version.yml | grep 'TEST_INFRA_DEFINITIONS_BUILDIMAGES:' | awk -F " " '{print $NF}')
-    - inv -e buildimages.update-test-infra-definitions --commit-sha $CI_COMMIT_SHA
+    - inv -e buildimages.update-test-infra-definitions --commit-sha $CI_COMMIT_SHA $EXTRA_UPDATE_ARGS
     - git add test/new-e2e/go.mod test/new-e2e/go.sum .gitlab/common/test_infra_version.yml
     - git commit -m "[test-infra-definitions][automated] Bump test-infra-definitions to $CI_COMMIT_SHORT_SHA"
     - git push -f origin auto-bump/bump-test-infra-$CI_COMMIT_SHORT_SHA
     - popd
     - pip install -r requirements.txt
     - inv ci.create-bump-pr-and-close-stale-ones-on-datadog-agent --branch auto-bump/bump-test-infra-$CI_COMMIT_SHORT_SHA --new-commit-sha $CI_COMMIT_SHA --old-commit-sha $PREVIOUS_SHA
+
+bump-version-on-datadog-agent-dev:
+  extends: .bump-version-on-datadog-agent
+  stage: post-release
+  image: ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA}
+  tags: ["arch:amd64"]
+  needs: ["build-runner-image"]
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+      when: never
+    - when: manual
+      allow_failure: true
+  variables:
+    EXTRA_UPDATE_ARGS: "--is-dev-image"
+
+bump-version-on-datadog-agent:
+  extends: .bump-version-on-datadog-agent
+  stage: post-release
+  image: ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA}
+  tags: ["arch:amd64"]
+  needs: ["release-runner-image"]
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+      when: on_success
+  

--- a/tasks/ci.py
+++ b/tasks/ci.py
@@ -9,12 +9,16 @@ COMMIT_TITLE_REGEX = re.compile(r"\[test-infra-definitions\]\[automated\] Bump t
 
 @task
 def create_bump_pr_and_close_stale_ones_on_datadog_agent(ctx, branch: str, new_commit_sha: str, old_commit_sha: str):
+    is_dev_branch = False
     if os.getenv("CI") != "true":
         print("This task should only be run in CI")
         return
     if os.getenv("GITHUB_TOKEN") is None:
         print("GITHUB_TOKEN is not set")
         return
+    if os.getenv("CI_COMMIT_BRANCH") != "main":
+        print("Running on a dev branch")
+        is_dev_branch = True
 
     repo = Github(auth=Auth.Token(os.environ["GITHUB_TOKEN"])).get_repo("DataDog/datadog-agent")
     pr_body = f"""
@@ -35,6 +39,10 @@ Here is the full changelog between the two commits: https://github.com/DataDog/t
     new_pr.add_to_labels("qa/no-code-change", "changelog/no-changelog", "automatic/test-infra-bump")
 
     print(f"PR created: {new_pr.html_url}")
+
+    if is_dev_branch:
+        print("Skipping stale PRs check since this is a dev branch")
+        return
 
     print("Looking for stale auto bump PRs...")
 


### PR DESCRIPTION
What does this PR do?
---------------------

* Add manual job to trigger a bump of test-infra-definitions in `datadog-agent` from dev branches
* Sync and tidy all go modules in `datadog-agent` 

Which scenarios this will impact?
-------------------

None

Motivation
----------

We often want to check that changes here do not break or fix tests in `datadog-agent`, this should reduce the manual operations to do this

Syncing and tidying all go modules as now `datadog-agent` uses go workspace, thus a bump in `test/new-e2e` might bump deps in other `datadog-agent` modules

Additional Notes
----------------

Requires https://github.com/DataDog/datadog-agent/pull/32245
