### PR TITLE
microvms: Use ARP to resolve DHCP leases in macOS

### DIFF
--- a/scenarios/aws/microVMs/microvms/libvirt.go
+++ b/scenarios/aws/microVMs/microvms/libvirt.go
@@ -397,7 +397,7 @@ func BuildVMCollections(instances map[string]*Instance, vmsets []vmconfig.VMSet,
 					// We have no network setup on macOS. We use the native vmnet framework
 					// for networking, which is not managed by libvirt but by QEMU. In order to resolve
 					// the IPs, we need to wait and watch the DHCP leases in another goroutine.
-					d.ip = d.mac.ApplyT(waitForBootpDHCPLeases).(pulumi.StringOutput)
+					d.ip = d.mac.ApplyT(waitForDHCPLeases).(pulumi.StringOutput)
 				} else {
 					ip = getNextVMIP(&ip)
 					d.ip = pulumi.Sprintf("%s", ip.String()) // Calling .String() is important, if we don't do that pulumi keeps the reference to IP (a byte array) and not the value itself

--- a/scenarios/aws/microVMs/microvms/network.go
+++ b/scenarios/aws/microVMs/microvms/network.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -216,7 +218,11 @@ func parseBootpDHCPLeases() ([]dhcpLease, error) {
 				return nil, fmt.Errorf("parseBootpDHCPLeases: invalid hw_address format: %s", hwaddr)
 			}
 
-			parsingLease.mac = parts[1]
+			mac, err := normalizeMAC(parts[1])
+			if err != nil {
+				return nil, fmt.Errorf("parseBootpDHCPLeases: error normalizing MAC address: %w", err)
+			}
+			parsingLease.mac = mac
 		}
 		if line == "}" {
 			leases = append(leases, parsingLease)
@@ -227,19 +233,99 @@ func parseBootpDHCPLeases() ([]dhcpLease, error) {
 	return leases, nil
 }
 
+func parseArpDhcpLeases() ([]dhcpLease, error) {
+	var leases []dhcpLease
+
+	cmd := exec.Command("arp", "-a", "-n")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("cannot run arp command (arp -an): %w", err)
+	}
+
+	lines := strings.Split(string(out), "\n")
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+
+		lease, err := parseArpLine(line)
+		if err == nil {
+			return nil, fmt.Errorf("error parsing line %s: %w", line, err)
+		}
+
+		leases = append(leases, lease)
+	}
+
+	return leases, nil
+}
+
+func parseArpLine(line string) (dhcpLease, error) {
+	// Single lease format, for reference:
+	// ? (10.211.55.4) at 0:1c:42:a:70:b on bridge100 ifscope [bridge]
+	parts := strings.Fields(line)
+	if len(parts) < 4 {
+		return dhcpLease{}, fmt.Errorf("line %s has not enough fields", line)
+	}
+
+	ip := strings.Trim(parts[1], "()")
+	mac, err := normalizeMAC(parts[3])
+	if err != nil {
+		return dhcpLease{}, fmt.Errorf("error normalizing MAC address: %w", err)
+	}
+
+	return dhcpLease{
+		ip:  ip,
+		mac: mac,
+	}, nil
+}
+
+// normalizeMAC normalizes a MAC address to the format XX:XX:XX:XX:XX:XX, in lowercase and with leading zeros
+func normalizeMAC(mac string) (string, error) {
+	parts := strings.Split(mac, ":")
+	if len(parts) != 6 {
+		return "", fmt.Errorf("normalizeMAC: invalid MAC address %s, not enough fields", mac)
+	}
+
+	normalizedParts := make([]string, 6)
+	for i, part := range parts {
+		num, err := strconv.ParseInt(part, 16, 64)
+		if err != nil {
+			return "", fmt.Errorf("normalizeMAC: invalid MAC address %s, cannot parse %s: %w", mac, part, err)
+		}
+		normalizedParts[i] = fmt.Sprintf("%02x", num)
+	}
+
+	return strings.Join(normalizedParts, ":"), nil
+}
+
 // waitForBootpDHCPLeases waits for the macOS DHCP server (BootP) to assign an IP address to the VM based on its MAC address, and
 // returns that IP address.
 func waitForBootpDHCPLeases(mac string) (string, error) {
+	mac, err := normalizeMAC(mac)
+	if err != nil {
+		return "", fmt.Errorf("waitForBootpDHCPLeases: invalid MAC address: %w", err)
+	}
+
 	// The DHCP server will assign an IP address to the VM based on its MAC address, wait until it is assigned
 	// and then return the IP address.
 	maxWait := 5 * time.Minute
 	interval := 500 * time.Millisecond
 	for totalWait := 0 * time.Second; totalWait < maxWait; totalWait += interval {
+		// Try to get the address asignment from the DHCP lease and also via ARP. The reason is that
+		// it seems that sometimes the DHCP lease will not include the correct mac address but will
+		// use another type of identifier. Combining the DHCP lease and ARP address table should
+		// give us more coverage to find the correct IP address.
 		leases, err := parseBootpDHCPLeases()
-
 		if err != nil {
 			return "", fmt.Errorf("waitForBootpDHCPLeases: error parsing leases: %s", err)
 		}
+
+		arpLeases, err := parseArpDhcpLeases()
+		if err != nil {
+			return "", fmt.Errorf("waitForBootpDHCPLeases: error parsing arp leases: %s", err)
+		}
+
+		leases = append(leases, arpLeases...)
 
 		for _, lease := range leases {
 			if lease.mac == mac {

--- a/scenarios/aws/microVMs/microvms/network.go
+++ b/scenarios/aws/microVMs/microvms/network.go
@@ -218,6 +218,11 @@ func parseBootpDHCPLeases() ([]dhcpLease, error) {
 				return nil, fmt.Errorf("parseBootpDHCPLeases: invalid hw_address format: %s", hwaddr)
 			}
 
+			if parts[0] != "1" {
+				// Only parse Ethernet MAC addresses, which are identified by the first part being 1.
+				continue
+			}
+
 			mac, err := normalizeMAC(parts[1])
 			if err != nil {
 				return nil, fmt.Errorf("parseBootpDHCPLeases: error normalizing MAC address: %w", err)
@@ -249,8 +254,10 @@ func parseArpDhcpLeases() ([]dhcpLease, error) {
 		}
 
 		lease, err := parseArpLine(line)
-		if err == nil {
-			return nil, fmt.Errorf("error parsing line %s: %w", line, err)
+		if err != nil {
+			// Ignore invalid lines
+			fmt.Printf("warning: error parsing arp line: %v\n", err)
+			continue
 		}
 
 		leases = append(leases, lease)

--- a/scenarios/aws/microVMs/microvms/network.go
+++ b/scenarios/aws/microVMs/microvms/network.go
@@ -298,9 +298,9 @@ func normalizeMAC(mac string) (string, error) {
 	return strings.Join(normalizedParts, ":"), nil
 }
 
-// waitForBootpDHCPLeases waits for the macOS DHCP server (BootP) to assign an IP address to the VM based on its MAC address, and
+// waitForDHCPLeases waits for the macOS DHCP server (BootP) to assign an IP address to the VM based on its MAC address, and
 // returns that IP address.
-func waitForBootpDHCPLeases(mac string) (string, error) {
+func waitForDHCPLeases(mac string) (string, error) {
 	mac, err := normalizeMAC(mac)
 	if err != nil {
 		return "", fmt.Errorf("waitForBootpDHCPLeases: invalid MAC address: %w", err)

--- a/scenarios/aws/microVMs/microvms/network.go
+++ b/scenarios/aws/microVMs/microvms/network.go
@@ -286,7 +286,9 @@ func parseArpLine(line string) (dhcpLease, error) {
 	}, nil
 }
 
-// normalizeMAC normalizes a MAC address to the format XX:XX:XX:XX:XX:XX, in lowercase and with leading zeros
+// normalizeMAC normalizes a MAC address to the format XX:XX:XX:XX:XX:XX, in lowercase and with leading zeros.
+// We need to use this custom function instead of net.ParseMAC because the latter does not support MAC addresses
+// without leading zeros, which is the format that we can find in both the BootP and the ARP tables.
 func normalizeMAC(mac string) (string, error) {
 	parts := strings.Split(mac, ":")
 	if len(parts) != 6 {

--- a/scenarios/aws/microVMs/microvms/network.go
+++ b/scenarios/aws/microVMs/microvms/network.go
@@ -295,16 +295,16 @@ func normalizeMAC(mac string) (string, error) {
 		return "", fmt.Errorf("normalizeMAC: invalid MAC address %s, not enough fields", mac)
 	}
 
-	normalizedParts := make([]string, 6)
+	var addr net.HardwareAddr = make([]byte, 6)
 	for i, part := range parts {
-		num, err := strconv.ParseInt(part, 16, 64)
+		num, err := strconv.ParseInt(part, 16, 8)
 		if err != nil {
 			return "", fmt.Errorf("normalizeMAC: invalid MAC address %s, cannot parse %s: %w", mac, part, err)
 		}
-		normalizedParts[i] = fmt.Sprintf("%02x", num)
+		addr[i] = byte(num)
 	}
 
-	return strings.Join(normalizedParts, ":"), nil
+	return addr.String(), nil
 }
 
 // waitForDHCPLeases waits for the macOS DHCP server (BootP) to assign an IP address to the VM based on its MAC address, and

--- a/scenarios/aws/microVMs/microvms/network.go
+++ b/scenarios/aws/microVMs/microvms/network.go
@@ -308,7 +308,7 @@ func normalizeMAC(mac string) (string, error) {
 // waitForDHCPLeases waits for the macOS DHCP server (BootP) to assign an IP address to the VM based on its MAC address, and
 // returns that IP address.
 func waitForDHCPLeases(mac string) (string, error) {
-	mac, err := normalizeMAC(mac)
+	normalizedMac, err := normalizeMAC(mac)
 	if err != nil {
 		return "", fmt.Errorf("waitForBootpDHCPLeases: invalid MAC address: %w", err)
 	}
@@ -335,7 +335,7 @@ func waitForDHCPLeases(mac string) (string, error) {
 		leases = append(leases, arpLeases...)
 
 		for _, lease := range leases {
-			if lease.mac == mac {
+			if lease.mac == normalizedMac {
 				return lease.ip, nil
 			}
 		}

--- a/scenarios/aws/microVMs/microvms/network.go
+++ b/scenarios/aws/microVMs/microvms/network.go
@@ -334,11 +334,20 @@ func waitForDHCPLeases(mac string) (string, error) {
 
 		leases = append(leases, arpLeases...)
 
+		foundIP := ""
 		for _, lease := range leases {
 			if lease.mac == normalizedMac {
-				return lease.ip, nil
+				if foundIP != "" && foundIP != lease.ip {
+					return "", fmt.Errorf("waitForBootpDHCPLeases: found multiple conflicting leases for MAC %s: %s and %s", mac, foundIP, lease.ip)
+				}
+				foundIP = lease.ip
 			}
 		}
+
+		if foundIP != "" {
+			return foundIP, nil
+		}
+
 		time.Sleep(interval)
 	}
 	return "", fmt.Errorf("waitForBootpDHCPLeases: timed out waiting for lease")

--- a/scenarios/aws/microVMs/microvms/network_test.go
+++ b/scenarios/aws/microVMs/microvms/network_test.go
@@ -18,7 +18,7 @@ func TestParseArpLine(t *testing.T) {
 			line: "? (10.211.55.4) at 0:1c:42:a:70:b on bridge100 ifscope [bridge]",
 			want: dhcpLease{
 				ip:  "10.211.55.4",
-				mac: "0:1c:42:a:70:b",
+				mac: "00:1c:42:0a:70:0b",
 			},
 		},
 		{
@@ -26,7 +26,7 @@ func TestParseArpLine(t *testing.T) {
 			line: "agent-dev-ubuntu-22.shared (10.211.55.4) at 0:1c:42:a:70:b on bridge100 ifscope [bridge]",
 			want: dhcpLease{
 				ip:  "10.211.55.4",
-				mac: "0:1c:42:a:70:b",
+				mac: "00:1c:42:0a:70:0b",
 			},
 		},
 		{

--- a/scenarios/aws/microVMs/microvms/network_test.go
+++ b/scenarios/aws/microVMs/microvms/network_test.go
@@ -1,0 +1,87 @@
+package microvms
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseArpLine(t *testing.T) {
+	cases := []struct {
+		name      string
+		line      string
+		want      dhcpLease
+		wantError bool
+	}{
+		{
+			name: "valid line",
+			line: "? (10.211.55.4) at 0:1c:42:a:70:b on bridge100 ifscope [bridge]",
+			want: dhcpLease{
+				ip:  "10.211.55.4",
+				mac: "0:1c:42:a:70:b",
+			},
+		},
+		{
+			name: "line with hostname",
+			line: "agent-dev-ubuntu-22.shared (10.211.55.4) at 0:1c:42:a:70:b on bridge100 ifscope [bridge]",
+			want: dhcpLease{
+				ip:  "10.211.55.4",
+				mac: "0:1c:42:a:70:b",
+			},
+		},
+		{
+			name:      "invalid mac address",
+			line:      "? (1.2.3.4) at 0:1c:42:a:70 on bridge100 ifscope [bridge]",
+			wantError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lease, err := parseArpLine(tc.line)
+			if tc.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.want, lease)
+			}
+		})
+	}
+}
+
+func TestNormalizeMAC(t *testing.T) {
+	cases := []struct {
+		name string
+		mac  string
+		want string
+	}{
+		{
+			name: "lowercase",
+			mac:  "0:1c:42:a:70:b",
+			want: "00:1c:42:0a:70:0b",
+		},
+		{
+			name: "uppercase",
+			mac:  "0:1C:42:A:70:B",
+			want: "00:1c:42:0a:70:0b",
+		},
+		{
+			name: "invalid",
+			mac:  "0:1c:42:a:70",
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := normalizeMAC(tc.mac)
+			if tc.want == "" {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.want, actual)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
What does this PR do?
---------------------

This PR adds ARP table querying as an additional source to listen for DHCP leases. In some cases we've seen that the `dhcpd_leases` file contains hardware identifiers that are not MAC addresses  (see [RFC 2132](https://www.rfc-editor.org/rfc/rfc2132#section-9), section 9.14, where it's specified that DHCP client IDs might not always be Ethernet addresses) which means we cannot extract the MAC address for the new VM from there. The ARP table should have information in those cases, as we do have a DHCP lease and the IP-MAC assignment should be present in the table.

Which scenarios this will impact?
-------------------

microvms

Motivation
----------

Additional Notes
----------------

Tested locally in macOS by launching a KMT local instance.
