### PR TITLE
Expose ssl configuration

### DIFF
--- a/components/datadog/apps/jmxfetch/images/jmx-test-app/run.sh
+++ b/components/datadog/apps/jmxfetch/images/jmx-test-app/run.sh
@@ -4,6 +4,7 @@ set -f
 [ -n "$JAVA_OPTS" ] || JAVA_OPTS="-Xmx128M -Xms128M"
 [ -n "$RMI_PORT" ] || RMI_PORT="9010"
 [ -n "$HOST_NAME" ] || HOST_NAME=`awk 'END{print $1}' /etc/hosts`
+[ -n "$SSL_MODE"] || SSL_MODE="false"
 
 echo "Using `java --version`"
 echo "With JAVA_OPTS '${JAVA_OPTS}'"
@@ -13,6 +14,7 @@ javac -d app SimpleApp.java
 
 echo "Starting app with hostname set to ${HOST_NAME}"
 echo "RMI port is set to ${RMI_PORT}"
+echo "SSL: ${SSL_MODE}"
 
 java -cp ./app \
     ${JAVA_OPTS} \
@@ -20,7 +22,8 @@ java -cp ./app \
     -Dcom.sun.management.jmxremote.port=${RMI_PORT} \
     -Dcom.sun.management.jmxremote.rmi.port=${RMI_PORT} \
     -Dcom.sun.management.jmxremote.authenticate=false \
-    -Dcom.sun.management.jmxremote.ssl=false \
+    -Dcom.sun.management.jmxremote.ssl=${SSL_MODE} \
+    -Dcom.sun.management.jmxremote.registry.ssl=${SSL_MODE} \
     -Djava.rmi.server.hostname=${HOST_NAME} \
     SimpleApp
 


### PR DESCRIPTION
What does this PR do?
---------------------

Expose ssl configuration for jmx test app.

Which scenarios this will impact?
-------------------

agent-metrics-logs/jmxfetch tests.

Motivation
----------

Test jmxfetch with encrypted jmx connection.

Additional Notes
----------------

Since jmx and the registry use the same port, they must have matching ssl configuration to avoid 'port already in use' errors.
