### PR TITLE
need to parse MAC parts as uint8

### DIFF
--- a/scenarios/aws/microVMs/microvms/network.go
+++ b/scenarios/aws/microVMs/microvms/network.go
@@ -297,7 +297,7 @@ func normalizeMAC(mac string) (string, error) {
 
 	var addr net.HardwareAddr = make([]byte, 6)
 	for i, part := range parts {
-		num, err := strconv.ParseInt(part, 16, 8)
+		num, err := strconv.ParseUint(part, 16, 8)
 		if err != nil {
 			return "", fmt.Errorf("normalizeMAC: invalid MAC address %s, cannot parse %s: %w", mac, part, err)
 		}

--- a/scenarios/aws/microVMs/microvms/network_test.go
+++ b/scenarios/aws/microVMs/microvms/network_test.go
@@ -70,6 +70,11 @@ func TestNormalizeMAC(t *testing.T) {
 			mac:  "0:1c:42:a:70",
 			want: "",
 		},
+		{
+			name: "uint only range",
+			mac:  "1:0:5e:0:0:fb",
+			want: "01:00:5e:00:00:fb",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
What does this PR do?
---------------------

fixes parsing of MAC addresses during KMT

Which scenarios this will impact?
-------------------

`aws/microVMs`

Motivation
----------

`invalid MAC address 1:0:5e:0:0:fb, cannot parse fb: strconv.ParseInt: parsing "fb": value out of range`

Additional Notes
----------------
