### PR TITLE
[ADXT-84] Add create-vm option to set agent config

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -58,6 +58,7 @@ const (
 	DDAgentExtraEnvVars                  = "extraEnvVars" // extraEnvVars is expected in the format: <key1>=<value1>,<key2>=<value2>,...
 	DDAgentJMX                           = "jmx"
 	DDAgentFIPS                          = "fips"
+	DDAgentConfigPathParamName           = "configPath"
 
 	// Updater Namespace
 	DDUpdaterParamName = "deploy"
@@ -444,4 +445,19 @@ func (e *CommonEnvironment) AgentFIPS() bool {
 
 func (e *CommonEnvironment) AgentJMX() bool {
 	return e.GetBoolWithDefault(e.AgentConfig, DDAgentJMX, false)
+}
+
+func (e *CommonEnvironment) AgentConfigPath() string {
+	return e.AgentConfig.Get(DDAgentConfigPathParamName)
+}
+
+func (e *CommonEnvironment) CustomAgentConfig() (string, error) {
+	configPath := e.AgentConfigPath()
+	if configPath == "" {
+		return "", fmt.Errorf("agent config path is empty")
+	}
+
+	config, err := os.ReadFile(configPath)
+
+	return string(config), err
 }

--- a/scenarios/aws/ec2/vm_run.go
+++ b/scenarios/aws/ec2/vm_run.go
@@ -52,6 +52,14 @@ func VMRun(ctx *pulumi.Context) error {
 			agentOptions = append(agentOptions, agentparams.WithFlavor(env.AgentFlavor()))
 		}
 
+		if env.AgentConfigPath() != "" {
+			configContent, err := env.CustomAgentConfig()
+			if err != nil {
+				return err
+			}
+			agentOptions = append(agentOptions, agentparams.WithAgentConfig(configContent))
+		}
+
 		agent, err := agent.NewHostAgent(&env, vm, agentOptions...)
 		if err != nil {
 			return err

--- a/scenarios/aws/ec2/vm_run.go
+++ b/scenarios/aws/ec2/vm_run.go
@@ -144,6 +144,15 @@ func VMRunWithDocker(ctx *pulumi.Context) error {
 			agentOptions = append(agentOptions, dockeragentparams.WithFakeintake(fakeintake))
 		}
 
+		// TODO A: Update docker params
+		// if env.AgentConfigPath() != "" {
+		// 	configContent, err := env.CustomAgentConfig()
+		// 	if err != nil {
+		// 		return err
+		// 	}
+		// 	agentOptions = append(agentOptions, dockeragentparams.WithAgentConfig(configContent))
+		// }
+
 		if env.TestingWorkloadDeploy() {
 			agentOptions = append(agentOptions, dockeragentparams.WithExtraComposeManifest(dogstatsd.DockerComposeManifest.Name, dogstatsd.DockerComposeManifest.Content))
 			agentOptions = append(agentOptions, dockeragentparams.WithEnvironmentVariables(pulumi.StringMap{"HOST_IP": vm.Address}))

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -97,6 +97,15 @@ func Run(ctx *pulumi.Context) error {
 			return err
 		}
 
+		// TODO A
+		// if awsEnv.AgentConfigPath() != "" {
+		// 	configContent, err := awsEnv.CustomAgentConfig()
+		// 	if err != nil {
+		// 		return
+		// 	}
+		// 	// ?
+		// }
+
 		if err := k8sAgentComponent.Export(awsEnv.Ctx(), nil); err != nil {
 			return err
 		}

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -133,6 +133,8 @@ agents:
 			return err
 		}
 
+		// TODO A
+
 		if err := k8sAgentComponent.Export(awsEnv.Ctx(), nil); err != nil {
 			return err
 		}
@@ -187,6 +189,8 @@ spec:
 		if err != nil {
 			return err
 		}
+
+		// TODO A: here?
 
 		dependsOnDDAgent = utils.PulumiDependsOn(k8sAgentWithOperatorComp)
 

--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -150,6 +150,15 @@ func newMetalInstance(instanceEnv *InstanceEnvironment, name, arch string, m con
 			agentOptions = append(agentOptions, agentparams.WithFlavor(awsEnv.AgentFlavor()))
 		}
 
+		if awsEnv.AgentConfigPath() != "" {
+			configContent, err := awsEnv.CustomAgentConfig()
+			if err != nil {
+				return nil, err
+			}
+
+			agentOptions = append(agentOptions, agentparams.WithAgentConfig(configContent))
+		}
+
 		_, err := agent.NewHostAgent(awsEnv, awsInstance, agentOptions...)
 		if err != nil {
 			awsEnv.Ctx().Log.Warn(fmt.Sprintf("failed to deploy datadog agent on host instance: %v", err), nil)

--- a/scenarios/azure/aks/run.go
+++ b/scenarios/azure/aks/run.go
@@ -93,6 +93,8 @@ providers:
 			return err
 		}
 
+		// TODO A
+
 		if err := k8sAgentComponent.Export(env.Ctx(), nil); err != nil {
 			return err
 		}

--- a/scenarios/azure/compute/run/vm_run.go
+++ b/scenarios/azure/compute/run/vm_run.go
@@ -42,6 +42,13 @@ func VMRun(ctx *pulumi.Context) error {
 		if env.AgentFlavor() != "" {
 			agentOptions = append(agentOptions, agentparams.WithFlavor(env.AgentFlavor()))
 		}
+		if env.AgentConfigPath() != "" {
+			configContent, err := env.CustomAgentConfig()
+			if err != nil {
+				return err
+			}
+			agentOptions = append(agentOptions, agentparams.WithAgentConfig(configContent))
+		}
 		_, err = agent.NewHostAgent(&env, vm, agentOptions...)
 		return err
 	}

--- a/scenarios/gcp/compute/run/vm_run.go
+++ b/scenarios/gcp/compute/run/vm_run.go
@@ -40,6 +40,13 @@ func VMRun(ctx *pulumi.Context) error {
 		if env.AgentFlavor() != "" {
 			agentOptions = append(agentOptions, agentparams.WithFlavor(env.AgentFlavor()))
 		}
+		if env.AgentConfigPath() != "" {
+			configContent, err := env.CustomAgentConfig()
+			if err != nil {
+				return err
+			}
+			agentOptions = append(agentOptions, agentparams.WithAgentConfig(configContent))
+		}
 		_, err = agent.NewHostAgent(&env, vm, agentOptions...)
 		return err
 	}

--- a/scenarios/gcp/gke/run.go
+++ b/scenarios/gcp/gke/run.go
@@ -80,6 +80,8 @@ func Run(ctx *pulumi.Context) error {
 			return err
 		}
 
+		// TODO A
+
 		if err := k8sAgentComponent.Export(env.Ctx(), nil); err != nil {
 			return err
 		}

--- a/scenarios/local/podman/run/vm_run.go
+++ b/scenarios/local/podman/run/vm_run.go
@@ -41,6 +41,13 @@ func VMRun(ctx *pulumi.Context) error {
 			agentOptions = append(agentOptions, agentparams.WithFlavor(env.AgentFlavor()))
 		}
 		agentOptions = append(agentOptions, agentparams.WithHostname("localpodman-vm"))
+		if env.AgentConfigPath() != "" {
+			configContent, err := env.CustomAgentConfig()
+			if err != nil {
+				return err
+			}
+			agentOptions = append(agentOptions, agentparams.WithAgentConfig(configContent))
+		}
 		_, err = agent.NewHostAgent(&env, vm, agentOptions...)
 		return err
 	}

--- a/tasks/aws/deploy.py
+++ b/tasks/aws/deploy.py
@@ -34,6 +34,7 @@ def deploy(
     full_image_path: Optional[str] = None,
     cluster_agent_full_image_path: Optional[str] = None,
     agent_flavor: Optional[str] = None,
+    agent_config_path: Optional[str] = None,
 ) -> str:
     flags = extra_flags if extra_flags else {}
 
@@ -89,6 +90,7 @@ def deploy(
         full_image_path,
         cluster_agent_full_image_path,
         agent_flavor,
+        agent_config_path,
     )
 
 

--- a/tasks/aws/vm.py
+++ b/tasks/aws/vm.py
@@ -47,6 +47,7 @@ remote_hostname = "aws-vm"
         "os_version": doc.os_version,
         "add_known_host": doc.add_known_host,
         "agent_flavor": doc.agent_flavor,
+        "agent_config_path": doc.agent_config_path,
     }
 )
 def create_vm(
@@ -70,6 +71,7 @@ def create_vm(
     ssh_user: Optional[str] = None,
     add_known_host: Optional[bool] = True,
     agent_flavor: Optional[str] = None,
+    agent_config_path: Optional[str] = None,
 ) -> None:
     """
     Create a new virtual machine on aws.
@@ -113,6 +115,7 @@ def create_vm(
         use_fakeintake=use_fakeintake,
         deploy_job=deploy_job,
         agent_flavor=agent_flavor,
+        agent_config_path=agent_config_path,
     )
 
     if interactive:

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -28,6 +28,7 @@ def deploy(
     full_image_path: Optional[str] = None,
     cluster_agent_full_image_path: Optional[str] = None,
     agent_flavor: Optional[str] = None,
+    agent_config_path: Optional[str] = None,
 ) -> str:
     flags = extra_flags if extra_flags else {}
 
@@ -52,6 +53,7 @@ def deploy(
     flags["ddagent:fakeintake"] = use_fakeintake
     flags["ddagent:fullImagePath"] = full_image_path
     flags["ddagent:clusterAgentFullImagePath"] = cluster_agent_full_image_path
+    flags["ddagent:configPath"] = agent_config_path
 
     if install_agent:
         flags["ddagent:apiKey"] = _get_api_key(cfg)

--- a/tasks/doc.py
+++ b/tasks/doc.py
@@ -33,3 +33,4 @@ full_image_path: str = "The full image path (registry:tag) of the Agent image to
 cluster_agent_full_image_path: str = "The full image path (registry:tag) of the Cluster Agent image to deploy"
 add_known_host: str = "Add the host to the known_hosts file (default True)"
 agent_flavor: str = "Use a specific Agent flavor (such as datadog-fips-agent, see PackageFlavor https://github.com/DataDog/agent-release-management/blob/main/generator/const.py)"
+agent_config_path: str = "Override the config for the Agent from a config file at this location"

--- a/tasks/doc.py
+++ b/tasks/doc.py
@@ -33,4 +33,4 @@ full_image_path: str = "The full image path (registry:tag) of the Agent image to
 cluster_agent_full_image_path: str = "The full image path (registry:tag) of the Cluster Agent image to deploy"
 add_known_host: str = "Add the host to the known_hosts file (default True)"
 agent_flavor: str = "Use a specific Agent flavor (such as datadog-fips-agent, see PackageFlavor https://github.com/DataDog/agent-release-management/blob/main/generator/const.py)"
-agent_config_path: str = "Override the config for the Agent from a config file at this location"
+agent_config_path: str = "Agent config to merge with default config from a file at this location"


### PR DESCRIPTION
What does this PR do?
---------------------

Adds an option that takes a path to set the agent config.
Note that this won't override the default config with the api key but both will be merged together.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
