### PR TITLE
Revert "Bump docker/library/python from 3.12-slim-bullseye to 3.13-slim-bullseye"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Adapted from https://github.com/pulumi/pulumi-docker-containers/blob/main/docker/pulumi/Dockerfile
 # to minimize image size
 
-FROM public.ecr.aws/docker/library/python:3.13-slim-bullseye AS base
+FROM public.ecr.aws/docker/library/python:3.12-slim-bullseye AS base
 
 ENV GO_VERSION=1.23.3
 ENV GO_SHA=a0afb9744c00648bafb1b90b4aba5bdb86f424f02f9275399ce0c20b93a2c3a8


### PR DESCRIPTION
Reverts DataDog/test-infra-definitions#1174

We're still on Python 3.12 on `datadog-agent` side