### PR TITLE
[aws|azure] do not override osDesc architecture in WithOS

### DIFF
--- a/scenarios/aws/ec2/vmargs.go
+++ b/scenarios/aws/ec2/vmargs.go
@@ -37,10 +37,9 @@ func buildArgs(options ...VMOption) (*vmArgs, error) {
 }
 
 // WithOS sets the OS
-// Architecture defaults to os.AMD64Arch
 // Version defaults to latest
 func WithOS(osDesc os.Descriptor) VMOption {
-	return WithOSArch(osDesc, os.AMD64Arch)
+	return WithOSArch(osDesc, osDesc.Architecture)
 }
 
 // WithArch set the architecture and the operating system.

--- a/scenarios/azure/compute/vmargs.go
+++ b/scenarios/azure/compute/vmargs.go
@@ -36,10 +36,9 @@ func buildArgs(options ...VMOption) (*vmArgs, error) {
 }
 
 // WithOS sets the OS
-// Architecture defaults to os.AMD64Arch
 // Version defaults to latest
 func WithOS(osDesc os.Descriptor) VMOption {
-	return WithOSArch(osDesc, os.AMD64Arch)
+	return WithOSArch(osDesc, osDesc.Architecture)
 }
 
 // WithArch set the architecture and the operating system.


### PR DESCRIPTION
What does this PR do?
---------------------

Use architecture defined in `osDesc` on `WithOS` option

Which scenarios this will impact?
-------------------

azure, aws VMs

Motivation
----------

ADXT-585. Current behaviour was unexpected, the `osDesc` contains a definition for architecture that defaults to amd64, we should not override it

Additional Notes
----------------
