### PR TITLE
Specifying local package folder with a given flavor should work

### DIFF
--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -69,14 +69,15 @@ func NewParams(env config.Env, options ...Option) (*Params, error) {
 	if env.PipelineID() != "" {
 		defaultVersion = WithPipeline(env.PipelineID())
 	}
+	if env.AgentLocalPackage() != "" {
+		defaultVersion = WithLocalPackage(env.AgentLocalPackage())
+	}
 	if env.AgentVersion() != "" {
 		defaultVersion = WithVersion(env.AgentVersion())
 	}
+
 	if env.AgentFIPS() {
 		defaultFlavor = WithFlavor(FIPSFlavor)
-	}
-	if env.AgentLocalPackage() != "" {
-		defaultFlavor = WithLocalPackage(env.AgentLocalPackage())
 	}
 
 	options = append([]Option{defaultFlavor}, options...)


### PR DESCRIPTION
What does this PR do?
---------------------

Before that PR, using local package would override the flavor, both should be compatible.
Instead we put local package in `defaultVersion` argument. That way the version is given by:
- a special version
- local package path
- pipeline id
In that order of priority


Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
