### PR TITLE
[ADXT-84] Add agent environment arg to create vm (docker)

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -55,7 +55,7 @@ const (
 	DDAgentDualShipping                  = "dualshipping"
 	DDAgentSite                          = "site"
 	DDAgentMajorVersion                  = "majorVersion"
-	DDAgentExtraEnvVars                  = "extraEnvVars" // expected in the format: <key1>=<value1>,<key2>=<value2>,...
+	DDAgentExtraEnvVars                  = "extraEnvVars" // extraEnvVars is expected in the format: <key1>=<value1>,<key2>=<value2>,...
 	DDAgentJMX                           = "jmx"
 	DDAgentFIPS                          = "fips"
 

--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -55,7 +55,7 @@ const (
 	DDAgentDualShipping                  = "dualshipping"
 	DDAgentSite                          = "site"
 	DDAgentMajorVersion                  = "majorVersion"
-	DDAgentExtraEnvVars                  = "extraEnvVars" // extraEnvVars is expected in the format: <key1>=<value1>,<key2>=<value2>,...
+	DDAgentExtraEnvVars                  = "extraEnvVars" // expected in the format: <key1>=<value1>,<key2>=<value2>,...
 	DDAgentJMX                           = "jmx"
 	DDAgentFIPS                          = "fips"
 

--- a/components/datadog/dockeragentparams/params.go
+++ b/components/datadog/dockeragentparams/params.go
@@ -61,6 +61,10 @@ func NewParams(e config.Env, options ...Option) (*Params, error) {
 		EnvironmentVariables:    pulumi.StringMap{},
 	}
 
+	for k, v := range e.AgentExtraEnvVars() {
+		version.AgentServiceEnvironment[k] = pulumi.String(v)
+	}
+
 	if e.PipelineID() != "" && e.CommitSHA() != "" {
 		options = append(options,
 			WithFullImagePath(utils.BuildDockerImagePath(

--- a/tasks/aws/deploy.py
+++ b/tasks/aws/deploy.py
@@ -34,6 +34,7 @@ def deploy(
     full_image_path: Optional[str] = None,
     cluster_agent_full_image_path: Optional[str] = None,
     agent_flavor: Optional[str] = None,
+    agent_env: Optional[str] = None,
 ) -> str:
     flags = extra_flags if extra_flags else {}
 
@@ -89,6 +90,7 @@ def deploy(
         full_image_path,
         cluster_agent_full_image_path,
         agent_flavor,
+        agent_env,
     )
 
 

--- a/tasks/aws/docker.py
+++ b/tasks/aws/docker.py
@@ -26,6 +26,7 @@ scenario_name = "aws/dockervm"
         "interactive": doc.interactive,
         "full_image_path": doc.full_image_path,
         "agent_flavor": doc.agent_flavor,
+        "agent_env": doc.agent_env,
     },
 )
 def create_docker(
@@ -40,6 +41,7 @@ def create_docker(
     interactive: Optional[bool] = True,
     full_image_path: Optional[str] = None,
     agent_flavor: Optional[str] = None,
+    agent_env: Optional[str] = None,
 ):
     """
     Create a docker environment.
@@ -62,6 +64,7 @@ def create_docker(
         extra_flags=extra_flags,
         full_image_path=full_image_path,
         agent_flavor=agent_flavor,
+        agent_env=agent_env,
     )
 
     if interactive:

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -28,6 +28,7 @@ def deploy(
     full_image_path: Optional[str] = None,
     cluster_agent_full_image_path: Optional[str] = None,
     agent_flavor: Optional[str] = None,
+    agent_env: Optional[str] = None,
 ) -> str:
     flags = extra_flags if extra_flags else {}
 
@@ -52,6 +53,7 @@ def deploy(
     flags["ddagent:fakeintake"] = use_fakeintake
     flags["ddagent:fullImagePath"] = full_image_path
     flags["ddagent:clusterAgentFullImagePath"] = cluster_agent_full_image_path
+    flags["ddagent:extraEnvVars"] = agent_env
 
     if install_agent:
         flags["ddagent:apiKey"] = _get_api_key(cfg)

--- a/tasks/doc.py
+++ b/tasks/doc.py
@@ -33,3 +33,4 @@ full_image_path: str = "The full image path (registry:tag) of the Agent image to
 cluster_agent_full_image_path: str = "The full image path (registry:tag) of the Cluster Agent image to deploy"
 add_known_host: str = "Add the host to the known_hosts file (default True)"
 agent_flavor: str = "Use a specific Agent flavor (such as datadog-fips-agent, see PackageFlavor https://github.com/DataDog/agent-release-management/blob/main/generator/const.py)"
+agent_env: str = "Extra envionment variables to run the agent with, the format is `VAR1=val1,VAR2=val2`"

--- a/tasks/doc.py
+++ b/tasks/doc.py
@@ -33,4 +33,4 @@ full_image_path: str = "The full image path (registry:tag) of the Agent image to
 cluster_agent_full_image_path: str = "The full image path (registry:tag) of the Cluster Agent image to deploy"
 add_known_host: str = "Add the host to the known_hosts file (default True)"
 agent_flavor: str = "Use a specific Agent flavor (such as datadog-fips-agent, see PackageFlavor https://github.com/DataDog/agent-release-management/blob/main/generator/const.py)"
-agent_env: str = "Extra envionment variables to run the agent with, the format is `VAR1=val1,VAR2=val2`"
+agent_env: str = "Extra environment variables to run the agent with, the format is `VAR1=val1,VAR2=val2`"


### PR DESCRIPTION
What does this PR do?
---------------------

This allows configuring the agent for docker by passing custom environment variables.

**Example**:

```sh
inv aws.create-docker --agent-env=DD_LOG_LEVEL=error,HELLO=world
```

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
