### PR TITLE
[CONTINT-4520] Port the legacy integration docker e2e tests

### DIFF
--- a/components/datadog/apps/redis/docker-compose.yaml
+++ b/components/datadog/apps/redis/docker-compose.yaml
@@ -1,0 +1,26 @@
+---
+version: "3.9"
+
+services:
+
+  redis:
+    image: public.ecr.aws/docker/library/redis:latest
+    container_name: redis
+    command:
+      - --loglevel
+      - verbose
+    ports:
+      - 6379:6379
+
+  redis-query:
+    image: ghcr.io/datadog/apps-redis-client:main
+    container_name: redis-query
+    command:
+      - -min-tps
+      - '1'
+      - -max-tps
+      - '60'
+      - -period
+      - 20m
+    depends_on:
+      - redis

--- a/components/datadog/apps/redis/docker.go
+++ b/components/datadog/apps/redis/docker.go
@@ -1,0 +1,17 @@
+package redis
+
+import (
+	_ "embed"
+
+	"github.com/DataDog/test-infra-definitions/components/docker"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+//go:embed docker-compose.yaml
+var dockerComposeYAML string
+
+var DockerComposeManifest = docker.ComposeInlineManifest{
+	Name:    "redis",
+	Content: pulumi.String(dockerComposeYAML),
+}

--- a/components/datadog/dockeragentparams/params.go
+++ b/components/datadog/dockeragentparams/params.go
@@ -10,6 +10,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	"github.com/DataDog/test-infra-definitions/components/docker"
+	"github.com/samber/lo"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
@@ -240,7 +241,7 @@ func WithExtraComposeManifest(name string, content pulumi.StringInput) func(*Par
 // WithExtraComposeInlineManifest adds extra docker.ComposeInlineManifest
 func WithExtraComposeInlineManifest(cpms ...docker.ComposeInlineManifest) func(*Params) error {
 	return func(p *Params) error {
-		p.ExtraComposeManifests = append(p.ExtraComposeManifests, cpms...)
+		p.ExtraComposeManifests = lo.Uniq(append(p.ExtraComposeManifests, cpms...))
 		return nil
 	}
 }


### PR DESCRIPTION
What does this PR do?
---------------------

Add a `docker-compose.yaml` file for the `redis` workload to be able to use it in the docker scenarios.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------

Used by DataDog/datadog-agent#32895.