### PR TITLE
prevent incomplete MAC address from spamming logs

### DIFF
--- a/scenarios/aws/microVMs/microvms/network.go
+++ b/scenarios/aws/microVMs/microvms/network.go
@@ -259,6 +259,9 @@ func parseArpDhcpLeases() ([]dhcpLease, error) {
 			fmt.Printf("warning: error parsing arp line: %v\n", err)
 			continue
 		}
+		if lease.mac == "" {
+			continue
+		}
 
 		leases = append(leases, lease)
 	}
@@ -275,6 +278,10 @@ func parseArpLine(line string) (dhcpLease, error) {
 	}
 
 	ip := strings.Trim(parts[1], "()")
+	if parts[3] == "(incomplete)" {
+		return dhcpLease{}, nil
+	}
+
 	mac, err := normalizeMAC(parts[3])
 	if err != nil {
 		return dhcpLease{}, fmt.Errorf("error normalizing MAC address: %w", err)


### PR DESCRIPTION
What does this PR do?
---------------------
Ignores ARP entries with `(incomplete)` for MAC address


Which scenarios this will impact?
-------------------
`aws/microVMs`

Motivation
----------
log spam


Additional Notes
----------------
