### PR TITLE
[ADXT-814] Add `agent-flavor` option to `inv create-vm`

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -38,6 +38,7 @@ const (
 	DDAgentDeployParamName               = "deploy"
 	DDAgentDeployWithOperatorParamName   = "deployWithOperator"
 	DDAgentVersionParamName              = "version"
+	DDAgentFlavorParamName               = "flavor"
 	DDAgentPipelineID                    = "pipeline_id"
 	DDAgentCommitSHA                     = "commit_sha"
 	DDAgentFullImagePathParamName        = "fullImagePath"
@@ -260,6 +261,14 @@ func (e *CommonEnvironment) AgentDeployWithOperator() bool {
 
 func (e *CommonEnvironment) AgentVersion() string {
 	return e.AgentConfig.Get(DDAgentVersionParamName)
+}
+
+func (e *CommonEnvironment) AgentFlavor() string {
+	flavor := e.AgentConfig.Get(DDAgentFlavorParamName)
+
+	panic("flavor: " + flavor)
+
+	return flavor
 }
 
 func (e *CommonEnvironment) PipelineID() string {

--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -264,11 +264,7 @@ func (e *CommonEnvironment) AgentVersion() string {
 }
 
 func (e *CommonEnvironment) AgentFlavor() string {
-	flavor := e.AgentConfig.Get(DDAgentFlavorParamName)
-
-	panic("flavor: " + flavor)
-
-	return flavor
+	return e.AgentConfig.Get(DDAgentFlavorParamName)
 }
 
 func (e *CommonEnvironment) PipelineID() string {

--- a/scenarios/aws/ec2/vm_run.go
+++ b/scenarios/aws/ec2/vm_run.go
@@ -48,6 +48,10 @@ func VMRun(ctx *pulumi.Context) error {
 			agentOptions = append(agentOptions, agentparams.WithFakeintake(fakeintake))
 		}
 
+		if env.AgentFlavor() != "" {
+			agentOptions = append(agentOptions, agentparams.WithFlavor(env.AgentFlavor()))
+		}
+
 		agent, err := agent.NewHostAgent(&env, vm, agentOptions...)
 		if err != nil {
 			return err

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -144,7 +144,13 @@ func newMetalInstance(instanceEnv *InstanceEnvironment, name, arch string, m con
 	// In the context of KMT, this agent runs on the host environment. As such,
 	// it has no knowledge of the individual test VMs, other than as processes in the host machine.
 	if awsEnv.AgentDeploy() {
-		_, err := agent.NewHostAgent(awsEnv, awsInstance, agentparams.WithAgentConfig(datadogAgentConfig), agentparams.WithSystemProbeConfig(systemProbeConfig), agentparams.WithIntegration("oom_kill", oomKillConfig))
+		agentOptions := []agentparams.Option{agentparams.WithAgentConfig(datadogAgentConfig), agentparams.WithSystemProbeConfig(systemProbeConfig), agentparams.WithIntegration("oom_kill", oomKillConfig)}
+
+		if awsEnv.AgentFlavor() != "" {
+			agentOptions = append(agentOptions, agentparams.WithFlavor(awsEnv.AgentFlavor()))
+		}
+
+		_, err := agent.NewHostAgent(awsEnv, awsInstance, agentOptions...)
 		if err != nil {
 			awsEnv.Ctx().Log.Warn(fmt.Sprintf("failed to deploy datadog agent on host instance: %v", err), nil)
 		}

--- a/scenarios/azure/compute/run/vm_run.go
+++ b/scenarios/azure/compute/run/vm_run.go
@@ -39,6 +39,9 @@ func VMRun(ctx *pulumi.Context) error {
 
 			agentOptions = append(agentOptions, agentparams.WithFakeintake(fakeintake))
 		}
+		if env.AgentFlavor() != "" {
+			agentOptions = append(agentOptions, agentparams.WithFlavor(env.AgentFlavor()))
+		}
 		_, err = agent.NewHostAgent(&env, vm, agentOptions...)
 		return err
 	}

--- a/scenarios/gcp/compute/run/vm_run.go
+++ b/scenarios/gcp/compute/run/vm_run.go
@@ -37,6 +37,9 @@ func VMRun(ctx *pulumi.Context) error {
 
 			agentOptions = append(agentOptions, agentparams.WithFakeintake(fakeintake))
 		}
+		if env.AgentFlavor() != "" {
+			agentOptions = append(agentOptions, agentparams.WithFlavor(env.AgentFlavor()))
+		}
 		_, err = agent.NewHostAgent(&env, vm, agentOptions...)
 		return err
 	}

--- a/scenarios/local/podman/run/vm_run.go
+++ b/scenarios/local/podman/run/vm_run.go
@@ -37,6 +37,9 @@ func VMRun(ctx *pulumi.Context) error {
 			}
 			agentOptions = append(agentOptions, agentparams.WithFakeintake(fakeintake))
 		}
+		if env.AgentFlavor() != "" {
+			agentOptions = append(agentOptions, agentparams.WithFlavor(env.AgentFlavor()))
+		}
 		agentOptions = append(agentOptions, agentparams.WithHostname("localpodman-vm"))
 		_, err = agent.NewHostAgent(&env, vm, agentOptions...)
 		return err

--- a/tasks/aks.py
+++ b/tasks/aks.py
@@ -21,6 +21,7 @@ def create_aks(
     install_agent: Optional[bool] = True,
     install_workload: Optional[bool] = True,
     agent_version: Optional[str] = None,
+    agent_flavor: Optional[str] = None,
 ):
     print('This command is deprecated, please use `az.create-aks` instead')
     print("Running `az.create-aks`...")
@@ -33,6 +34,7 @@ def create_aks(
         install_agent=install_agent,
         install_workload=install_workload,
         agent_version=agent_version,
+        agent_flavor=agent_flavor,
     )
 
 

--- a/tasks/aks.py
+++ b/tasks/aks.py
@@ -12,6 +12,7 @@ from . import doc
         "install_workload": doc.install_workload,
         "agent_version": doc.container_agent_version,
         "stack_name": doc.stack_name,
+        "agent_flavor": doc.agent_flavor,
     }
 )
 def create_aks(

--- a/tasks/aws/deploy.py
+++ b/tasks/aws/deploy.py
@@ -33,6 +33,7 @@ def deploy(
     deploy_job: Optional[str] = None,
     full_image_path: Optional[str] = None,
     cluster_agent_full_image_path: Optional[str] = None,
+    agent_flavor: Optional[str] = None,
 ) -> str:
     flags = extra_flags if extra_flags else {}
 
@@ -87,6 +88,7 @@ def deploy(
         use_fakeintake,
         full_image_path,
         cluster_agent_full_image_path,
+        agent_flavor,
     )
 
 

--- a/tasks/aws/docker.py
+++ b/tasks/aws/docker.py
@@ -38,6 +38,7 @@ def create_docker(
     use_loadBalancer: Optional[bool] = False,
     interactive: Optional[bool] = True,
     full_image_path: Optional[str] = None,
+    agent_flavor: Optional[str] = None,
 ):
     """
     Create a docker environment.
@@ -59,6 +60,7 @@ def create_docker(
         use_fakeintake=use_fakeintake,
         extra_flags=extra_flags,
         full_image_path=full_image_path,
+        agent_flavor=agent_flavor,
     )
 
     if interactive:

--- a/tasks/aws/docker.py
+++ b/tasks/aws/docker.py
@@ -25,6 +25,7 @@ scenario_name = "aws/dockervm"
         "use_loadBalancer": doc.use_loadBalancer,
         "interactive": doc.interactive,
         "full_image_path": doc.full_image_path,
+        "agent_flavor": doc.agent_flavor,
     },
 )
 def create_docker(

--- a/tasks/aws/ecs.py
+++ b/tasks/aws/ecs.py
@@ -28,6 +28,7 @@ scenario_name = "aws/ecs"
         "bottlerocket_node_group": doc.bottlerocket_node_group,
         "windows_node_group": doc.windows_node_group,
         "full_image_path": doc.full_image_path,
+        "agent_flavor": doc.agent_flavor,
     }
 )
 def create_ecs(
@@ -43,6 +44,7 @@ def create_ecs(
     bottlerocket_node_group: bool = True,
     windows_node_group: bool = False,
     full_image_path: Optional[str] = None,
+    agent_flavor: Optional[str] = None,
 ):
     """
     Create a new ECS environment.
@@ -65,6 +67,7 @@ def create_ecs(
         agent_version=agent_version,
         extra_flags=extra_flags,
         full_image_path=full_image_path,
+        agent_flavor=agent_flavor,
     )
 
     tool.notify(ctx, "Your ECS cluster is now created")

--- a/tasks/aws/eks.py
+++ b/tasks/aws/eks.py
@@ -49,6 +49,7 @@ def create_eks(
     instance_type: Optional[str] = None,
     full_image_path: Optional[str] = None,
     cluster_agent_full_image_path: Optional[str] = None,
+    agent_flavor: Optional[str] = None,
 ):
     """
     Create a new EKS environment. It lasts around 20 minutes.
@@ -81,6 +82,7 @@ def create_eks(
         extra_flags=extra_flags,
         full_image_path=full_image_path,
         cluster_agent_full_image_path=cluster_agent_full_image_path,
+        agent_flavor=agent_flavor,
     )
 
     tool.notify(ctx, "Your EKS cluster is now created")

--- a/tasks/aws/eks.py
+++ b/tasks/aws/eks.py
@@ -32,6 +32,7 @@ scenario_name = "aws/eks"
         "instance_type": aws_doc.instance_type,
         "full_image_path": doc.full_image_path,
         "cluster_agent_full_image_path": doc.cluster_agent_full_image_path,
+        "agent_flavor": doc.agent_flavor,
     }
 )
 def create_eks(

--- a/tasks/aws/installer.py
+++ b/tasks/aws/installer.py
@@ -22,6 +22,7 @@ def create_installer_lab(
     debug: Optional[bool] = False,
     pipeline_id: Optional[str] = None,
     site: Optional[str] = "datad0g.com",
+    agent_flavor: Optional[str] = None,
 ):
     full_stack_name = deploy(
         ctx,
@@ -31,6 +32,7 @@ def create_installer_lab(
         install_installer=True,
         debug=debug,
         extra_flags={"ddagent:site": site},
+        agent_flavor=agent_flavor,
     )
 
     print(f"Installer lab created: {full_stack_name}")

--- a/tasks/aws/installer.py
+++ b/tasks/aws/installer.py
@@ -15,6 +15,7 @@ scenario_name = "aws/installer"
         "debug": doc.debug,
         "pipeline_id": doc.pipeline_id,
         "site": doc.site,
+        "agent_flavor": doc.agent_flavor,
     }
 )
 def create_installer_lab(

--- a/tasks/aws/kind.py
+++ b/tasks/aws/kind.py
@@ -28,6 +28,7 @@ scenario_name = "aws/kind"
         "interactive": doc.interactive,
         "full_image_path": doc.full_image_path,
         "cluster_agent_full_image_path": doc.cluster_agent_full_image_path,
+        "agent_flavor": doc.agent_flavor,
     }
 )
 def create_kind(

--- a/tasks/aws/kind.py
+++ b/tasks/aws/kind.py
@@ -43,6 +43,7 @@ def create_kind(
     interactive: Optional[bool] = True,
     full_image_path: Optional[str] = None,
     cluster_agent_full_image_path: Optional[str] = None,
+    agent_flavor: Optional[str] = None,
 ):
     """
     Create a kind environment.
@@ -68,6 +69,7 @@ def create_kind(
         app_key_required=True,
         full_image_path=full_image_path,
         cluster_agent_full_image_path=cluster_agent_full_image_path,
+        agent_flavor=agent_flavor,
     )
 
     if interactive:

--- a/tasks/aws/vm.py
+++ b/tasks/aws/vm.py
@@ -46,6 +46,7 @@ remote_hostname = "aws-vm"
         "ssh_user": doc.ssh_user,
         "os_version": doc.os_version,
         "add_known_host": doc.add_known_host,
+        "agent_flavor": doc.agent_flavor,
     }
 )
 def create_vm(

--- a/tasks/aws/vm.py
+++ b/tasks/aws/vm.py
@@ -68,6 +68,7 @@ def create_vm(
     no_verify: Optional[bool] = False,
     ssh_user: Optional[str] = None,
     add_known_host: Optional[bool] = True,
+    agent_flavor: Optional[str] = None,
 ) -> None:
     """
     Create a new virtual machine on aws.
@@ -110,6 +111,7 @@ def create_vm(
         extra_flags=extra_flags,
         use_fakeintake=use_fakeintake,
         deploy_job=deploy_job,
+        agent_flavor=agent_flavor,
     )
 
     if interactive:

--- a/tasks/azure/aks.py
+++ b/tasks/azure/aks.py
@@ -22,6 +22,7 @@ scenario_name = "az/aks"
         "install_workload": doc.install_workload,
         "agent_version": doc.container_agent_version,
         "stack_name": doc.stack_name,
+        "agent_flavor": doc.agent_flavor,
     }
 )
 def create_aks(

--- a/tasks/azure/aks.py
+++ b/tasks/azure/aks.py
@@ -37,6 +37,7 @@ def create_aks(
     full_image_path: Optional[str] = None,
     cluster_agent_full_image_path: Optional[str] = None,
     use_fakeintake: Optional[bool] = False,
+    agent_flavor: Optional[str] = None,
 ):
     """
     Create a new AKS environment. It lasts around 5 minutes.
@@ -66,6 +67,7 @@ def create_aks(
         full_image_path=full_image_path,
         cluster_agent_full_image_path=cluster_agent_full_image_path,
         use_fakeintake=use_fakeintake,
+        agent_flavor=agent_flavor,
     )
 
     if interactive:

--- a/tasks/azure/vm.py
+++ b/tasks/azure/vm.py
@@ -61,6 +61,7 @@ def create_vm(
     no_verify: Optional[bool] = False,
     use_fakeintake: Optional[bool] = False,
     add_known_host: Optional[bool] = True,
+    agent_flavor: Optional[str] = None,
 ) -> None:
     """
     Create a new virtual machine on azure.
@@ -103,6 +104,7 @@ def create_vm(
         debug=debug,
         extra_flags=extra_flags,
         use_fakeintake=use_fakeintake,
+        agent_flavor=agent_flavor,
     )
 
     if interactive:

--- a/tasks/azure/vm.py
+++ b/tasks/azure/vm.py
@@ -40,6 +40,7 @@ remote_hostname = "az-vm"
         "instance_type": azure_doc.instance_type,
         "os_version": doc.os_version,
         "add_known_host": doc.add_known_host,
+        "agent_flavor": doc.agent_flavor,
     }
 )
 def create_vm(

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -27,6 +27,7 @@ def deploy(
     use_fakeintake: Optional[bool] = False,
     full_image_path: Optional[str] = None,
     cluster_agent_full_image_path: Optional[str] = None,
+    agent_flavor: Optional[str] = None,
 ) -> str:
     flags = extra_flags if extra_flags else {}
 
@@ -47,6 +48,7 @@ def deploy(
     flags["scenario"] = scenario_name
     flags["ddagent:pipeline_id"] = pipeline_id
     flags["ddagent:version"] = agent_version
+    flags["ddagent:flavor"] = agent_flavor
     flags["ddagent:fakeintake"] = use_fakeintake
     flags["ddagent:fullImagePath"] = full_image_path
     flags["ddagent:clusterAgentFullImagePath"] = cluster_agent_full_image_path

--- a/tasks/doc.py
+++ b/tasks/doc.py
@@ -32,3 +32,4 @@ os_version: str = "The version of the OS to use (default will be selected depend
 full_image_path: str = "The full image path (registry:tag) of the Agent image to deploy"
 cluster_agent_full_image_path: str = "The full image path (registry:tag) of the Cluster Agent image to deploy"
 add_known_host: str = "Add the host to the known_hosts file (default True)"
+agent_flavor: str = "Use a specific Agent flavor (such as datadog-fips-agent, see PackageFlavor https://github.com/DataDog/agent-release-management/blob/main/generator/const.py)"

--- a/tasks/gcp/gke.py
+++ b/tasks/gcp/gke.py
@@ -21,6 +21,7 @@ scenario_name = "gcp/gke"
         "install_agent": doc.install_agent,
         "agent_version": doc.container_agent_version,
         "stack_name": doc.stack_name,
+        "agent_flavor": doc.agent_flavor,
     }
 )
 def create_gke(

--- a/tasks/gcp/gke.py
+++ b/tasks/gcp/gke.py
@@ -37,6 +37,7 @@ def create_gke(
     cluster_agent_full_image_path: Optional[str] = None,
     use_fakeintake: Optional[bool] = False,
     use_autopilot: Optional[bool] = False,
+    agent_flavor: Optional[str] = None,
 ) -> None:
     """
     Create a new GKE environment.
@@ -67,6 +68,7 @@ def create_gke(
         full_image_path=full_image_path,
         cluster_agent_full_image_path=cluster_agent_full_image_path,
         use_fakeintake=use_fakeintake,
+        agent_flavor=agent_flavor,
     )
 
     if interactive:

--- a/tasks/gcp/vm.py
+++ b/tasks/gcp/vm.py
@@ -68,6 +68,7 @@ def create_vm(
     no_verify: Optional[bool] = False,
     use_fakeintake: Optional[bool] = False,
     add_known_host: Optional[bool] = True,
+    agent_flavor: Optional[str] = None,
 ) -> None:
     """
     Create a new virtual machine on gcp.
@@ -110,6 +111,7 @@ def create_vm(
         debug=debug,
         extra_flags=extra_flags,
         use_fakeintake=use_fakeintake,
+        agent_flavor=agent_flavor,
     )
 
     if interactive:

--- a/tasks/gcp/vm.py
+++ b/tasks/gcp/vm.py
@@ -47,6 +47,7 @@ remote_hostname = "gcp-vm"
         "instance_type": gcp_doc.instance_type,
         "os_version": doc.os_version,
         "add_known_host": doc.add_known_host,
+        "agent_flavor": doc.agent_flavor,
     }
 )
 def create_vm(

--- a/tasks/localpodman/vm.py
+++ b/tasks/localpodman/vm.py
@@ -27,6 +27,7 @@ remote_hostname = "local-podman-vm"
         "use_fakeintake": doc.fakeintake,
         "interactive": doc.interactive,
         "add_known_host": doc.add_known_host,
+        "agent_flavor": doc.agent_flavor,
     }
 )
 def create_vm(

--- a/tasks/localpodman/vm.py
+++ b/tasks/localpodman/vm.py
@@ -40,6 +40,7 @@ def create_vm(
     use_fakeintake: Optional[bool] = False,
     interactive: Optional[bool] = True,
     add_known_host: Optional[bool] = True,
+    agent_flavor: Optional[str] = None,
 ) -> None:
     """
     Create a new virtual machine on local podman.
@@ -68,6 +69,7 @@ def create_vm(
         debug=debug,
         extra_flags=extra_flags,
         use_fakeintake=use_fakeintake,
+        agent_flavor=agent_flavor,
     )
 
     if interactive:

--- a/tasks/vm.py
+++ b/tasks/vm.py
@@ -31,6 +31,7 @@ from . import config, doc, tool
         "no_verify": doc.no_verify,
         "ssh_user": doc.ssh_user,
         "os_version": doc.os_version,
+        "agent_flavor": doc.agent_flavor,
     }
 )
 def create_vm(
@@ -52,6 +53,7 @@ def create_vm(
     instance_type: Optional[str] = None,
     no_verify: Optional[bool] = False,
     ssh_user: Optional[str] = None,
+    agent_flavor: Optional[str] = None,
 ) -> None:
     from tasks.aws.vm import create_vm as create_vm_aws
 
@@ -76,6 +78,7 @@ def create_vm(
         instance_type,
         no_verify,
         ssh_user,
+        agent_flavor=agent_flavor,
     )
 
 


### PR DESCRIPTION
What does this PR do?
---------------------

This adds an option to chose the agent flavor following this [PR](https://github.com/DataDog/test-infra-definitions/pull/1286).

```sh
inv aws.create-vm --agent-flavor datadog-fips-agent --pipeline-id 52797187
```

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
