### PR TITLE
add custom install path as Windows install Agent option

### DIFF
--- a/components/datadog/agentparams/msi/install_params.go
+++ b/components/datadog/agentparams/msi/install_params.go
@@ -13,7 +13,7 @@ type InstallAgentParams struct {
 	AgentUserPassword string `installer_arg:"DDAGENTUSER_PASSWORD"`
 	DdURL             string `installer_arg:"DD_URL"`
 	Site              string `installer_arg:"SITE"`
-	InstallPath       string `installer_arg:"APPLICATIONDATADIRECTORY"`
+	InstallPath       string `installer_arg:"PROJECTLOCATION"`
 	InstallLogFile    string `installer_arg:"/log"`
 }
 

--- a/components/datadog/agentparams/msi/install_params.go
+++ b/components/datadog/agentparams/msi/install_params.go
@@ -2,8 +2,9 @@ package msi
 
 import (
 	"fmt"
-	"github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	"reflect"
+
+	"github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 )
 
 // InstallAgentParams are the parameters used for installing the Agent using msiexec.
@@ -12,6 +13,7 @@ type InstallAgentParams struct {
 	AgentUserPassword string `installer_arg:"DDAGENTUSER_PASSWORD"`
 	DdURL             string `installer_arg:"DD_URL"`
 	Site              string `installer_arg:"SITE"`
+	InstallPath       string `installer_arg:"APPLICATIONDATADIRECTORY"`
 	InstallLogFile    string `installer_arg:"/log"`
 }
 
@@ -93,4 +95,11 @@ func WithInstallLogFile(logFileName string) InstallAgentOption {
 // WithFakeIntake configures the Agent to use a fake intake URL.
 func WithFakeIntake(fakeIntake *fakeintake.FakeintakeOutput) InstallAgentOption {
 	return WithDdURL(fakeIntake.URL)
+}
+
+// WithFakeIntake configures the Agent to use a fake intake URL.
+func WithCustomInstallPath(installPath string) InstallAgentOption {
+	return func(i *InstallAgentParams) {
+		i.InstallPath = installPath
+	}
 }


### PR DESCRIPTION
What does this PR do?
---------------------
This PR introduce an option to set a custom installation path for host-based Windows installation.

Which scenarios this will impact?
-------------------

Motivation
----------
This will be useful for edge-cases where the Agent rely on assets stored in the Agent install directory. 

Additional Notes
----------------
