### PR TITLE
Revert default to ubuntu22

### DIFF
--- a/components/os/linux_descriptors.go
+++ b/components/os/linux_descriptors.go
@@ -2,8 +2,8 @@ package os
 
 // Implements commonly used descriptors for easier usage
 var (
+	UbuntuDefault = Ubuntu2204
 	Ubuntu2404    = NewDescriptor(Ubuntu, "24.04")
-	UbuntuDefault = Ubuntu2404
 	Ubuntu2204    = NewDescriptor(Ubuntu, "22.04")
 
 	DebianDefault = Debian12


### PR DESCRIPTION
What does this PR do?
---------------------
Expose Ubuntu 2404 but still use 2204 as default because it breaks a lot of test otherwise

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
