### PR TITLE
[kind] mount host /sys into kind node

### DIFF
--- a/components/kubernetes/kind-cluster.yaml
+++ b/components/kubernetes/kind-cluster.yaml
@@ -1,10 +1,12 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
-- role: control-plane
-  extraMounts:
-  - hostPath: /proc
-    containerPath: /host/proc
+  - role: control-plane
+    extraMounts:
+      - hostPath: /proc
+        containerPath: /host/proc
+      - hostPath: /sys
+        containerPath: /host/sys
 containerdConfigPatches:
   - |-
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]


### PR DESCRIPTION
What does this PR do?
---------------------

Similarly to #774, the system-probe container needs access to the host /sys filesystem to retrieve cgroup data of processes. This PR hence updates the kind node configuration to mount the host /sys directory into the control-plane container so that it can be propagated to the system-probe container. 

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
