### PR TITLE
fix(awscli) Force the v2 installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update -y && \
   # AWS v2 cli
   curl --retry 10 -fsSLo awscliv2.zip https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip && \
   unzip -q awscliv2.zip && \
-  ./aws/install && \
+  ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update && \
   rm -rf aws && \
   rm awscliv2.zip && \
   # Add additional apt repos all at once


### PR DESCRIPTION
What does this PR do?
---------------------
The awsv2 installed version using curl is currently installed in `/usr/local/aws-cli/v2/current`. Using the `--update` should force the installation in `/usr/local/bin` and usage of this version when running aws commands.

Which scenarios this will impact?
-------------------
All, but this is not a functional modification of the framework

Motivation
----------
When we run `e2e` tests on `datadog-agent` we have these warnings ([link](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/867053946))
```
/usr/local/lib/python3.12/site-packages/awscli/compat.py:454: SyntaxWarning: invalid escape sequence '\s'
  _distributor_id_file_re = re.compile("(?:DISTRIB_ID\s*=)\s*(.*)", re.I)
/usr/local/lib/python3.12/site-packages/awscli/compat.py:455: SyntaxWarning: invalid escape sequence '\s'
  _release_file_re = re.compile("(?:DISTRIB_RELEASE\s*=)\s*(.*)", re.I)
/usr/local/lib/python3.12/site-packages/awscli/compat.py:456: SyntaxWarning: invalid escape sequence '\s'
  _codename_file_re = re.compile("(?:DISTRIB_CODENAME\s*=)\s*(.*)", re.I)
/usr/local/lib/python3.12/site-packages/awscli/shorthand.py:132: SyntaxWarning: invalid escape sequence '\!'
  _START_WORD = u'\!\#-&\(-\+\--\<\>-Z\\\\-z\u007c-\uffff'
/usr/local/lib/python3.12/site-packages/awscli/shorthand.py:133: SyntaxWarning: invalid escape sequence '\s'
  _FIRST_FOLLOW_CHARS = u'\s\!\#-&\(-\+\--\\\\\^-\|~-\uffff'
/usr/local/lib/python3.12/site-packages/awscli/shorthand.py:134: SyntaxWarning: invalid escape sequence '\s'
  _SECOND_FOLLOW_CHARS = u'\s\!\#-&\(-\+\--\<\>-\uffff'
/usr/local/lib/python3.12/site-packages/awscli/customizations/cloudtrail/validation.py:76: SyntaxWarning: invalid escape sequence '\d'
  pattern = re.compile('arn:.+:cloudtrail:.+:\d{12}:trail/.+')
/usr/local/lib/python3.12/site-packages/awscli/customizations/codedeploy/push.py:65: SyntaxWarning: invalid escape sequence '\<'
  'uploading. Use the format s3://\<bucket\>/\<key\>'
/usr/local/lib/python3.12/site-packages/awscli/customizations/emr/createcluster.py:195: SyntaxWarning: invalid escape sequence '\d'
```
This started with use of python3.12 and is [fixed](https://github.com/aws/aws-cli/issues/8547) on awscli side.
On the image we are using 
```
aws-cli/1.29.45 Python/3.12.9 Linux/5.15.49-linuxkit-pr botocore/1.31.45
```
despite installing awscli v2 on the `Dockerfile`
Tested in the image:
```
root@98338f1bf6a7:/# aws --version
/usr/local/lib/python3.12/site-packages/awscli/compat.py:454: SyntaxWarning: invalid escape sequence '\s'
  _distributor_id_file_re = re.compile("(?:DISTRIB_ID\s*=)\s*(.*)", re.I)
/usr/local/lib/python3.12/site-packages/awscli/compat.py:455: SyntaxWarning: invalid escape sequence '\s'
  _release_file_re = re.compile("(?:DISTRIB_RELEASE\s*=)\s*(.*)", re.I)
/usr/local/lib/python3.12/site-packages/awscli/compat.py:456: SyntaxWarning: invalid escape sequence '\s'
  _codename_file_re = re.compile("(?:DISTRIB_CODENAME\s*=)\s*(.*)", re.I)
/usr/local/lib/python3.12/site-packages/awscli/shorthand.py:132: SyntaxWarning: invalid escape sequence '\!'
  _START_WORD = u'\!\#-&\(-\+\--\<\>-Z\\\\-z\u007c-\uffff'
/usr/local/lib/python3.12/site-packages/awscli/shorthand.py:133: SyntaxWarning: invalid escape sequence '\s'
  _FIRST_FOLLOW_CHARS = u'\s\!\#-&\(-\+\--\\\\\^-\|~-\uffff'
/usr/local/lib/python3.12/site-packages/awscli/shorthand.py:134: SyntaxWarning: invalid escape sequence '\s'
  _SECOND_FOLLOW_CHARS = u'\s\!\#-&\(-\+\--\<\>-\uffff'
/usr/local/lib/python3.12/site-packages/awscli/customizations/cloudtrail/validation.py:76: SyntaxWarning: invalid escape sequence '\d'
  pattern = re.compile('arn:.+:cloudtrail:.+:\d{12}:trail/.+')
/usr/local/lib/python3.12/site-packages/awscli/customizations/codedeploy/push.py:65: SyntaxWarning: invalid escape sequence '\<'
  'uploading. Use the format s3://\<bucket\>/\<key\>'
/usr/local/lib/python3.12/site-packages/awscli/customizations/emr/createcluster.py:195: SyntaxWarning: invalid escape sequence '\d'
  is_valid_ami_version = re.match('\d?\..*', parsed_args.ami_version)
aws-cli/1.29.45 Python/3.12.9 Linux/5.15.49-linuxkit-pr botocore/1.31.45
root@98338f1bf6a7:/# export PATH=/usr/local/aws-cli/v2/current/bin:$PATH
root@98338f1bf6a7:/# which aws
/usr/local/aws-cli/v2/current/bin/aws
root@98338f1bf6a7:/# aws --version
aws-cli/2.25.1 Python/3.12.9 Linux/5.15.49-linuxkit-pr exe/x86_64.debian.11
```

Additional Notes
----------------
The `--bin-dir` and `--install-dir` are maybe not necessary but it's safer and as explained in the [documentation](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-version.html)
