### PR TITLE
Add support for NVIDIA nvkind cluster

### DIFF
--- a/components/kubernetes/kind.go
+++ b/components/kubernetes/kind.go
@@ -45,22 +45,12 @@ func NewKindCluster(env config.Env, vm *remote.Host, name string, kubeVersion st
 		}
 		opts = utils.MergeOptions(opts, utils.PulumiDependsOn(dockerManager, curlCommand))
 
-		kindVersionConfig, err := getKindVersionConfig(kubeVersion)
+		kindVersionConfig, err := GetKindVersionConfig(kubeVersion)
 		if err != nil {
 			return err
 		}
 
-		kindArch := vm.OS.Descriptor().Architecture
-		if kindArch == os.AMD64Arch {
-			kindArch = "amd64"
-		}
-		kindInstall, err := runner.Command(
-			commonEnvironment.CommonNamer().ResourceName("kind-install"),
-			&command.Args{
-				Create: pulumi.Sprintf(`curl --retry 10 -fsSLo ./kind "https://kind.sigs.k8s.io/dl/%s/kind-linux-%s" && sudo install kind /usr/local/bin/kind`, kindVersionConfig.kindVersion, kindArch),
-			},
-			opts...,
-		)
+		kindInstall, err := InstallKindBinary(env, vm, kindVersionConfig.KindVersion, opts...)
 		if err != nil {
 			return err
 		}
@@ -73,7 +63,7 @@ func NewKindCluster(env config.Env, vm *remote.Host, name string, kubeVersion st
 			return err
 		}
 
