### PR TITLE
Do not use CopyToRemote everywhere

### DIFF
--- a/components/command/filemanager.go
+++ b/components/command/filemanager.go
@@ -68,6 +68,8 @@ func (fm *FileManager) CopyFile(name string, localPath, remotePath pulumi.String
 	return fm.runner.newCopyFile(name, localPath, remotePath, opts...)
 }
 
+// CopyToRemoteFile copies a local file to a remote file. Under the hood it uses remote.CopyToRemote, so localPath will be converted to a File Asset, it breaks if the local path is not known at plan time.
+// Ideally it should replace CopyFile but it is not possible due to the limitation of CopyToRemote for now.
 func (fm *FileManager) CopyToRemoteFile(name string, localPath, remotePath pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error) {
 	return fm.command.NewCopyToRemoteFile(fm.runner, name, localPath, remotePath, opts...)
 }

--- a/components/command/filemanager.go
+++ b/components/command/filemanager.go
@@ -74,12 +74,13 @@ func (fm *FileManager) CopyToRemoteFile(name string, localPath, remotePath pulum
 
 func (fm *FileManager) CopyInlineFile(fileContent pulumi.StringInput, remotePath string, opts ...pulumi.ResourceOption) (pulumi.Resource, error) {
 	// Write the content into a temporary file and get the path
-	tempFile, err := os.CreateTemp("", filepath.Base(remotePath))
-	if err != nil {
-		return nil, err
-	}
 
-	_ = fileContent.ToStringOutput().ApplyT(func(content string) (string, error) {
+	localTempPath := fileContent.ToStringOutput().ApplyT(func(content string) (string, error) {
+		tempFile, err := os.CreateTemp("", filepath.Base(remotePath))
+		if err != nil {
+			return "", err
+		}
+
 		if err != nil {
 			return "", err
 		}
@@ -93,7 +94,7 @@ func (fm *FileManager) CopyInlineFile(fileContent pulumi.StringInput, remotePath
 		return tempFilePath, nil
 	}).(pulumi.StringInput)
 
-	return fm.CopyFile(remotePath, pulumi.String(tempFile.Name()), pulumi.String(remotePath), opts...)
+	return fm.CopyFile(remotePath, localTempPath, pulumi.String(remotePath), opts...)
 }
 
 // CopyRelativeFolder copies recursively a relative folder to a remote folder.

--- a/components/command/filemanager.go
+++ b/components/command/filemanager.go
@@ -68,6 +68,10 @@ func (fm *FileManager) CopyFile(name string, localPath, remotePath pulumi.String
 	return fm.runner.newCopyFile(name, localPath, remotePath, opts...)
 }
 
+func (fm *FileManager) CopyToRemoteFile(name string, localPath, remotePath pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error) {
+	return fm.command.NewCopyToRemoteFile(fm.runner, name, localPath, remotePath, opts...)
+}
+
 func (fm *FileManager) CopyInlineFile(fileContent pulumi.StringInput, remotePath string, opts ...pulumi.ResourceOption) (pulumi.Resource, error) {
 	// Write the content into a temporary file and get the path
 	tempFile, err := os.CreateTemp("", filepath.Base(remotePath))

--- a/components/command/osCommand.go
+++ b/components/command/osCommand.go
@@ -34,6 +34,7 @@ type OSCommand interface {
 	NewCopyToRemoteFile(runner Runner, name string, localPath, remotePath pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error)
 	copyLocalFile(runner *LocalRunner, name string, src, dst pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error)
 	copyRemoteFile(runner *RemoteRunner, name string, src, dst pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error)
+	// copyToRemoteFileV2 rely on CopyToRemote to copy files to remote, which uses a File asset instead of a Pulumi.StringInput with the path. It breaks when the path is not determined at runtime.
 	copyRemoteFileV2(runner *RemoteRunner, name string, src, dst pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error)
 }
 

--- a/components/command/osCommand.go
+++ b/components/command/osCommand.go
@@ -31,8 +31,10 @@ type OSCommand interface {
 	PathJoin(parts ...string) string
 
 	NewCopyFile(runner Runner, name string, localPath, remotePath pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error)
+	NewCopyToRemoteFile(runner Runner, name string, localPath, remotePath pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error)
 	copyLocalFile(runner *LocalRunner, name string, src, dst pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error)
 	copyRemoteFile(runner *RemoteRunner, name string, src, dst pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error)
+	copyRemoteFileV2(runner *RemoteRunner, name string, src, dst pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error)
 }
 
 // ------------------------------

--- a/components/command/runner.go
+++ b/components/command/runner.go
@@ -141,6 +141,7 @@ type Runner interface {
 	Command(name string, args RunnerCommandArgs, opts ...pulumi.ResourceOption) (Command, error)
 
 	newCopyFile(name string, localPath, remotePath pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error)
+	newCopyToRemoteFile(name string, localPath, remotePath pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error)
 }
 
 var _ Runner = &RemoteRunner{}
@@ -233,6 +234,10 @@ func (r *RemoteRunner) newCopyFile(name string, localPath, remotePath pulumi.Str
 	return r.osCommand.copyRemoteFile(r, name, localPath, remotePath, opts...)
 }
 
+func (r *RemoteRunner) newCopyToRemoteFile(name string, localPath, remotePath pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error) {
+	return r.osCommand.copyRemoteFileV2(r, name, localPath, remotePath, opts...)
+}
+
 func (r *RemoteRunner) PulumiOptions() []pulumi.ResourceOption {
 	return r.options
 }
@@ -296,6 +301,10 @@ func (r *LocalRunner) Command(name string, args RunnerCommandArgs, opts ...pulum
 
 func (r *LocalRunner) newCopyFile(name string, localPath, remotePath pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error) {
 	return r.osCommand.copyLocalFile(r, name, localPath, remotePath, opts...)
+}
+
+func (r *LocalRunner) newCopyToRemoteFile(name string, localPath, remotePath pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error) {
+	return r.newCopyFile(name, localPath, remotePath, opts...)
 }
 
 func (r *LocalRunner) PulumiOptions() []pulumi.ResourceOption {

--- a/components/command/unixOSCommand.go
+++ b/components/command/unixOSCommand.go
@@ -128,12 +128,9 @@ func (fs unixOSCommand) copyRemoteFile(runner *RemoteRunner, name string, src, d
 		return fs.PathJoin(runner.OsCommand().GetTemporaryDirectory(), filepath.Base(path))
 	}).(pulumi.StringOutput)
 
-	srcAsset := src.ToStringOutput().ApplyT(func(path string) pulumi.AssetOrArchive {
-		return pulumi.NewFileAsset(path)
-	}).(pulumi.AssetOrArchiveOutput)
-	tempCopyFile, err := remote.NewCopyToRemote(runner.Environment().Ctx(), runner.Namer().ResourceName("copy", name), &remote.CopyToRemoteArgs{
+	tempCopyFile, err := remote.NewCopyFile(runner.Environment().Ctx(), runner.Namer().ResourceName("copy", name), &remote.CopyFileArgs{
 		Connection: runner.Config().connection,
-		Source:     srcAsset,
+		LocalPath:  src,
 		RemotePath: tempRemotePath,
 		Triggers:   pulumi.Array{src, tempRemotePath},
 	}, utils.MergeOptions(runner.PulumiOptions(), opts...)...)

--- a/components/command/unixOSCommand.go
+++ b/components/command/unixOSCommand.go
@@ -80,6 +80,10 @@ func (fs unixOSCommand) NewCopyFile(runner Runner, name string, localPath, remot
 	return runner.newCopyFile(name, localPath, remotePath, opts...)
 }
 
+func (fs unixOSCommand) NewCopyToRemoteFile(runner Runner, name string, localPath, remotePath pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error) {
+	return runner.newCopyToRemoteFile(name, localPath, remotePath, opts...)
+}
+
 func formatCommandIfNeeded(command pulumi.StringInput, sudo bool, password bool, user string) pulumi.StringInput {
 	if command == nil {
 		return nil
@@ -145,4 +149,17 @@ func (fs unixOSCommand) copyRemoteFile(runner *RemoteRunner, name string, src, d
 	}
 
 	return moveCommand, err
+}
+
+func (fs unixOSCommand) copyRemoteFileV2(runner *RemoteRunner, name string, src, dst pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error) {
+	srcAsset := src.ToStringOutput().ApplyT(func(path string) pulumi.AssetOrArchive {
+		return pulumi.NewFileAsset(path)
+	}).(pulumi.AssetOrArchiveOutput)
+
+	return remote.NewCopyToRemote(runner.Environment().Ctx(), runner.Namer().ResourceName("copy", name), &remote.CopyToRemoteArgs{
+		Connection: runner.Config().connection,
+		Source:     srcAsset,
+		RemotePath: dst,
+		Triggers:   pulumi.Array{src, dst},
+	}, utils.MergeOptions(runner.PulumiOptions(), opts...)...)
 }

--- a/components/command/windowsOSCommand.go
+++ b/components/command/windowsOSCommand.go
@@ -109,13 +109,9 @@ func (fs windowsOSCommand) copyLocalFile(runner *LocalRunner, name string, src, 
 }
 
 func (fs windowsOSCommand) copyRemoteFile(runner *RemoteRunner, name string, src, dst pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error) {
-	srcAsset := src.ToStringOutput().ApplyT(func(path string) pulumi.AssetOrArchive {
-		return pulumi.NewFileAsset(path)
-	}).(pulumi.AssetOrArchiveOutput)
-
-	return remote.NewCopyToRemote(runner.Environment().Ctx(), runner.Namer().ResourceName("copy", name), &remote.CopyToRemoteArgs{
+	return remote.NewCopyFile(runner.Environment().Ctx(), runner.Namer().ResourceName("copy", name), &remote.CopyFileArgs{
 		Connection: runner.Config().connection,
-		Source:     srcAsset,
+		LocalPath:  src,
 		RemotePath: dst,
 		Triggers:   pulumi.Array{src, dst},
 	}, utils.MergeOptions(runner.PulumiOptions(), opts...)...)

--- a/components/command/windowsOSCommand.go
+++ b/components/command/windowsOSCommand.go
@@ -86,6 +86,10 @@ func (fs windowsOSCommand) NewCopyFile(runner Runner, name string, localPath, re
 	return runner.newCopyFile(name, localPath, remotePath, opts...)
 }
 
+func (fs windowsOSCommand) NewCopyToRemoteFile(runner Runner, name string, localPath, remotePath pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error) {
+	return runner.newCopyToRemoteFile(name, localPath, remotePath, opts...)
+}
+
 func (fs windowsOSCommand) MoveFile(runner Runner, name string, source, destination pulumi.StringInput, sudo bool, opts ...pulumi.ResourceOption) (Command, error) {
 	backupPath := pulumi.Sprintf("%v.%s", destination, backupExtension)
 	copyCommand := pulumi.Sprintf(`Copy-Item -Path '%v' -Destination '%v'`, source, destination)
@@ -112,6 +116,19 @@ func (fs windowsOSCommand) copyRemoteFile(runner *RemoteRunner, name string, src
 	return remote.NewCopyFile(runner.Environment().Ctx(), runner.Namer().ResourceName("copy", name), &remote.CopyFileArgs{
 		Connection: runner.Config().connection,
 		LocalPath:  src,
+		RemotePath: dst,
+		Triggers:   pulumi.Array{src, dst},
+	}, utils.MergeOptions(runner.PulumiOptions(), opts...)...)
+}
+
+func (fs windowsOSCommand) copyRemoteFileV2(runner *RemoteRunner, name string, src, dst pulumi.StringInput, opts ...pulumi.ResourceOption) (pulumi.Resource, error) {
+	srcAsset := src.ToStringOutput().ApplyT(func(path string) pulumi.AssetOrArchive {
+		return pulumi.NewFileAsset(path)
+	}).(pulumi.AssetOrArchiveOutput)
+
+	return remote.NewCopyToRemote(runner.Environment().Ctx(), runner.Namer().ResourceName("copy", name), &remote.CopyToRemoteArgs{
+		Connection: runner.Config().connection,
+		Source:     srcAsset,
 		RemotePath: dst,
 		Triggers:   pulumi.Array{src, dst},
 	}, utils.MergeOptions(runner.PulumiOptions(), opts...)...)

--- a/components/datadog/agent/host.go
+++ b/components/datadog/agent/host.go
@@ -132,7 +132,7 @@ func (h *HostAgent) directInstallInstallation(env config.Env, params *agentparam
 	}
 	packageToInstall := matches[0]
 	env.Ctx().Log.Info(fmt.Sprintf("Found local package to install %s", packageToInstall), nil)
-	uploadCmd, err := h.Host.OS.FileManager().CopyFile("copy-agent-package", pulumi.String(packagePath), pulumi.String("./"), baseOpts...)
+	uploadCmd, err := h.Host.OS.FileManager().CopyToRemoteFile("copy-agent-package", pulumi.String(packagePath), pulumi.String("./"), baseOpts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This reverts commit 9bbbec2

What does this PR do?
---------------------

Partially revert a change that was made to use `CopyToRemote` instead of `CopyFile` because it does not support well copying a file when it is not determined at plan time. Let's use `CopyToRemote` only for uploading package file, we know it works there.

I'll open a discussion with pulumi-command maintainer to check if it is something that they are aware of

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
