### PR TITLE
Add info about wether FIPS should be enabled or not in Agent components

### DIFF
--- a/components/datadog/agent/docker.go
+++ b/components/datadog/agent/docker.go
@@ -23,6 +23,7 @@ type DockerAgentOutput struct {
 
 	DockerManager docker.ManagerOutput `json:"dockerManager"`
 	ContainerName string               `json:"containerName"`
+	FIPSEnabled   bool                 `json:"fipsEnabled"`
 }
 
 // DockerAgent is a Docker installer on a remote Host
@@ -32,6 +33,7 @@ type DockerAgent struct {
 
 	DockerManager *docker.Manager     `pulumi:"dockerManager"`
 	ContainerName pulumi.StringOutput `pulumi:"containerName"`
+	FIPSEnabled   pulumi.BoolOutput   `pulumi:"fipsEnabled"`
 }
 
 func (h *DockerAgent) Export(ctx *pulumi.Context, out *DockerAgentOutput) error {
@@ -45,6 +47,7 @@ func NewDockerAgent(e config.Env, vm *remoteComp.Host, manager *docker.Manager, 
 			return err
 		}
 
+		comp.FIPSEnabled = pulumi.Bool(e.AgentFIPS() || params.FIPS).ToBoolOutput()
 		fullImagePath := params.FullImagePath
 		if fullImagePath == "" {
 			fullImagePath = dockerAgentFullImagePath(e, params.Repository, params.ImageTag, false, params.FIPS, params.JMX)
@@ -72,6 +75,7 @@ func NewDockerAgent(e config.Env, vm *remoteComp.Host, manager *docker.Manager, 
 		}
 
 		// Fill component
+		comp.FIPSEnabled = pulumi.Bool(params.FIPS).ToBoolOutput()
 		comp.DockerManager = manager
 		comp.ContainerName = pulumi.String(agentContainerName).ToStringOutput()
 

--- a/components/datadog/agent/helm/kubernetes_agent.go
+++ b/components/datadog/agent/helm/kubernetes_agent.go
@@ -18,6 +18,8 @@ func NewKubernetesAgent(e config.Env, resourceName string, kubeProvider *kuberne
 		if err != nil {
 			return err
 		}
+		comp.FIPSEnabled = pulumi.Bool(e.AgentFIPS() || params.FIPS).ToBoolOutput()
+
 		pulumiResourceOptions := append(params.PulumiResourceOptions, pulumi.Parent(comp))
 
 		helmComponent, err := agent.NewHelmInstallation(e, agent.HelmInstallationArgs{

--- a/components/datadog/agent/host.go
+++ b/components/datadog/agent/host.go
@@ -20,7 +20,8 @@ import (
 type HostAgentOutput struct {
 	components.JSONImporter
 
-	Host remoteComp.HostOutput `json:"host"`
+	Host        remoteComp.HostOutput `json:"host"`
+	FIPSEnabled bool                  `json:"fipsEnabled"`
 }
 
 // HostAgent is an installer for the Agent on a remote host
@@ -31,7 +32,8 @@ type HostAgent struct {
 	namer   namer.Namer
 	manager agentOSManager
 
-	Host *remoteComp.Host `pulumi:"host"`
+	Host        *remoteComp.Host  `pulumi:"host"`
+	FIPSEnabled pulumi.BoolOutput `pulumi:"fipsEnabled"`
 }
 
 func (h *HostAgent) Export(ctx *pulumi.Context, out *HostAgentOutput) error {
@@ -49,6 +51,8 @@ func NewHostAgent(e config.Env, host *remoteComp.Host, options ...agentparams.Op
 		if err != nil {
 			return err
 		}
+
+		comp.FIPSEnabled = pulumi.Bool(e.AgentFIPS()).ToBoolOutput()
 
 		deps := append(params.ResourceOptions, pulumi.Parent(comp))
 		err = comp.installAgent(e, params, deps...)

--- a/components/datadog/agent/kubernetes.go
+++ b/components/datadog/agent/kubernetes.go
@@ -17,6 +17,8 @@ type KubernetesAgentOutput struct {
 	WindowsNodeAgent     kubernetes.KubernetesObjRefOutput `json:"windowsNodeAgent"`
 	WindowsClusterAgent  kubernetes.KubernetesObjRefOutput `json:"windowsClusterAgent"`
 	WindowsClusterChecks kubernetes.KubernetesObjRefOutput `json:"windowsClusterChecks"`
+
+	FIPSEnabled bool `json:"fipsEnabled"`
 }
 
 // KubernetesAgent is an installer to install the Datadog Agent on a Kubernetes cluster.
@@ -31,6 +33,8 @@ type KubernetesAgent struct {
 	WindowsNodeAgent     *kubernetes.KubernetesObjectRef `pulumi:"windowsNodeAgent"`
 	WindowsClusterAgent  *kubernetes.KubernetesObjectRef `pulumi:"windowsClusterAgent"`
 	WindowsClusterChecks *kubernetes.KubernetesObjectRef `pulumi:"windowsClusterChecks"`
+
+	FIPSEnabled pulumi.BoolOutput `pulumi:"fipsEnabled"`
 }
 
 func (h *KubernetesAgent) Export(ctx *pulumi.Context, out *KubernetesAgentOutput) error {


### PR DESCRIPTION
What does this PR do?
---------------------

Expose information about wether FIPS should be enabled or not in the agent.
Since several method are available to enable FIPS, through environment variable or using `WithFIPS` flag, we do not have any way to know if FIPS is enabled or not in tests.
With that the Agent should contains an input indicating if FIPS is supposed to be enabled

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
