### PR TITLE
Fix procfs in nvkind clusters

### DIFF
--- a/components/kubernetes/nvidia/nvidia.go
+++ b/components/kubernetes/nvidia/nvidia.go
@@ -216,7 +216,7 @@ func initNvkindCluster(env config.Env, vm *remote.Host, name string, clusterOpts
 			env.CommonNamer().ResourceName("nvkind-create"),
 			&command.Args{
 				Create:   pulumi.Sprintf("nvkind cluster create --name %s --config-template %s --config-values %s", kindClusterName, nvkindTemplatePath, nvkindValuesPath),
-				Delete:   pulumi.Sprintf("kind cluster delete --name %s", kindClusterName),
+				Delete:   pulumi.Sprintf("kind delete clusters %s || true", kindClusterName),
 				Triggers: pulumi.Array{nvkindValuesContent, pulumi.String(nvkindConfigTemplate)},
 			},
 			opts...)

--- a/components/kubernetes/nvidia/nvkind-config-template.yml
+++ b/components/kubernetes/nvidia/nvkind-config-template.yml
@@ -44,6 +44,11 @@ nodes:
     - hostPath: /dev/null
       containerPath: /var/run/nvidia-container-devices/{{ $d }}
     {{- end }}
+    # We need to mount the /host/proc directory to access the host's /proc directory inside
+    # of the agent container. Else we just get access to the process namespace of the docker container
+    extraMounts:
+    - hostPath: /proc
+      containerPath: /host/proc
   {{- end }}
 {{- end }}
 containerdConfigPatches:

--- a/components/kubernetes/nvidia/nvkind-config-template.yml
+++ b/components/kubernetes/nvidia/nvkind-config-template.yml
@@ -46,7 +46,6 @@ nodes:
     {{- end }}
     # We need to mount the /host/proc directory to access the host's /proc directory inside
     # of the agent container. Else we just get access to the process namespace of the docker container
-    extraMounts:
     - hostPath: /proc
       containerPath: /host/proc
   {{- end }}


### PR DESCRIPTION
What does this PR do?
---------------------

This PR fixes the nvkind cluster creation code to ensure they have visibility into the host procfs, necessary for the agent to see processes in the host root procfs.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
