### PR TITLE
[components/datadog] Add etcd with config check

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -406,6 +406,21 @@ func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentI
 					},
 				},
 			},
+			// "useConfigMap" and "customAgentConfig" are used to configure the
+			// agent to get check configurations from etcd. "config_providers"
+			// cannot be configured via ENV, so we need to use a ConfigMap.
+			"useConfigMap": pulumi.Bool(true),
+			"customAgentConfig": pulumi.Map{
+				"config_providers": pulumi.Array{
+					pulumi.Map{
+						"name":         pulumi.String("etcd"),
+						"polling":      pulumi.Bool(true),
+						"template_dir": pulumi.String("/datadog/check_configs"),
+						// This relies on a service exposed by the etcd app
+						"template_url": pulumi.String("http://etcd.etcd.svc.cluster.local:2379"),
+					},
+				},
+			},
 		},
 		"clusterAgent": pulumi.Map{
 			"enabled": pulumi.Bool(true),

--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/etcd"
 	"github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	"github.com/DataDog/test-infra-definitions/resources/helm"
 
@@ -417,7 +418,9 @@ func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentI
 						"polling":      pulumi.Bool(true),
 						"template_dir": pulumi.String("/datadog/check_configs"),
 						// This relies on a service exposed by the etcd app
-						"template_url": pulumi.String("http://etcd.etcd.svc.cluster.local:2379"),
+						"template_url": pulumi.String(
+							fmt.Sprintf("http://%s.%s.svc.cluster.local:2379", etcd.ServiceName, etcd.Namespace),
+						),
 					},
 				},
 			},

