### PR TITLE
Use patched AMI for Ubuntu 22

### DIFF
--- a/scenarios/aws/ec2/os_resolver.go
+++ b/scenarios/aws/ec2/os_resolver.go
@@ -141,6 +141,14 @@ func resolveUbuntuAMI(e aws.Environment, osInfo *os.Descriptor) (string, error) 
 		volumeType = "ebs-gp3"
 	}
 
+	// PATCH: Ubuntu 22.04 has a bugged version of curl. Use our own patched AMI instead
+	if osInfo.Version == "22.04" {
+		if paramArch == os.ARM64Arch {
+			return "ami-07e8e5f83dd25f929", nil
+		}
+		return "ami-0c6d6caaaa95d1d0c", nil
+	}
+
 	return ec2.GetAMIFromSSM(e, fmt.Sprintf("/aws/service/canonical/ubuntu/server/%s/stable/current/%s/hvm/%s/ami-id", osInfo.Version, paramArch, volumeType))
 }
 


### PR DESCRIPTION
What does this PR do?
---------------------

The curl version in Ubuntu seems to be buggy: https://stackoverflow.com/questions/72627218/openssl-error-messages-error0a000126ssl-routinesunexpected-eof-while-readin
It should reduce flakiness in our e2e tests

Images generated with: https://gitlab.ddbuild.io/DataDog/ami-builder/-/pipelines/56995600

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
