### PR TITLE
feat(autobump): Push signed commits on auto-bump PR

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,6 +124,7 @@ bump-version-on-datadog-agent:
         EXTRA_UPDATE_ARGS: "--is-dev-image"
   variables:
     EXTRA_UPDATE_ARGS: ""
+    PR_BRANCH: auto-bump/bump-test-infra-$CI_COMMIT_SHORT_SHA
   before_script:
     - set +x
     - export GITHUB_APP_USER_ID=153269286 # Can be found on https://api.github.com/users/agent-platform-auto-pr[bot]
@@ -140,13 +141,13 @@ bump-version-on-datadog-agent:
     - git config --global credential.helper '!f() { echo "username=x-access-token"; echo "password='${GITHUB_TOKEN}'"; }; f'
     - git clone https://github.com/DataDog/datadog-agent.git datadog-agent
     - pushd datadog-agent
-    - git checkout -b auto-bump/bump-test-infra-$CI_COMMIT_SHORT_SHA
+    - git checkout -b $PR_BRANCH
+    - git push origin $PR_BRANCH # Create the reference to push the commit through API later
     - export PREVIOUS_SHA=$(cat .gitlab/common/test_infra_version.yml | grep 'TEST_INFRA_DEFINITIONS_BUILDIMAGES:' | awk -F " " '{print $NF}')
     - inv -e buildimages.update-test-infra-definitions --commit-sha $CI_COMMIT_SHA $EXTRA_UPDATE_ARGS
     - inv -e tidy
     - git add -u
-    - git commit -m "[test-infra-definitions][automated] Bump test-infra-definitions to $CI_COMMIT_SHORT_SHA"
-    - git push -f origin auto-bump/bump-test-infra-$CI_COMMIT_SHORT_SHA
+    - inv -e git.push-signed-commits --branch $PR_BRANCH --commit-message "[test-infra-definitions][automated] Bump test-infra-definitions to $CI_COMMIT_SHORT_SHA"
     - popd
     - pip install -r requirements.txt
     - inv ci.create-bump-pr-and-close-stale-ones-on-datadog-agent --branch auto-bump/bump-test-infra-$CI_COMMIT_SHORT_SHA --new-commit-sha $CI_COMMIT_SHA --old-commit-sha $PREVIOUS_SHA


### PR DESCRIPTION
What does this PR do?
---------------------
Use a new task defined in https://github.com/DataDog/datadog-agent/pull/36163 to push signed commits when creating the auto-bump PR.
Tested with [this pipeline](https://gitlab.ddbuild.io/DataDog/test-infra-definitions/-/jobs/898989580) and signed commit was properly created [here](https://github.com/DataDog/datadog-agent/commit/56fdb74b654133fe30bd7d193117bb63b7a387c3)

Which scenarios this will impact?
-------------------
PR creation

Motivation
----------
https://datadoghq.atlassian.net/browse/ACIX-515

Additional Notes
----------------
