### PR TITLE
Add || true so that user script never fails

### DIFF
--- a/components/os/scripts/apt-disable-unattended-upgrades.sh
+++ b/components/os/scripts/apt-disable-unattended-upgrades.sh
@@ -27,4 +27,4 @@ done
 # Kill any unattended-upgrades processes that didn't terminate
 pgrep unattended-upgrades | xargs -r -n 1 -t kill -KILL || true
 
-apt-get -y purge unattended-upgrades
+apt-get -y purge unattended-upgrades || true


### PR DESCRIPTION
What does this PR do?
---------------------

Add a `|| true` to make sure instruction executed in user script never fails. Otherwise it will break the connection to the VM in tests.
We had some occurence of that call failing in debian 10 test

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
