### PR TITLE
Fix apt-get unattended-upgrades removal

### DIFF
--- a/components/os/scripts/apt-disable-unattended-upgrades.sh
+++ b/components/os/scripts/apt-disable-unattended-upgrades.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Try to disable unattended upgrades and apt automatic updates, should not fail if it is not installed
 sudo systemctl disable unattended-upgrades.service || true
 sudo systemctl stop unattended-upgrades.service || true
@@ -15,16 +17,23 @@ sudo systemctl stop apt-daily-upgrade.service || true
 sudo systemctl stop apt-daily-upgrade.timer || true
 
 # Send the TERM signal to any remaining unattended-upgrades processes
-pgrep unattended-upgrades | xargs -r -n 1 -t kill -TERM || true
+pkill --signal TERM -f unattended-upgrade || true
 
 max_to_wait=10
-while pgrep unattended-upgrades && [ $max_to_wait -gt 0 ]; do
-	echo "Waiting for unattended-upgrades to terminate"
+while pgrep -f unattended-upgrade && [ $max_to_wait -gt 0 ]; do
+	echo "Waiting for unattended-upgrade to terminate"
 	sleep 1
 	max_to_wait=$((max_to_wait - 1))
 done
 
-# Kill any unattended-upgrades processes that didn't terminate
-pgrep unattended-upgrades | xargs -r -n 1 -t kill -KILL || true
+# Kill any unattended-upgrade processes that didn't terminate
+pkill --signal KILL -f unattended-upgrade || true
 
-apt-get -y purge unattended-upgrades || true
+# Ensure the lock files are removed
+rm -f /var/lib/apt/lists/lock || true
+rm -f /var/cache/apt/archives/lock || true
+rm -f /var/lib/dpkg/lock || true
+rm -f /var/lib/dpkg/lock-frontend || true
+rm -f /var/cache/apt/archives/partial/lock || true
+
+apt-get -y purge unattended-upgrade || true

--- a/components/os/scripts/apt-disable-unattended-upgrades.sh
+++ b/components/os/scripts/apt-disable-unattended-upgrades.sh
@@ -36,4 +36,8 @@ rm -f /var/lib/dpkg/lock || true
 rm -f /var/lib/dpkg/lock-frontend || true
 rm -f /var/cache/apt/archives/partial/lock || true
 
-apt-get -y purge unattended-upgrade || true
+# Important note: we're searching for unattended-upgrade for the process because
+# apparently there can be 'unattended-upgrades' and 'unattended-upgrade' commands
+# However, the APT package is called unattended-upgrades
+
+apt-get -y purge unattended-upgrades || true


### PR DESCRIPTION
What does this PR do?
---------------------

Fix the removal of unattended-upgrades by purging _after_ removing the locks in case they're taken

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
