### PR TITLE
set dca loglevel to trace

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -440,6 +440,13 @@ func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentI
 					"name":  pulumi.String("DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INJECT_AUTO_DETECTED_LIBRARIES"),
 					"value": pulumi.String("true"),
 				},
+				// The loglevel is set to trace in order to debug a flaky e2e in the
+				// language detection handler/patcher.
+				// TODO: remove when done.
+				pulumi.StringMap{
+					"name":  pulumi.String("DD_LOG_LEVEL"),
+					"value": pulumi.String("TRACE"),
+				},
 			},
 			"confd": pulumi.StringMap{
 				"kubernetes_state_core.yaml": pulumi.String(utils.YAMLMustMarshal(map[string]interface{}{


### PR DESCRIPTION
What does this PR do?
---------------------

See title.

Which scenarios this will impact?
-------------------

Any scenario deploying the cluster agent with helm.

Motivation
----------

Debug e2e test.

The trace logs was added in [this](https://github.com/DataDog/datadog-agent/pull/34055) PR.

Additional Notes
----------------

This is a temporary change. Can be reverted once the investigation is done.

I tried to see if I can override the loglevel in the dd-agent repo directly but couldn't figure out a straight forward way.
