### PR TITLE
Enable collection of CRDs/apiservices in KSM config

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -447,8 +447,10 @@ func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentI
 					"instances": []map[string]interface{}{
 						{
 							"collectors": []string{
+								"apiservices",
 								"secrets",
 								"configmaps",
+								"customresourcedefinitions",
 								"nodes",
 								"pods",
 								"services",


### PR DESCRIPTION
What does this PR do?
---------------------
Enable collection of `customresourcedefinitions` and `apiservices` in `kubernetes_state_core` check.

Which scenarios this will impact?
-------------------
`aws/eks`
`aws/kind`

Motivation
----------
These resources are collected by default in the operator. This change brings us closer to mimic-ing customer environments to allow us to catch any regressions quicker. 

Additional Notes
----------------
Tested this update, and ensured current e2e tests pass: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/55468209