--- a/components/datadog/apps/etcd/k8s.go
+++ b/components/datadog/apps/etcd/k8s.go
@@ -63,7 +63,10 @@ echo "[init] Done setting check configuration keys in etcd"
 sleep infinity
 `
 
-func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
+const Namespace = "etcd"
+const ServiceName = "etcd"
+
+func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &componentskube.Workload{}
@@ -73,9 +76,9 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 
 	opts = append(opts, pulumi.Parent(k8sComponent))
 
-	ns, err := corev1.NewNamespace(e.Ctx(), namespace, &corev1.NamespaceArgs{
+	ns, err := corev1.NewNamespace(e.Ctx(), Namespace, &corev1.NamespaceArgs{
 		Metadata: metav1.ObjectMetaArgs{
-			Name: pulumi.String(namespace),
+			Name: pulumi.String(Namespace),
 		},
 	}, opts...)
 	if err != nil {
@@ -87,7 +90,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 	_, err = appsv1.NewDeployment(e.Ctx(), "etcd", &appsv1.DeploymentArgs{
 		Metadata: &metav1.ObjectMetaArgs{
 			Name:      pulumi.String("etcd"),
-			Namespace: pulumi.String(namespace),
+			Namespace: pulumi.String(Namespace),
 			Labels: pulumi.StringMap{
 				"app": pulumi.String("etcd"),
 			},
@@ -165,10 +168,10 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 		return nil, err
 	}
 
-	_, err = corev1.NewService(e.Ctx(), "etcd", &corev1.ServiceArgs{
+	_, err = corev1.NewService(e.Ctx(), ServiceName, &corev1.ServiceArgs{
 		Metadata: &metav1.ObjectMetaArgs{
-			Name:      pulumi.String("etcd"),
-			Namespace: pulumi.String(namespace),
+			Name:      pulumi.String(ServiceName),
+			Namespace: pulumi.String(Namespace),
 			Labels: pulumi.StringMap{
 				"app": pulumi.String("etcd"),
 			},

--- a/components/datadog/apps/etcd/k8s.go
+++ b/components/datadog/apps/etcd/k8s.go
@@ -110,6 +110,24 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 									Protocol:      pulumi.String("TCP"),
 								},
 							},
+							ReadinessProbe: &corev1.ProbeArgs{
+								HttpGet: &corev1.HTTPGetActionArgs{
+									Path:   pulumi.String("/health"),
+									Port:   pulumi.Int(2379),
+									Scheme: pulumi.String("HTTP"),
+								},
+								InitialDelaySeconds: pulumi.Int(10),
+								TimeoutSeconds:      pulumi.Int(5),
+							},
+							LivenessProbe: &corev1.ProbeArgs{
+								HttpGet: &corev1.HTTPGetActionArgs{
+									Path:   pulumi.String("/health"),
+									Port:   pulumi.Int(2379),
+									Scheme: pulumi.String("HTTP"),
+								},
+								InitialDelaySeconds: pulumi.Int(10),
+								TimeoutSeconds:      pulumi.Int(5),
+							},
 						},
 					},
 				},

--- a/components/datadog/apps/etcd/k8s.go
+++ b/components/datadog/apps/etcd/k8s.go
@@ -1,0 +1,150 @@
+package etcd
+
+import (
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/common/utils"
+	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
+)
+
+// This stores an openmetrics check configuration in etcd.
+// It runs the check against the example prometheus app already deployed
+// ("apps-prometheus").
+// The check renames one of the prometheus metrics so that we can verify that
+// the check was discovered.
+const setupCommands = `
+# Start etcd in background
+etcd --enable-v2 \
+     --name=etcd-0 \
+     --data-dir=/var/lib/etcd \
+     --listen-client-urls=http://0.0.0.0:2379 \
+     --advertise-client-urls=http://etcd:2379 \
+     --listen-peer-urls=http://0.0.0.0:2380 \
+     --initial-advertise-peer-urls=http://etcd:2380 \
+     --initial-cluster=etcd-0=http://etcd:2380 \
+     --initial-cluster-token=etcd-cluster-1 \
+     --initial-cluster-state=new &
+
+# Wait for etcd to be ready
+until etcdctl endpoint health; do
+  echo "Waiting for etcd..."
+  sleep 1
+done
+
+# It's not always immediately ready. Let's wait a bit more to be sure.
+sleep 10
+
+export ETCDCTL_API=2
+etcdctl set /datadog/check_configs/apps-prometheus/check_names '["openmetrics"]'
+etcdctl set /datadog/check_configs/apps-prometheus/init_configs '[{}]'
+etcdctl set /datadog/check_configs/apps-prometheus/instances '[{"openmetrics_endpoint": "http://%%host%%:8080/metrics", "metrics":[{"prom_gauge": "prom_gauge_configured_in_etcd"}]}]'
+
+wait
+`
+
+func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
+	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
+
+	k8sComponent := &componentskube.Workload{}
+	if err := e.Ctx().RegisterComponentResource("dd:apps", "etcd", k8sComponent, opts...); err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, pulumi.Parent(k8sComponent))
+
+	ns, err := corev1.NewNamespace(e.Ctx(), namespace, &corev1.NamespaceArgs{
+		Metadata: metav1.ObjectMetaArgs{
+			Name: pulumi.String(namespace),
+		},
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, utils.PulumiDependsOn(ns))
+
+	_, err = appsv1.NewDeployment(e.Ctx(), "etcd", &appsv1.DeploymentArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.String("etcd"),
+			Namespace: pulumi.String(namespace),
+			Labels: pulumi.StringMap{
+				"app": pulumi.String("etcd"),
+			},
+		},
+		Spec: &appsv1.DeploymentSpecArgs{
+			Replicas: pulumi.Int(1),
+			Selector: &metav1.LabelSelectorArgs{
+				MatchLabels: pulumi.StringMap{
+					"app": pulumi.String("etcd"),
+				},
+			},
+			Template: &corev1.PodTemplateSpecArgs{
+				Metadata: &metav1.ObjectMetaArgs{
+					Labels: pulumi.StringMap{
+						"app": pulumi.String("etcd"),
+					},
+				},
+				Spec: &corev1.PodSpecArgs{
+					Containers: corev1.ContainerArray{
+						&corev1.ContainerArgs{
+							Name: pulumi.String("etcd"),
+							// The agent only supports the v2 API, which is not
+							// supported anymore in newer versions of etcd.
+							Image: pulumi.String("quay.io/coreos/etcd:v3.5.1"),
+							Command: pulumi.StringArray{
+								pulumi.String("/bin/sh"),
+								pulumi.String("-c"),
+							},
+							Args: pulumi.StringArray{
+								pulumi.String(setupCommands),
+							},
+							Ports: &corev1.ContainerPortArray{
+								&corev1.ContainerPortArgs{
+									Name:          pulumi.String("etcd"),
+									ContainerPort: pulumi.Int(2379),
+									Protocol:      pulumi.String("TCP"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = corev1.NewService(e.Ctx(), "etcd", &corev1.ServiceArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.String("etcd"),
+			Namespace: pulumi.String(namespace),
+			Labels: pulumi.StringMap{
+				"app": pulumi.String("etcd"),
+			},
+		},
+		Spec: &corev1.ServiceSpecArgs{
+			Selector: pulumi.StringMap{
+				"app": pulumi.String("etcd"),
+			},
+			Ports: &corev1.ServicePortArray{
+				&corev1.ServicePortArgs{
+					Name:       pulumi.String("client"),
+					Port:       pulumi.Int(2379),
+					TargetPort: pulumi.Int(2379),
+					Protocol:   pulumi.String("TCP"),
+				},
+			},
+		},
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return k8sComponent, nil
+}

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -5,6 +5,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent/helm"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/cpustress"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/dogstatsd"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/etcd"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/mutatedbyadmissioncontroller"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/nginx"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/prometheus"
@@ -146,6 +147,10 @@ func Run(ctx *pulumi.Context) error {
 		}
 
 		if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-mutated", "workload-mutated-lib-injection", dependsOnDDAgent /* for admission */); err != nil {
+			return err
+		}
+
+		if _, err := etcd.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "etcd"); err != nil {
 			return err
 		}
 	}

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -150,7 +150,7 @@ func Run(ctx *pulumi.Context) error {
 			return err
 		}
 
-		if _, err := etcd.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "etcd"); err != nil {
+		if _, err := etcd.K8sAppDefinition(&awsEnv, cluster.KubeProvider); err != nil {
 			return err
 		}
 	}

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -7,6 +7,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/components/datadog/agentwithoperatorparams"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/cpustress"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/dogstatsd"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/etcd"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/mutatedbyadmissioncontroller"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/nginx"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/prometheus"
@@ -239,6 +240,10 @@ spec:
 		}
 
 		if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-mutated", "workload-mutated-lib-injection", dependsOnDDAgent /* for admission */); err != nil {
+			return err
+		}
+
+		if _, err := etcd.K8sAppDefinition(&awsEnv, kindKubeProvider, "etcd"); err != nil {
 			return err
 		}
 	}

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -243,7 +243,7 @@ spec:
 			return err
 		}
 
-		if _, err := etcd.K8sAppDefinition(&awsEnv, kindKubeProvider, "etcd"); err != nil {
+		if _, err := etcd.K8sAppDefinition(&awsEnv, kindKubeProvider); err != nil {
 			return err
 		}
 	}

--- a/scenarios/azure/aks/run.go
+++ b/scenarios/azure/aks/run.go
@@ -5,6 +5,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent/helm"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/cpustress"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/dogstatsd"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/etcd"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/mutatedbyadmissioncontroller"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/nginx"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/prometheus"
@@ -142,6 +143,10 @@ providers:
 		}
 
 		if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(&env, aksCluster.KubeProvider, "workload-mutated", "workload-mutated-lib-injection", dependsOnDDAgent /* for admission */); err != nil {
+			return err
+		}
+
+		if _, err := etcd.K8sAppDefinition(&env, aksCluster.KubeProvider, "etcd"); err != nil {
 			return err
 		}
 	}

--- a/scenarios/azure/aks/run.go
+++ b/scenarios/azure/aks/run.go
@@ -146,7 +146,7 @@ providers:
 			return err
 		}
 
-		if _, err := etcd.K8sAppDefinition(&env, aksCluster.KubeProvider, "etcd"); err != nil {
+		if _, err := etcd.K8sAppDefinition(&env, aksCluster.KubeProvider); err != nil {
 			return err
 		}
 	}

--- a/scenarios/gcp/gke/run.go
+++ b/scenarios/gcp/gke/run.go
@@ -5,6 +5,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent/helm"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/cpustress"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/dogstatsd"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/etcd"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/mutatedbyadmissioncontroller"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/nginx"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/prometheus"
@@ -103,6 +104,10 @@ func Run(ctx *pulumi.Context) error {
 		}
 
 		if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(&env, cluster.KubeProvider, "workload-mutated", "workload-mutated-lib-injection", dependsOnDDAgent /* for admission */); err != nil {
+			return err
+		}
+
+		if _, err := etcd.K8sAppDefinition(&env, cluster.KubeProvider, "etcd"); err != nil {
 			return err
 		}
 

--- a/scenarios/gcp/gke/run.go
+++ b/scenarios/gcp/gke/run.go
@@ -107,7 +107,7 @@ func Run(ctx *pulumi.Context) error {
 			return err
 		}
 
-		if _, err := etcd.K8sAppDefinition(&env, cluster.KubeProvider, "etcd"); err != nil {
+		if _, err := etcd.K8sAppDefinition(&env, cluster.KubeProvider); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
What does this PR do?
---------------------

Adds an etcd pod that stores a Datadog check configuration for testing purposes. This setup uses a basic OpenMetrics check and is intended to validate that Autodiscovery works correctly when etcd is used as a configuration provider.