### PR TITLE
Fixed wrong output name for ecs

### DIFF
--- a/tasks/aws/ecs.py
+++ b/tasks/aws/ecs.py
@@ -77,7 +77,7 @@ def create_ecs(
 
 def _show_connection_message(ctx: Context, config_path: Optional[str], full_stack_name: str):
     outputs = tool.get_stack_json_outputs(ctx, full_stack_name)
-    cluster_name = outputs["dd-Cluster-ecs-cluster"]["clusterName"]
+    cluster_name = outputs["dd-Cluster-ecs"]["clusterName"]
 
     try:
         local_config = config.get_local_config(config_path)


### PR DESCRIPTION
What does this PR do?
---------------------

The pulumi output doesn't contain the `-cluster` suffix.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