-		nodeImage := fmt.Sprintf("%s/%s:%s", env.InternalDockerhubMirror(), kindNodeImageName, kindVersionConfig.nodeImageVersion)
+		nodeImage := fmt.Sprintf("%s/%s:%s", env.InternalDockerhubMirror(), kindNodeImageName, kindVersionConfig.NodeImageVersion)
 		createCluster, err := runner.Command(
 			commonEnvironment.CommonNamer().ResourceName("kind-create-cluster"),
 			&command.Args{
@@ -116,7 +106,7 @@ func NewLocalKindCluster(env config.Env, name string, kubeVersion string, opts .
 		opts = utils.MergeOptions[pulumi.ResourceOption](opts, pulumi.Parent(clusterComp))
 		commonEnvironment := env
 
-		kindVersionConfig, err := getKindVersionConfig(kubeVersion)
+		kindVersionConfig, err := GetKindVersionConfig(kubeVersion)
 		if err != nil {
 			return err
 		}
@@ -136,7 +126,7 @@ func NewLocalKindCluster(env config.Env, name string, kubeVersion string, opts .
 			return err
 		}
 
-		nodeImage := fmt.Sprintf("%s/%s:%s", env.InternalDockerhubMirror(), kindNodeImageName, kindVersionConfig.nodeImageVersion)
+		nodeImage := fmt.Sprintf("%s/%s:%s", env.InternalDockerhubMirror(), kindNodeImageName, kindVersionConfig.NodeImageVersion)
 		createCluster, err := runner.Command(
 			commonEnvironment.CommonNamer().ResourceName("kind-create-cluster"),
 			&command.Args{
@@ -166,4 +156,18 @@ func NewLocalKindCluster(env config.Env, name string, kubeVersion string, opts .
 
 		return nil
 	}, opts...)
+}
+
+func InstallKindBinary(env config.Env, vm *remote.Host, kindVersion string, opts ...pulumi.ResourceOption) (pulumi.Resource, error) {
+	kindArch := vm.OS.Descriptor().Architecture
+	if kindArch == os.AMD64Arch {
+		kindArch = "amd64"
+	}
+	return vm.OS.Runner().Command(
+		env.CommonNamer().ResourceName("kind-install"),
+		&command.Args{
+			Create: pulumi.Sprintf(`curl --retry 10 -fsSLo ./kind "https://kind.sigs.k8s.io/dl/%s/kind-linux-%s" && sudo install kind /usr/local/bin/kind`, kindVersion, kindArch),
+		},
+		opts...,
+	)
 }

--- a/components/kubernetes/kind_versions.go
+++ b/components/kubernetes/kind_versions.go
@@ -7,13 +7,14 @@ import (
 	"github.com/Masterminds/semver"
 )
 
-type kindConfig struct {
+// KindConfig contains the kind version and the kind node image to use
+type KindConfig struct {
 	KindVersion      string
 	NodeImageVersion string
 }
 
 // Source: https://github.com/kubernetes-sigs/kind/releases
-var kubeToKindVersion = map[string]kindConfig{
+var kubeToKindVersion = map[string]KindConfig{
 	"1.32": {
 		KindVersion:      "v0.26.0",
 		NodeImageVersion: "v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027",
@@ -86,7 +87,7 @@ var kubeToKindVersion = map[string]kindConfig{
 }
 
 // GetKindVersionConfig returns the kind version and the kind node image to use based on kubernetes version
-func GetKindVersionConfig(kubeVersion string) (*kindConfig, error) {
+func GetKindVersionConfig(kubeVersion string) (*KindConfig, error) {
 	kubeSemVer, err := semver.NewVersion(kubeVersion)
 	if err != nil {
 		return nil, err

--- a/components/kubernetes/kind_versions.go
+++ b/components/kubernetes/kind_versions.go
@@ -8,85 +8,85 @@ import (
 )
 
 type kindConfig struct {
-	kindVersion      string
-	nodeImageVersion string
+	KindVersion      string
+	NodeImageVersion string
 }
 
 // Source: https://github.com/kubernetes-sigs/kind/releases
 var kubeToKindVersion = map[string]kindConfig{
 	"1.32": {
-		kindVersion:      "v0.26.0",
-		nodeImageVersion: "v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027",
+		KindVersion:      "v0.26.0",
+		NodeImageVersion: "v1.32.0@sha256:c48c62eac5da28cdadcf560d1d8616cfa6783b58f0d94cf63ad1bf49600cb027",
 	},
 	"1.31": {
-		kindVersion:      "v0.26.0",
-		nodeImageVersion: "v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30",
+		KindVersion:      "v0.26.0",
+		NodeImageVersion: "v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30",
 	},
 	"1.30": {
-		kindVersion:      "v0.26.0",
-		nodeImageVersion: "v1.30.8@sha256:17cd608b3971338d9180b00776cb766c50d0a0b6b904ab4ff52fd3fc5c6369bf",
+		KindVersion:      "v0.26.0",
+		NodeImageVersion: "v1.30.8@sha256:17cd608b3971338d9180b00776cb766c50d0a0b6b904ab4ff52fd3fc5c6369bf",
 	},
 	"1.29": {
-		kindVersion:      "v0.22.0",
-		nodeImageVersion: "v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245",
+		KindVersion:      "v0.22.0",
+		NodeImageVersion: "v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245",
 	},
 	"1.28": {
-		kindVersion:      "v0.22.0",
-		nodeImageVersion: "v1.28.7@sha256:9bc6c451a289cf96ad0bbaf33d416901de6fd632415b076ab05f5fa7e4f65c58",
+		KindVersion:      "v0.22.0",
+		NodeImageVersion: "v1.28.7@sha256:9bc6c451a289cf96ad0bbaf33d416901de6fd632415b076ab05f5fa7e4f65c58",
 	},
 	"1.27": {
-		kindVersion:      "v0.22.0",
-		nodeImageVersion: "v1.27.11@sha256:681253009e68069b8e01aad36a1e0fa8cf18bb0ab3e5c4069b2e65cafdd70843",
+		KindVersion:      "v0.22.0",
+		NodeImageVersion: "v1.27.11@sha256:681253009e68069b8e01aad36a1e0fa8cf18bb0ab3e5c4069b2e65cafdd70843",
 	},
 	"1.26": {
-		kindVersion:      "v0.22.0",
-		nodeImageVersion: "v1.26.14@sha256:5d548739ddef37b9318c70cb977f57bf3e5015e4552be4e27e57280a8cbb8e4f",
+		KindVersion:      "v0.22.0",
+		NodeImageVersion: "v1.26.14@sha256:5d548739ddef37b9318c70cb977f57bf3e5015e4552be4e27e57280a8cbb8e4f",
 	},
 	"1.25": {
-		kindVersion:      "v0.22.0",
-		nodeImageVersion: "v1.25.16@sha256:e8b50f8e06b44bb65a93678a65a26248fae585b3d3c2a669e5ca6c90c69dc519",
+		KindVersion:      "v0.22.0",
+		NodeImageVersion: "v1.25.16@sha256:e8b50f8e06b44bb65a93678a65a26248fae585b3d3c2a669e5ca6c90c69dc519",
 	},
 	"1.24": {
-		kindVersion:      "v0.22.0",
-		nodeImageVersion: "v1.24.17@sha256:bad10f9b98d54586cba05a7eaa1b61c6b90bfc4ee174fdc43a7b75ca75c95e51",
+		KindVersion:      "v0.22.0",
+		NodeImageVersion: "v1.24.17@sha256:bad10f9b98d54586cba05a7eaa1b61c6b90bfc4ee174fdc43a7b75ca75c95e51",
 	},
 	"1.23": {
-		kindVersion:      "v0.22.0",
-		nodeImageVersion: "v1.23.17@sha256:14d0a9a892b943866d7e6be119a06871291c517d279aedb816a4b4bc0ec0a5b3",
+		KindVersion:      "v0.22.0",
+		NodeImageVersion: "v1.23.17@sha256:14d0a9a892b943866d7e6be119a06871291c517d279aedb816a4b4bc0ec0a5b3",
 	},
 	"1.22": {
-		kindVersion:      "v0.20.0",
-		nodeImageVersion: "v1.22.17@sha256:f5b2e5698c6c9d6d0adc419c0deae21a425c07d81bbf3b6a6834042f25d4fba2",
+		KindVersion:      "v0.20.0",
+		NodeImageVersion: "v1.22.17@sha256:f5b2e5698c6c9d6d0adc419c0deae21a425c07d81bbf3b6a6834042f25d4fba2",
 	},
 	"1.21": {
-		kindVersion:      "v0.20.0",
-		nodeImageVersion: "v1.21.14@sha256:8a4e9bb3f415d2bb81629ce33ef9c76ba514c14d707f9797a01e3216376ba093",
+		KindVersion:      "v0.20.0",
+		NodeImageVersion: "v1.21.14@sha256:8a4e9bb3f415d2bb81629ce33ef9c76ba514c14d707f9797a01e3216376ba093",
 	},
 	"1.20": {
-		kindVersion:      "v0.17.0",
-		nodeImageVersion: "v1.20.15@sha256:a32bf55309294120616886b5338f95dd98a2f7231519c7dedcec32ba29699394",
+		KindVersion:      "v0.17.0",
+		NodeImageVersion: "v1.20.15@sha256:a32bf55309294120616886b5338f95dd98a2f7231519c7dedcec32ba29699394",
 	},
 	"1.19": {
-		kindVersion:      "v0.17.0",
-		nodeImageVersion: "v1.19.16@sha256:476cb3269232888437b61deca013832fee41f9f074f9bed79f57e4280f7c48b7",
+		KindVersion:      "v0.17.0",
+		NodeImageVersion: "v1.19.16@sha256:476cb3269232888437b61deca013832fee41f9f074f9bed79f57e4280f7c48b7",
 	},
 	// Use ubuntu 20.04 for the below k8s versions
 	"1.18": {
-		kindVersion:      "v0.17.0",
-		nodeImageVersion: "v1.18.20@sha256:61c9e1698c1cb19c3b1d8151a9135b379657aee23c59bde4a8d87923fcb43a91",
+		KindVersion:      "v0.17.0",
+		NodeImageVersion: "v1.18.20@sha256:61c9e1698c1cb19c3b1d8151a9135b379657aee23c59bde4a8d87923fcb43a91",
 	},
 	"1.17": {
-		kindVersion:      "v0.17.0",
-		nodeImageVersion: "v1.17.17@sha256:e477ee64df5731aa4ef4deabbafc34e8d9a686b49178f726563598344a3898d5",
+		KindVersion:      "v0.17.0",
+		NodeImageVersion: "v1.17.17@sha256:e477ee64df5731aa4ef4deabbafc34e8d9a686b49178f726563598344a3898d5",
 	},
 	"1.16": {
-		kindVersion:      "v0.15.0",
-		nodeImageVersion: "v1.16.15@sha256:64bac16b83b6adfd04ea3fbcf6c9b5b893277120f2b2cbf9f5fa3e5d4c2260cc",
+		KindVersion:      "v0.15.0",
+		NodeImageVersion: "v1.16.15@sha256:64bac16b83b6adfd04ea3fbcf6c9b5b893277120f2b2cbf9f5fa3e5d4c2260cc",
 	},
 }
 
-// getKindVersionConfig returns the kind version and the kind node image to use based on kubernetes version
-func getKindVersionConfig(kubeVersion string) (*kindConfig, error) {
+// GetKindVersionConfig returns the kind version and the kind node image to use based on kubernetes version
+func GetKindVersionConfig(kubeVersion string) (*kindConfig, error) {
 	kubeSemVer, err := semver.NewVersion(kubeVersion)
 	if err != nil {
 		return nil, err

--- a/components/kubernetes/nvidia/nvidia.go
+++ b/components/kubernetes/nvidia/nvidia.go
@@ -215,7 +215,7 @@ func initNvkindCluster(env config.Env, vm *remote.Host, name string, clusterOpts
 		nvkindCreateCluster, err := vm.OS.Runner().Command(
 			env.CommonNamer().ResourceName("nvkind-create"),
 			&command.Args{
-				Create:   pulumi.Sprintf("nvkind cluster create  --name %s --config-template %s --config-values %s", kindClusterName, nvkindTemplatePath, nvkindValuesPath),
+				Create:   pulumi.Sprintf("nvkind cluster create --name %s --config-template %s --config-values %s", kindClusterName, nvkindTemplatePath, nvkindValuesPath),
 				Delete:   pulumi.Sprintf("kind cluster delete --name %s", kindClusterName),
 				Triggers: pulumi.Array{nvkindValuesContent, pulumi.String(nvkindConfigTemplate)},
 			},

--- a/components/kubernetes/nvidia/nvidia.go
+++ b/components/kubernetes/nvidia/nvidia.go
@@ -1,0 +1,280 @@
+package nvidia
+
+import (
+	_ "embed"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/helm/v3"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components"
+	"github.com/DataDog/test-infra-definitions/components/command"
+	"github.com/DataDog/test-infra-definitions/components/docker"
+	"github.com/DataDog/test-infra-definitions/components/kubernetes"
+	"github.com/DataDog/test-infra-definitions/components/remote"
+
+	pulumik8s "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+)
+
+const nvkindPackage = "github.com/NVIDIA/nvkind/cmd/nvkind"
+const nvkindVersion = "eeeb9ca30763177fbe7b4d10fb6b7e21725e2295"
+const nvkindRequiredGoVersion = "1.23"
+const kindNodeImageName = "kindest/node"
+
+const gpuOperatorVersion = "v24.9.2"
+
+const nvkindClusterValues = `
+image: %s
+workers:
+- devices: all
+`
+
+//go:embed nvkind-config-template.yml
+var nvkindConfigTemplate string
+
+// NvidiaKindCluster represents a Kubernetes cluster that is GPU-enabled using nvkind.
+// Both the cluster and the GPU operator should be depended on for resources that require GPU support.
+type NvidiaKindCluster struct {
+	*kubernetes.Cluster
+
+	GPUOperator *helm.Release
+}
+
+// NewKindCluster creates a new Kubernetes cluster using nvkind so that nodes can be GPU-enabled.
+// We need a different function rather than re-using kubernetes.NewKindCluster because we GPU-enabled kind
+// clusters require a set of patches that aren't trivial. Instead of writing them all down here, we have
+// decided to use the nvkind tool to create the cluster. This means that we cannot follow the same code path
+// as for regular kind clusters.
+func NewKindCluster(env config.Env, vm *remote.Host, name string, kubeVersion string, opts ...pulumi.ResourceOption) (*NvidiaKindCluster, error) {
+	// Configure the nvidia container toolkit
+	cmd, err := configureContainerToolkit(env, vm, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare NVIDIA runtime: %w", err)
+	}
+	opts = utils.MergeOptions(opts, utils.PulumiDependsOn(cmd))
+
+	// Create the cluster
+	cluster, err := initNvkindCluster(env, vm, name, kubeVersion, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create nvkind cluster: %w", err)
+	}
+
+	// Create the provider based on the kubeconfig output we ahve
+	cluster.KubeProvider, err = pulumik8s.NewProvider(env.Ctx(), env.CommonNamer().ResourceName("k8s-provider"), &pulumik8s.ProviderArgs{
+		EnableServerSideApply: pulumi.Bool(true),
+		Kubeconfig:            cluster.KubeConfig,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("kubernetes.NewProvider: %w", err)
+	}
+	opts = append(opts, pulumi.Provider(cluster.KubeProvider), pulumi.Parent(cluster.KubeProvider), pulumi.DeletedWith(cluster.KubeProvider))
+
+	// Now install the operator
+	operator, err := installGPUOperator(env, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to install GPU operator: %w", err)
+	}
+
+	return &NvidiaKindCluster{
+		Cluster:     cluster,
+		GPUOperator: operator,
+	}, nil
+}
+
+func configureContainerToolkit(env config.Env, vm *remote.Host, opts ...pulumi.ResourceOption) (pulumi.Resource, error) {
+	// Ensure we have Docker
+	dockerManager, err := docker.NewManager(env, vm, opts...)
+	if err != nil {
+		return nil, err
+	}
+	opts = utils.MergeOptions(opts, utils.PulumiDependsOn(dockerManager))
+
+	// Enable the NVIDIA Container Toolkit (nvidia-ctk) runtime for Docker
+	// Source for these commands: https://github.com/NVIDIA/nvkind#setup
+	ctkRuntime := "sudo nvidia-ctk runtime configure --runtime=docker --set-as-default --cdi.enabled "
+	ctkConfig := "sudo nvidia-ctk config --set accept-nvidia-visible-devices-as-volume-mounts=true --in-place"
+	ctkDockerRestart := "sudo systemctl restart docker"
+	ctkConfigureCmdline := strings.Join([]string{ctkRuntime, ctkConfig, ctkDockerRestart}, " && ")
+
+	ctkConfigureCmd, err := vm.OS.Runner().Command(
+		env.CommonNamer().ResourceName("nvidia-ctk-configure"),
+		&command.Args{
+			Create: pulumi.String(ctkConfigureCmdline),
+		},
+		opts...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure NVIDIA runtime: %w", err)
+	}
+
+	// Validate that the runtime is configured properly
+	return vm.OS.Runner().Command(
+		env.CommonNamer().ResourceName("nvidia-ctk-check"),
+		&command.Args{
+			Create: pulumi.String("docker run --runtime=nvidia -e NVIDIA_VISIBLE_DEVICES=all ubuntu:20.04 nvidia-smi -L"),
+		},
+		utils.MergeOptions(opts, utils.PulumiDependsOn(ctkConfigureCmd))...,
+	)
+}
+
+// installNvkind installs the nvkind tool with all the necessary requisites
+func installNvkind(env config.Env, vm *remote.Host, kindVersion string, kubeVersion string, opts ...pulumi.ResourceOption) (command.Command, error) {
+	// kind is a requisite for nvkind, as it calls it under the hood
+	kindInstall, err := kubernetes.InstallKindBinary(env, vm, kindVersion, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to install kind: %w", err)
+	}
+
+	// kubectl is a requisite for nvkind, it's called under the hood
+	kubectlInstall, err := vm.OS.Runner().Command(
+		env.CommonNamer().ResourceName("kubectl-install"),
+		&command.Args{
+			// use snap installer as it contains multiple versions, rather than APT
+			Create: pulumi.Sprintf("sudo snap install kubectl --classic --channel=%s/stable", kubeVersion),
+		},
+		opts...,
+	)
+
+	// We need Go to install nvkind as it's a go package
+	golangInstall, err := vm.OS.Runner().Command(
+		env.CommonNamer().ResourceName("golang-install"),
+		&command.Args{
+			// use snap installer as it contains multiple versions, rather than APT
+			Create: pulumi.Sprintf("sudo snap install --classic go --channel=%s/stable", nvkindRequiredGoVersion),
+		},
+		opts...,
+	)
+
+	// Install nvkind using go install
+	nvkindInstall, err := vm.OS.Runner().Command(
+		env.CommonNamer().ResourceName("nvkind-install"),
+		&command.Args{
+			// Ensure it gets installed to the global $PATH to avoid having to copy it or change $PATH
+			Create: pulumi.Sprintf("sudo GOBIN=/usr/local/bin go install %s@%s", nvkindPackage, nvkindVersion),
+		},
+		utils.MergeOptions(opts, utils.PulumiDependsOn(golangInstall, kindInstall, kubectlInstall))...,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to install nvkind: %w", err)
+	}
+
+	return nvkindInstall, nil
+}
+
+// inivtNvkindCluster creates a new Kubernetes cluster using nvkind so that nodes can be GPU-enabled, installing
+// the necessary components and configuring the cluster.
+func initNvkindCluster(env config.Env, vm *remote.Host, name string, kubeVersion string, opts ...pulumi.ResourceOption) (*kubernetes.Cluster, error) {
+	return components.NewComponent(env, name, func(clusterComp *kubernetes.Cluster) error {
+		opts = utils.MergeOptions[pulumi.ResourceOption](opts, pulumi.Parent(clusterComp))
+		kindVersionConfig, err := kubernetes.GetKindVersionConfig(kubeVersion)
+		if err != nil {
+			return err
+		}
+
+		// Install nvkind to create the cluster
+		nvkindInstall, err := installNvkind(env, vm, kindVersionConfig.KindVersion, kubeVersion, opts...)
+		if err != nil {
+			return fmt.Errorf("failed to install nvkind: %w", err)
+		}
+		opts = utils.MergeOptions(opts, utils.PulumiDependsOn(nvkindInstall))
+
+		// Copy the cluster configuration to the VM
+		nvkindTemplatePath := "/tmp/nvkind-config.yaml"
+		nvkindTemplate, err := vm.OS.FileManager().CopyInlineFile(
+			pulumi.String(nvkindConfigTemplate),
+			nvkindTemplatePath,
+			opts...)
+		if err != nil {
+			return err
+		}
+
+		nodeImage := fmt.Sprintf("%s/%s:%s", env.InternalDockerhubMirror(), kindNodeImageName, kindVersionConfig.NodeImageVersion)
+		nvkindValuesPath := "/tmp/nvkind-values.yaml"
+		nvkindValuesContent := pulumi.Sprintf(nvkindClusterValues, nodeImage)
+		nvkindValues, err := vm.OS.FileManager().CopyInlineFile(
+			nvkindValuesContent,
+			nvkindValuesPath,
+			opts...)
+		if err != nil {
+			return err
+		}
+
+		opts = utils.MergeOptions(opts, utils.PulumiDependsOn(nvkindTemplate, nvkindValues))
+
+		// Run the nvkind command to create the cluster
+		kindClusterName := env.CommonNamer().DisplayName(49)
+		nvkindCreateCluster, err := vm.OS.Runner().Command(
+			env.CommonNamer().ResourceName("nvkind-create"),
+			&command.Args{
+				Create:   pulumi.Sprintf("nvkind cluster create  --name %s --config-template %s --config-values %s", kindClusterName, nvkindTemplatePath, nvkindValuesPath),
+				Delete:   pulumi.Sprintf("kind cluster delete --name %s", kindClusterName),
+				Triggers: pulumi.Array{nvkindValuesContent, pulumi.String(nvkindConfigTemplate)},
+			},
+			opts...)
+		if err != nil {
+			return fmt.Errorf("failed to create nvkind cluster: %w", err)
+		}
+		opts = utils.MergeOptions(opts, utils.PulumiDependsOn(nvkindCreateCluster))
+
+		// Get the kubeconfig for the cluster so we can connect to it
+		kubeConfigCmd, err := vm.OS.Runner().Command(
+			env.CommonNamer().ResourceName("kind-kubeconfig"),
+			&command.Args{
+				Create: pulumi.Sprintf("kind get kubeconfig --name %s", kindClusterName),
+			},
+			opts...,
+		)
+		if err != nil {
+			return err
+		}
+
+		// Patch Kubeconfig based on private IP output
+		// Also add skip tls
+		clusterComp.KubeConfig = pulumi.All(kubeConfigCmd.StdoutOutput(), vm.Address).ApplyT(func(args []interface{}) string {
+			allowInsecure := regexp.MustCompile("certificate-authority-data:.+").ReplaceAllString(args[0].(string), "insecure-skip-tls-verify: true")
+			return strings.ReplaceAll(allowInsecure, "0.0.0.0", args[1].(string))
+		}).(pulumi.StringOutput)
+		clusterComp.ClusterName = kindClusterName.ToStringOutput()
+
+		return nil
+	}, opts...)
+}
+
+// installGPUOperator installs the GPU operator in the cluster
+func installGPUOperator(env config.Env, opts ...pulumi.ResourceOption) (*helm.Release, error) {
+	// Create namespace
+	operatorNs := "gpu-operator"
+	ns, err := corev1.NewNamespace(env.Ctx(), operatorNs, &corev1.NamespaceArgs{
+		Metadata: metav1.ObjectMetaArgs{
+			Name: pulumi.String(operatorNs),
+		},
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+	opts = append(opts, utils.PulumiDependsOn(ns))
+
+	helmInstall, err := helm.NewRelease(env.Ctx(), "gpu-operator", &helm.ReleaseArgs{
+		RepositoryOpts: helm.RepositoryOptsArgs{
+			Repo: pulumi.String("https://nvidia.github.io/gpu-operator"),
+		},
+		Chart:            pulumi.String("gpu-operator"),
+		Namespace:        pulumi.String(operatorNs),
+		Version:          pulumi.String(gpuOperatorVersion),
+		CreateNamespace:  pulumi.Bool(true),
+		DependencyUpdate: pulumi.BoolPtr(true),
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return helmInstall, nil
+}

--- a/components/kubernetes/nvidia/nvkind-config-template.yml
+++ b/components/kubernetes/nvidia/nvkind-config-template.yml
@@ -22,6 +22,9 @@ nodes:
   {{- if hasKey $ "image" }}
   image: {{ $.image }}
   {{- end }}
+  extraMounts:
+  - hostPath: /proc
+    containerPath: /host/proc
 {{- range $.workers }}
 - role: worker
   {{- if hasKey $ "image" }}

--- a/components/kubernetes/nvidia/nvkind-config-template.yml
+++ b/components/kubernetes/nvidia/nvkind-config-template.yml
@@ -1,0 +1,53 @@
+# Copyright 2024 NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+{{- if hasKey $ "name" }}
+name: {{ $.name }}
+{{- end }}
+nodes:
+- role: control-plane
+  {{- if hasKey $ "image" }}
+  image: {{ $.image }}
+  {{- end }}
+{{- range $.workers }}
+- role: worker
+  {{- if hasKey $ "image" }}
+  image: {{ $.image }}
+  {{- end }}
+
+  {{- if hasKey . "devices" }}
+  {{- $devices := .devices }}
+  {{- if not (kindIs "slice" $devices) }}
+    {{- $devices = list .devices }}
+  {{- end }}
+  extraMounts:
+    # We inject all NVIDIA GPUs using the nvidia-container-runtime.
+    # This requires `accept-nvidia-visible-devices-as-volume-mounts = true` be set
+    # in `/etc/nvidia-container-runtime/config.toml`
+    {{- range $d := $devices }}
+    - hostPath: /dev/null
+      containerPath: /var/run/nvidia-container-devices/{{ $d }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+      endpoint = ["https://mirror.gcr.io", "https://registry-1.docker.io"]
+networking:
+  # Ensure we can connect to the API server from outside the host
+  apiServerAddress: "0.0.0.0"
+  apiServerPort: 8443

--- a/components/kubernetes/nvidia/options.go
+++ b/components/kubernetes/nvidia/options.go
@@ -1,0 +1,104 @@
+package nvidia
+
+// defaultGpuOperatorVersion is the default version of the Nvidia GPU operator to install
+const defaultGpuOperatorVersion = "v24.9.2"
+
+// defaultNvkindVersion is the default version of the nvkind utility to install
+// Must be a valid reference for the github.com/NVIDIA/nvkind repository
+const defaultNvkindVersion = "eeeb9ca30763177fbe7b4d10fb6b7e21725e2295"
+
+// defaultHostGoVersion is the default version of Go to install in the host. This version
+// must be compatible with the nvkind utility
+const defaultHostGoVersion = "1.23"
+
+// defaultKindNodeImage is the default image to use for the kind nodes.
+const defaultKindNodeImage = "kindest/node"
+
+// defaultCudaSanityCheckImage is a Docker image that contains a CUDA sample to
+// validate the GPU setup with the default CUDA installation. Note that the CUDA
+// version in this image must be equal or less than the one installed in the
+// AMI.
+const defaultCudaSanityCheckImage = "669783387624.dkr.ecr.us-east-1.amazonaws.com/dockerhub/nvidia/cuda:12.6.3-base-ubuntu22.04"
+
+// KindClusterOptions contains the options for creating a kind cluster with the Nvidia GPU operator
+type KindClusterOptions struct {
+	// kubeVersion is the version of Kubernetes to install in the kind cluster
+	kubeVersion string
+
+	// gpuOperatorVersion is the version of the Nvidia GPU operator to install
+	gpuOperatorVersion string
+
+	// nvkindVersion is the version of the nvkind utility to install
+	nvkindVersion string
+
+	// hostGoVersion is the version of Go to install in the host
+	hostGoVersion string
+
+	// kindImage is the image to use for the kind nodes
+	kindImage string
+
+	// cudaSanityCheckImage is a Docker image to use when performing sanity checks for validation of the GPU setup in containers
+	cudaSanityCheckImage string
+}
+
+// KindClusterOption is a function that modifies a KindClusterOptions
+type KindClusterOption func(*KindClusterOptions)
+
+// WithGPUOperatorVersion sets the version of the Nvidia GPU operator to install
+func WithKubeVersion(version string) KindClusterOption {
+	return func(o *KindClusterOptions) {
+		o.kubeVersion = version
+	}
+}
+
+// WithGPUOperatorVersion sets the version of the Nvidia GPU operator to install
+func WithGPUOperatorVersion(version string) KindClusterOption {
+	return func(o *KindClusterOptions) {
+		o.gpuOperatorVersion = version
+	}
+}
+
+// WithNvkindVersion sets the version of the nvkind utility to install
+func WithNvkindVersion(version string) KindClusterOption {
+	return func(o *KindClusterOptions) {
+		o.nvkindVersion = version
+	}
+}
+
+// WithHostGoVersion sets the version of Go to install in the host
+func WithHostGoVersion(version string) KindClusterOption {
+	return func(o *KindClusterOptions) {
+		o.hostGoVersion = version
+	}
+}
+
+// WithKindImage sets the image to use for the kind nodes. The version used by this image will
+// be the one defined by kubernetes.GetKindVersionConfig based on the kubernetes version used.
+func WithKindImage(image string) KindClusterOption {
+	return func(o *KindClusterOptions) {
+		o.kindImage = image
+	}
+}
+
+// WithCudaSanityCheckImage sets the image to use for the CUDA sanity check commands. Note that
+// the CUDA version in this image must be equal or less than the one installed in the AMI.
+func WithCudaSanityCheckImage(image string) KindClusterOption {
+	return func(o *KindClusterOptions) {
+		o.cudaSanityCheckImage = image
+	}
+}
+
+// NewKindClusterOptions creates a new KindClusterOptions with the given options, or defaults
+func NewKindClusterOptions(opts ...KindClusterOption) *KindClusterOptions {
+	o := &KindClusterOptions{
+		gpuOperatorVersion:   defaultGpuOperatorVersion,
+		nvkindVersion:        defaultNvkindVersion,
+		hostGoVersion:        defaultHostGoVersion,
+		kindImage:            defaultKindNodeImage,
+		cudaSanityCheckImage: defaultCudaSanityCheckImage,
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+	return o
+}


### PR DESCRIPTION
What does this PR do?
---------------------

This PR adds code to support Kubernetes Kind clusters with GPU support. Due to the patches required for these clusters, we use the `nvkind` tool provided by NVIDIA. Some of the existing code for kind cluster creation is separated into new functions/exported to enable code sharing.

Which scenarios this will impact?
-------------------

Should not have impact on existing scenarios.

Motivation
----------

Implement e2e tests of the GPU monitoring feature.

Additional Notes
----------------
