### PR TITLE
Fix automatic shutdown in microVMs

### DIFF
--- a/scenarios/aws/microVMs/microvms/run.go
+++ b/scenarios/aws/microVMs/microvms/run.go
@@ -104,7 +104,7 @@ func buildUserData(instanceEnv *InstanceEnvironment, m *config.DDMicroVMConfig) 
 
 	if instanceEnv.DefaultShutdownBehavior() == "terminate" {
 		shutdownPeriod := time.Duration(m.GetIntWithDefault(m.MicroVMConfig, config.DDMicroVMShutdownPeriod, defaultShutdownPeriod)) * time.Minute
-		sb.WriteString(fmt.Sprintf("sudo shutdown -P +%.0f\n", shutdownPeriod.Minutes()))
+		sb.WriteString(fmt.Sprintf("#!/bin/bash\nsudo shutdown -P +%d\n", int(shutdownPeriod.Minutes())))
 	}
 
 	return sb.String()


### PR DESCRIPTION
What does this PR do?
---------------------

This PR fixes the userdata script being executed on the host VM, as it was not configuring the automatic shutdown properly.

Which scenarios this will impact?
-------------------

MicroVMs scenario.

Motivation
----------

Stop long-running instances from not shutting down automatically.

Additional Notes
----------------

Validated by booting a host with the microvms runner and checking with `cat /run/systemd/shutdown/scheduled` that the shutdown is properly scheduled.
