### PR TITLE
Improve disable-unattended-upgrade script to also disable apt daily upgrade

### DIFF
--- a/components/os/scripts/apt-disable-unattended-upgrades.sh
+++ b/components/os/scripts/apt-disable-unattended-upgrades.sh
@@ -1,2 +1,14 @@
 #!/bin/bash
 apt-get -y remove unattended-upgrades
+sudo systemctl disable unattented-upgrades.service
+sudo systemctl stop unattented-upgrades.service
+
+sudo systemctl disable apt-daily.service
+sudo systemctl disable apt-daily.timer
+sudo systemctl stop apt-daily.service
+sudo systemctl stop apt-daily.timer
+
+sudo systemctl disable apt-daily-upgrade.service
+sudo systemctl disable apt-daily-upgrade.timer
+sudo systemctl stop apt-daily-upgrade.service
+sudo systemctl stop apt-daily-upgrade.timer


### PR DESCRIPTION
What does this PR do?
---------------------

Update user data script to remove systemd unit that can trigger updates of apt, picking lock and introducing flakiness


Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
