### PR TITLE
Fix image.pullSecrets configuration for NewDDAWithOperator

### DIFF
--- a/components/datadog/apps/dda/datadogagent.go
+++ b/components/datadog/apps/dda/datadogagent.go
@@ -266,22 +266,28 @@ func (d datadogAgentWorkload) defaultDDAYamlTransformations() []yaml.Transformat
 			imgPullSecretOverride := map[string]interface{}{
 				"nodeAgent": map[string]interface{}{
 					"image": map[string]interface{}{
-						"pullSecrets": map[string]interface{}{
-							"name": d.imagePullSecret.Metadata.Name(),
+						"pullSecrets": []map[string]interface{}{
+							{
+								"name": d.imagePullSecret.Metadata.Name(),
+							},
 						},
 					},
 				},
 				"clusterAgent": map[string]interface{}{
 					"image": map[string]interface{}{
-						"pullSecrets": map[string]interface{}{
-							"name": d.imagePullSecret.Metadata.Name(),
+						"pullSecrets": []map[string]interface{}{
+							{
+								"name": d.imagePullSecret.Metadata.Name(),
+							},
 						},
 					},
 				},
 				"clusterChecksRunner": map[string]interface{}{
 					"image": map[string]interface{}{
-						"pullSecrets": map[string]interface{}{
-							"name": d.imagePullSecret.Metadata.Name(),
+						"pullSecrets": []map[string]interface{}{
+							{
+								"name": d.imagePullSecret.Metadata.Name(),
+							},
 						},
 					},
 				},


### PR DESCRIPTION
What does this PR do?
---------------------
Fix the `image.pullSecrets` configuration when creating a new DDA resource with the NewDDAWithOperator component. `image.pullSecrets` should be a list of secret names, not a map.

Which scenarios this will impact?
-------------------

aws/KindVM

Motivation
----------
bugfix

Additional Notes
----------------
