### PR TITLE
Ensure unattended-upgrade processes are getting killed

### DIFF
--- a/components/os/scripts/apt-disable-unattended-upgrades.sh
+++ b/components/os/scripts/apt-disable-unattended-upgrades.sh
@@ -14,3 +14,7 @@ sudo systemctl disable apt-daily-upgrade.service || true
 sudo systemctl disable apt-daily-upgrade.timer || true
 sudo systemctl stop apt-daily-upgrade.service || true
 sudo systemctl stop apt-daily-upgrade.timer || true
+
+# Kill any remaining unattended-upgrades processes just in case
+sudo killall -9 unattended-upgrades || true
+sudo killall -9 unattended-upgrade-shutdown || true

--- a/components/os/scripts/apt-disable-unattended-upgrades.sh
+++ b/components/os/scripts/apt-disable-unattended-upgrades.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-apt-get -y remove unattended-upgrades
+
+# Kill any unattended-upgrades processes
+sudo killall -9 unattended-upgrades || true
+sudo killall -9 unattended-upgrade-shutdown || true
 
 # Try to disable unattended upgrades and apt automatic updates, should not fail if it is not installed
 sudo systemctl disable unattented-upgrades.service || true
@@ -15,6 +18,4 @@ sudo systemctl disable apt-daily-upgrade.timer || true
 sudo systemctl stop apt-daily-upgrade.service || true
 sudo systemctl stop apt-daily-upgrade.timer || true
 
-# Kill any remaining unattended-upgrades processes just in case
-sudo killall -9 unattended-upgrades || true
-sudo killall -9 unattended-upgrade-shutdown || true
+apt-get -y purge unattended-upgrades

--- a/components/os/scripts/apt-disable-unattended-upgrades.sh
+++ b/components/os/scripts/apt-disable-unattended-upgrades.sh
@@ -1,12 +1,8 @@
 #!/bin/bash
 
-# Kill any unattended-upgrades processes
-sudo killall -9 unattended-upgrades || true
-sudo killall -9 unattended-upgrade-shutdown || true
-
 # Try to disable unattended upgrades and apt automatic updates, should not fail if it is not installed
-sudo systemctl disable unattented-upgrades.service || true
-sudo systemctl stop unattented-upgrades.service || true
+sudo systemctl disable unattended-upgrades.service || true
+sudo systemctl stop unattended-upgrades.service || true
 
 sudo systemctl disable apt-daily.service || true
 sudo systemctl disable apt-daily.time || true
@@ -17,5 +13,18 @@ sudo systemctl disable apt-daily-upgrade.service || true
 sudo systemctl disable apt-daily-upgrade.timer || true
 sudo systemctl stop apt-daily-upgrade.service || true
 sudo systemctl stop apt-daily-upgrade.timer || true
+
+# Send the TERM signal to any remaining unattended-upgrades processes
+pgrep unattended-upgrades | xargs -r -n 1 -t kill -TERM || true
+
+max_to_wait=10
+while pgrep unattended-upgrades && [ $max_to_wait -gt 0 ]; do
+	echo "Waiting for unattended-upgrades to terminate"
+	sleep 1
+	max_to_wait=$((max_to_wait - 1))
+done
+
+# Kill any unattended-upgrades processes that didn't terminate
+pgrep unattended-upgrades | xargs -r -n 1 -t kill -KILL || true
 
 apt-get -y purge unattended-upgrades


### PR DESCRIPTION
What does this PR do?
---------------------

Adds extra commands to ensure unattended-upgrades processes get killed.

Which scenarios this will impact?
-------------------

Most of the scenarios run the cloud init script.

Motivation
----------

Reduce flakiness due to unattended-upgrades lingering.

Additional Notes
----------------
