### PR TITLE
[CONTP-547] reduce language detection refresh period to 1 minute

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -344,6 +344,17 @@ func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentI
 			},
 			"containers": pulumi.Map{
 				"agent": pulumi.Map{
+					"env": pulumi.StringMapArray{
+						pulumi.StringMap{
+							// TODO: remove this environment variable override once a retry mechanism is added to the language detection client
+							//
+							// the refresh period is reduced to 1 minute because the language detection client doesn't implement a retry mechanism
+							// if the cluster agent is not available when the client tries to send the first detected language, the language will only
+							// be sent again after 20 minutes (default refresh period). This causes E2E to fail since it only waits 5 minutes.
+							"name":  pulumi.String("DD_LANGUAGE_DETECTION_REPORTING_REFRESH_PERIOD"),
+							"value": pulumi.String("1m"),
+						},
+					},
 					"resources": pulumi.StringMapMap{
 						"requests": pulumi.StringMap{
 							"cpu":    pulumi.String("400m"),


### PR DESCRIPTION
What does this PR do?
---------------------

This PR fixes a flakiness in e2e test (See [here](https://app.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.name%3A%22TestEKSSuite%2FTestAdmissionControllerWithAutoDetectedLanguage%22%20%40test.suite%3A%22github.com%2FDataDog%2Fdatadog-agent%2Ftest%2Fnew-e2e%2Ftests%2Fcontainers%22%20%40git.branch%3Amain%20%40test.service%3Adatadog-agent%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=true&graphType=flamegraph&index=citest&spanViewType=logs&start=1733229830363&end=1735821830363&paused=false)).

Language detection client runs in the core agent, and periodically sends detected languages to the cluster agent. 
When the cluster agent receives a detected language, it patches the related deployment with a language annotation.

The default period is 20 minutes.

If the first detected language is sent before the cluster agent is available, the cluster agent won't receive the detected language until after 20 minutes. This is caused by the absence of a retry mechanism in the language detection client. 

As a result, some assertions in the E2E tests of datadog-agent fail, and are reported as flaky.

The ideal fix would be to implement a retry mechanism in the PLD client. In the meantime, a temporary fix to remove flakiness is to simply reduce the refresh period to 1 minute.

Which scenarios this will impact?
-------------------
All scenarios installing the agent with helm.

Motivation
----------
Fix flakiness in e2e.

Additional Notes
----------------
