### PR TITLE
Set cluster-agent replicas to 2

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -467,6 +467,7 @@ func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentI
 				"tag":           pulumi.String(clusterAgentImageTag),
 				"doNotCheckTag": pulumi.Bool(true),
 			},
+			"replicas": pulumi.Int(2),
 			"metricsProvider": pulumi.Map{
 				"enabled":           pulumi.Bool(true),
 				"useDatadogMetrics": pulumi.Bool(true),


### PR DESCRIPTION
What does this PR do?
---------------------
Set cluster agent replicas to 2 so that k8s cluster has one leader dca and one follower dca pod.

Which scenarios this will impact?
-------------------
k8s_test.go
eks_test.go

Motivation
----------
Cluster agent leader election test has been added to E2E test in[PR](https://github.com/DataDog/datadog-agent/pull/35612)

Additional Notes
----------------
Test run is [here](https://github.com/DataDog/datadog-agent/pull/35991)
