### PR TITLE
Check binary for ECR credentials helper

### DIFF
--- a/scenarios/aws/ec2/vm.go
+++ b/scenarios/aws/ec2/vm.go
@@ -110,7 +110,7 @@ func NewVM(e aws.Environment, name string, params ...VMOption) (*remote.Host, er
 }
 
 func InstallECRCredentialsHelper(e aws.Environment, vm *remote.Host) (command.Command, error) {
-	ecrCredsHelperInstall, err := vm.OS.PackageManager().Ensure("amazon-ecr-credential-helper", nil, "")
+	ecrCredsHelperInstall, err := vm.OS.PackageManager().Ensure("amazon-ecr-credential-helper", nil, "docker-credential-ecr-login")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
What does this PR do?
---------------------

Checks that the binary for the ecr credentials helper is not present before trying to install it.

Which scenarios this will impact?
-------------------

Motivation
----------

Some AMIs have the binary installed, without using the package manager. If we always try to install it the provisioning fails.

Additional Notes
----------------
