### PR TITLE
Remove all apt/dpkg locks in cloud-init script

### DIFF
--- a/components/os/scripts/apt-disable-unattended-upgrades.sh
+++ b/components/os/scripts/apt-disable-unattended-upgrades.sh
@@ -28,3 +28,10 @@ done
 pgrep unattended-upgrades | xargs -r -n 1 -t kill -KILL || true
 
 apt-get -y purge unattended-upgrades || true
+
+# Ensure the lock files are removed
+rm -f /var/lib/apt/lists/lock || true
+rm -f /var/cache/apt/archives/lock || true
+rm -f /var/lib/dpkg/lock || true
+rm -f /var/lib/dpkg/lock-frontend || true
+rm -f /var/cache/apt/archives/partial/lock || true


### PR DESCRIPTION
What does this PR do?
---------------------

Remove all DPKG/APT locks when the init-script finishes

Which scenarios this will impact?
-------------------

Motivation
----------

Avoid unattended-upgrades causing CI failures

Additional Notes
----------------
