### PR TITLE
Disabling automatic update should not fail provisioning if it has no effect

### DIFF
--- a/components/os/scripts/apt-disable-unattended-upgrades.sh
+++ b/components/os/scripts/apt-disable-unattended-upgrades.sh
@@ -6,7 +6,7 @@ sudo systemctl disable unattented-upgrades.service || true
 sudo systemctl stop unattented-upgrades.service || true
 
 sudo systemctl disable apt-daily.service || true
-sudo systemctl disable apt-daily.time || truer
+sudo systemctl disable apt-daily.time || true
 sudo systemctl stop apt-daily.service || true
 sudo systemctl stop apt-daily.timer || true
 

--- a/components/os/scripts/apt-disable-unattended-upgrades.sh
+++ b/components/os/scripts/apt-disable-unattended-upgrades.sh
@@ -1,2 +1,16 @@
 #!/bin/bash
 apt-get -y remove unattended-upgrades
+
+# Try to disable unattended upgrades and apt automatic updates, should not fail if it is not installed
+sudo systemctl disable unattented-upgrades.service || true
+sudo systemctl stop unattented-upgrades.service || true
+
+sudo systemctl disable apt-daily.service || true
+sudo systemctl disable apt-daily.time || truer
+sudo systemctl stop apt-daily.service || true
+sudo systemctl stop apt-daily.timer || true
+
+sudo systemctl disable apt-daily-upgrade.service || true
+sudo systemctl disable apt-daily-upgrade.timer || true
+sudo systemctl stop apt-daily-upgrade.service || true
+sudo systemctl stop apt-daily-upgrade.timer || true


### PR DESCRIPTION
What does this PR do?
---------------------

Make sure user script does not fail provisioning if automatic updates are already disabled or the script is not relevant for the platform

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
