### PR TITLE
Fixed ssh-keyscan error

### DIFF
--- a/tasks/tool.py
+++ b/tasks/tool.py
@@ -269,7 +269,7 @@ def add_known_host(ctx: Context, address: str) -> None:
     """
     # remove the host if it already exists
     clean_known_hosts(ctx, address)
-    result = ctx.run(f"ssh-keyscan {address}", hide=True)
+    result = ctx.run(f"ssh-keyscan {address}", hide=True, warn=True)
     if result and result.ok:
         home = pathlib.Path.home()
         filtered_hosts = '\n'.join([line for line in result.stdout.splitlines() if not line.startswith("#")])


### PR DESCRIPTION
What does this PR do?
---------------------

If the know host was already added, it made the program crash (known host introduced [here](https://github.com/DataDog/test-infra-definitions/commit/4372e330fe39826b544454dadc3fdefc19374db3))

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
