### PR TITLE
Fixed inv destroy issues with clean know host

### DIFF
--- a/tasks/aws/vm.py
+++ b/tasks/aws/vm.py
@@ -141,13 +141,16 @@ def destroy_vm(
     """
     Destroy a new virtual machine on aws.
     """
+
     host = get_host(ctx, remote_hostname, scenario_name, stack_name)
+
     destroy(
         ctx,
         scenario_name=scenario_name,
         config_path=config_path,
         stack=stack_name,
     )
+
     if clean_known_hosts:
         clean_known_hosts_func(ctx, host.address)
 

--- a/tasks/azure/vm.py
+++ b/tasks/azure/vm.py
@@ -134,14 +134,17 @@ def destroy_vm(
     """
     Destroy a new virtual machine on azure.
     """
+
+    host = get_host(ctx, remote_hostname, scenario_name, stack_name)
+
     destroy(
         ctx,
         scenario_name=scenario_name,
         config_path=config_path,
         stack=stack_name,
     )
+
     if clean_known_hosts:
-        host = get_host(ctx, remote_hostname, scenario_name, stack_name)
         clean_known_hosts_func(ctx, host.address)
 
 

--- a/tasks/gcp/vm.py
+++ b/tasks/gcp/vm.py
@@ -141,14 +141,17 @@ def destroy_vm(
     """
     Destroy a new virtual machine on gcp.
     """
+
+    host = get_host(ctx, remote_hostname, scenario_name, stack_name)
+
     destroy(
         ctx,
         scenario_name=scenario_name,
         config_path=config_path,
         stack=stack_name,
     )
+
     if clean_known_hosts:
-        host = get_host(ctx, remote_hostname, scenario_name, stack_name)
         clean_known_hosts_func(ctx, host.address)
 
 

--- a/tasks/localpodman/vm.py
+++ b/tasks/localpodman/vm.py
@@ -99,12 +99,15 @@ def destroy_vm(
     """
     Destroy a new virtual machine on aws.
     """
+
+    host = get_host(ctx, remote_hostname, scenario_name, stack_name)
+
     destroy(
         ctx,
         scenario_name=scenario_name,
         config_path=config_path,
         stack=stack_name,
     )
+
     if clean_known_hosts:
-        host = get_host(ctx, remote_hostname, scenario_name, stack_name)
         clean_known_hosts_func(ctx, host.address)

--- a/tasks/tool.py
+++ b/tasks/tool.py
@@ -269,7 +269,7 @@ def add_known_host(ctx: Context, address: str) -> None:
     """
     # remove the host if it already exists
     clean_known_hosts(ctx, address)
-    result = ctx.run(f"ssh-keyscan {address}", hide=True)
+    result = ctx.run(f"ssh-keyscan {address}", hide=True, warn=True)
     if result and result.ok:
         home = pathlib.Path.home()
         filtered_hosts = '\n'.join([line for line in result.stdout.splitlines() if not line.startswith("#")])


### PR DESCRIPTION
What does this PR do?
---------------------

The `clean_know_hosts` option is now enabled by default but created an error without any stack trace when doing a destroy.
The host couldn't be found after the destroy.
Fixed this

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
