### PR TITLE
Fail if several pacakge are found for the test

### DIFF
--- a/components/datadog/agent/package.go
+++ b/components/datadog/agent/package.go
@@ -76,6 +76,11 @@ func GetPackagePath(localPath string, flavor tifos.Flavor, agentFlavor string, a
 				continue
 			}
 
+			// Exclude datadog-agent-upgrade-test package on Windows
+			if flavor == tifos.WindowsServer && strings.Contains(entry.Name(), "upgrade-test") {
+				continue
+			}
+
 			// Skip architecture check for Windows packages
 			if flavor != tifos.WindowsServer {
 				archStr := string(arch)
@@ -126,7 +131,7 @@ func GetPackagePath(localPath string, flavor tifos.Flavor, agentFlavor string, a
 		}
 
 		if len(matches) > 1 {
-			fmt.Printf("Found multiple packages to install, using the first one: %s\n", matches[0])
+			return "", fmt.Errorf("found multiple packages to install:\n%s", strings.Join(matches, "\n"))
 		}
 		packagePath = path.Join(packagePath, matches[0])
 	} else {


### PR DESCRIPTION
What does this PR do?
---------------------

Picking the first artifact can lead to unexpected artifact installed in the CI, let's avoid that.
Also ignore upgrade-test msi packages that are exposed by the agent CI

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
