### PR TITLE
Use pinned version of the test apps docker images

### DIFF
--- a/components/datadog/apps/dogstatsd/docker-compose.yaml
+++ b/components/datadog/apps/dogstatsd/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   dogstatsd-udp:
-    image: ghcr.io/datadog/apps-dogstatsd:main
+    image: ghcr.io/datadog/apps-dogstatsd:{APPS_VERSION}
     container_name: metric-sender-udp
     network_mode: host
     pid: "host"
@@ -10,7 +10,7 @@ services:
     depends_on:
       - agent
   dogstatsd-uds:
-    image: ghcr.io/datadog/apps-dogstatsd:main
+    image: ghcr.io/datadog/apps-dogstatsd:{APPS_VERSION}
     container_name: metric-sender-uds
     volumes:
       - /var/run/datadog:/var/run/datadog:ro

--- a/components/datadog/apps/dogstatsd/docker.go
+++ b/components/datadog/apps/dogstatsd/docker.go
@@ -2,7 +2,9 @@ package dogstatsd
 
 import (
 	_ "embed"
+	"strings"
 
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	"github.com/DataDog/test-infra-definitions/components/docker"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -13,5 +15,5 @@ var dockerComposeContent string
 
 var DockerComposeManifest = docker.ComposeInlineManifest{
 	Name:    "dogstatsd-sender",
-	Content: pulumi.String(dockerComposeContent),
+	Content: pulumi.String(strings.ReplaceAll(dockerComposeContent, "{APPS_VERSION}", apps.Version)),
 }

--- a/components/datadog/apps/dogstatsd/ecs.go
+++ b/components/datadog/apps/dogstatsd/ecs.go
@@ -2,6 +2,7 @@ package dogstatsd
 
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	ecsComp "github.com/DataDog/test-infra-definitions/components/ecs"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 	classicECS "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ecs"
@@ -34,7 +35,7 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...
 			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
 				"dogstatsd": {
 					Name:  pulumi.String("dogstatsd"),
-					Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:main"),
+					Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:" + apps.Version),
 					Environment: ecs.TaskDefinitionKeyValuePairArray{
 						ecs.TaskDefinitionKeyValuePairArgs{
 							Name:  pulumi.StringPtr("STATSD_URL"),
@@ -80,7 +81,7 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...
 			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
 				"dogstatsd": {
 					Name:  pulumi.String("dogstatsd"),
-					Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:main"),
+					Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:" + apps.Version),
 					Environment: ecs.TaskDefinitionKeyValuePairArray{
 						ecs.TaskDefinitionKeyValuePairArgs{
 							Name:  pulumi.StringPtr("ECS_AGENT_HOST"),

--- a/components/datadog/apps/dogstatsd/eksFargate.go
+++ b/components/datadog/apps/dogstatsd/eksFargate.go
@@ -3,6 +3,7 @@ package dogstatsd
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
 
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
@@ -146,7 +147,7 @@ func EksFargateAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, na
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("dogstatsd"),
-							Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:main"),
+							Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:" + apps.Version),
 							Env: &corev1.EnvVarArray{
 								&corev1.EnvVarArgs{
 									Name:  pulumi.String("STATSD_URL"),

--- a/components/datadog/apps/dogstatsd/k8s.go
+++ b/components/datadog/apps/dogstatsd/k8s.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
 
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
@@ -60,7 +61,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("dogstatsd"),
-							Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:main"),
+							Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:" + apps.Version),
 							Env: &corev1.EnvVarArray{
 								&corev1.EnvVarArgs{
 									Name:  pulumi.String("STATSD_URL"),
@@ -126,7 +127,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("dogstatsd"),
-							Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:main"),
+							Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:" + apps.Version),
 							Env: &corev1.EnvVarArray{
 								&corev1.EnvVarArgs{
 									Name: pulumi.String("HOST_IP"),
@@ -193,7 +194,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("dogstatsd"),
-							Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:main"),
+							Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:" + apps.Version),
 							Env: &corev1.EnvVarArray{
 								&corev1.EnvVarArgs{
 									Name: pulumi.String("HOST_IP"),
@@ -252,7 +253,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("dogstatsd"),
-							Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:main"),
+							Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:" + apps.Version),
 							Env: &corev1.EnvVarArray{
 								&corev1.EnvVarArgs{
 									Name: pulumi.String("HOST_IP"),
@@ -324,7 +325,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("dogstatsd"),
-							Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:main"),
+							Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:" + apps.Version),
 							Env: &corev1.EnvVarArray{
 								&corev1.EnvVarArgs{
 									Name: pulumi.String("HOST_IP"),

--- a/components/datadog/apps/jmxfetch/docker-compose.yaml
+++ b/components/datadog/apps/jmxfetch/docker-compose.yaml
@@ -4,7 +4,7 @@ version: "3.9"
 services:
 
   jmx-test-app:
-    image: ghcr.io/datadog/apps-jmx-test-app:main
+    image: ghcr.io/datadog/apps-jmx-test-app:{APPS_VERSION}
     container_name: jmx-test-app
     environment:
       HOST_NAME: "jmx-test-app"

--- a/components/datadog/apps/jmxfetch/docker.go
+++ b/components/datadog/apps/jmxfetch/docker.go
@@ -2,7 +2,9 @@ package jmxfetch
 
 import (
 	_ "embed"
+	"strings"
 
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	"github.com/DataDog/test-infra-definitions/components/docker"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -19,7 +21,7 @@ var dockerComposeSlowMetricsContent string
 
 var DockerComposeManifest = docker.ComposeInlineManifest{
 	Name:    "jmx-test-app",
-	Content: pulumi.String(dockerComposeContent),
+	Content: pulumi.String(strings.ReplaceAll(dockerComposeContent, "{APPS_VERSION}", apps.Version)),
 }
 
 var DockerComposeAllMetricsManifest = docker.ComposeInlineManifest{

--- a/components/datadog/apps/logger/docker-compose.yaml
+++ b/components/datadog/apps/logger/docker-compose.yaml
@@ -3,7 +3,7 @@
 services:
 
   logger-app:
-    image: ghcr.io/datadog/apps-logger:main
+    image: ghcr.io/datadog/apps-logger:{APPS_VERSION}
     container_name: logger-app
     depends_on:
       - agent

--- a/components/datadog/apps/logger/docker.go
+++ b/components/datadog/apps/logger/docker.go
@@ -2,7 +2,9 @@ package logger
 
 import (
 	_ "embed"
+	"strings"
 
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	"github.com/DataDog/test-infra-definitions/components/docker"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -13,5 +15,5 @@ var dockerComposeContent string
 
 var DockerComposeManifest = docker.ComposeInlineManifest{
 	Name:    "logger-test",
-	Content: pulumi.String(dockerComposeContent),
+	Content: pulumi.String(strings.ReplaceAll(dockerComposeContent, "{APPS_VERSION}", apps.Version)),
 }

--- a/components/datadog/apps/logger/k8s.go
+++ b/components/datadog/apps/logger/k8s.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
 	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
@@ -63,7 +64,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 					Containers: corev1.ContainerArray{
 						corev1.ContainerArgs{
 							Name:  pulumi.String("logger"),
-							Image: pulumi.String("ghcr.io/datadog/apps-logger:main"),
+							Image: pulumi.String("ghcr.io/datadog/apps-logger:" + apps.Version),
 							Resources: &corev1.ResourceRequirementsArgs{
 								Limits: pulumi.StringMap{
 									"cpu":    pulumi.String("100m"),

--- a/components/datadog/apps/mutatedbyadmissioncontroller/k8s.go
+++ b/components/datadog/apps/mutatedbyadmissioncontroller/k8s.go
@@ -3,6 +3,7 @@ package mutatedbyadmissioncontroller
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"
 
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
 
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
@@ -88,7 +89,7 @@ func k8sDeploymentWithoutLibInjection(e config.Env, namespace string, name strin
 					Containers: corev1.ContainerArray{
 						corev1.ContainerArgs{
 							Name:  pulumi.String(name),
-							Image: pulumi.String("ghcr.io/datadog/apps-mutated:main"),
+							Image: pulumi.String("ghcr.io/datadog/apps-mutated:" + apps.Version),
 						},
 					},
 				},

--- a/components/datadog/apps/nginx/ecs.go
+++ b/components/datadog/apps/nginx/ecs.go
@@ -3,6 +3,7 @@ package nginx
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	ecsComp "github.com/DataDog/test-infra-definitions/components/ecs"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 	classicECS "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ecs"
@@ -31,7 +32,7 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...
 			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
 				"nginx": {
 					Name:  pulumi.String("nginx"),
-					Image: pulumi.String("ghcr.io/datadog/apps-nginx-server:main"),
+					Image: pulumi.String("ghcr.io/datadog/apps-nginx-server:" + apps.Version),
 					DockerLabels: pulumi.StringMap{
 						"com.datadoghq.ad.checks": pulumi.String(utils.JSONMustMarshal(
 							map[string]interface{}{
@@ -78,7 +79,7 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...
 				},
 				"query": {
 					Name:  pulumi.String("query"),
-					Image: pulumi.String("ghcr.io/datadog/apps-http-client:main"),
+					Image: pulumi.String("ghcr.io/datadog/apps-http-client:" + apps.Version),
 					Command: pulumi.StringArray{
 						pulumi.String("-url"),
 						pulumi.String("http://nginx"),

--- a/components/datadog/apps/nginx/ecsFargate.go
+++ b/components/datadog/apps/nginx/ecsFargate.go
@@ -3,6 +3,7 @@ package nginx
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	fakeintakeComp "github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	ecsComp "github.com/DataDog/test-infra-definitions/components/ecs"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
@@ -26,7 +27,7 @@ func FargateAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, apiK
 
 	serverContainer := &ecs.TaskDefinitionContainerDefinitionArgs{
 		Name:  pulumi.String("nginx"),
-		Image: pulumi.String("ghcr.io/datadog/apps-nginx-server:main"),
+		Image: pulumi.String("ghcr.io/datadog/apps-nginx-server:" + apps.Version),
 		DockerLabels: pulumi.StringMap{
 			"com.datadoghq.ad.checks": pulumi.String(utils.JSONMustMarshal(
 				map[string]interface{}{
@@ -69,7 +70,7 @@ func FargateAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, apiK
 
 	queryContainer := &ecs.TaskDefinitionContainerDefinitionArgs{
 		Name:  pulumi.String("query"),
-		Image: pulumi.String("ghcr.io/datadog/apps-http-client:main"),
+		Image: pulumi.String("ghcr.io/datadog/apps-http-client:" + apps.Version),
 		Command: pulumi.StringArray{
 			pulumi.String("-url"),
 			pulumi.String("http://localhost"),

--- a/components/datadog/apps/nginx/k8s.go
+++ b/components/datadog/apps/nginx/k8s.go
@@ -3,6 +3,7 @@ package nginx
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
 
 	"github.com/Masterminds/semver"
@@ -107,7 +108,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("nginx"),
-							Image: pulumi.String("ghcr.io/datadog/apps-nginx-server:main"),
+							Image: pulumi.String("ghcr.io/datadog/apps-nginx-server:" + apps.Version),
 							Resources: &corev1.ResourceRequirementsArgs{
 								Limits: pulumi.StringMap{
 									"cpu":    pulumi.String("100m"),
@@ -411,7 +412,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("query"),
-							Image: pulumi.String("ghcr.io/datadog/apps-http-client:main"),
+							Image: pulumi.String("ghcr.io/datadog/apps-http-client:" + apps.Version),
 							Args: pulumi.StringArray{
 								pulumi.String("-min-tps"),
 								pulumi.String("1"),

--- a/components/datadog/apps/npm-tools/ecs.go
+++ b/components/datadog/apps/npm-tools/ecs.go
@@ -6,6 +6,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	ecsComp "github.com/DataDog/test-infra-definitions/components/ecs"
 	"github.com/pulumi/pulumi-awsx/sdk/v2/go/awsx/awsx"
 	"github.com/pulumi/pulumi-awsx/sdk/v2/go/awsx/ecs"
@@ -36,7 +37,7 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, testURL 
 			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
 				"curl-dig": {
 					Name:  pulumi.String("curl-dig"),
-					Image: pulumi.String("ghcr.io/datadog/apps-npm-tools:main"),
+					Image: pulumi.String("ghcr.io/datadog/apps-npm-tools:" + apps.Version),
 					Command: pulumi.StringArray{
 						pulumi.String("sh"),
 						pulumi.String("-c"),

--- a/components/datadog/apps/npm-tools/k8s.go
+++ b/components/datadog/apps/npm-tools/k8s.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
 )
 
@@ -60,7 +61,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 					Containers: corev1.ContainerArray{
 						corev1.ContainerArgs{
 							Name:  pulumi.String("curl-dig"),
-							Image: pulumi.String("ghcr.io/datadog/apps-npm-tools:main"),
+							Image: pulumi.String("ghcr.io/datadog/apps-npm-tools:" + apps.Version),
 							Args: pulumi.StringArray{
 								pulumi.String("sh"),
 								pulumi.String("-c"),

--- a/components/datadog/apps/prometheus/ecs.go
+++ b/components/datadog/apps/prometheus/ecs.go
@@ -3,6 +3,7 @@ package prometheus
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	ecsComp "github.com/DataDog/test-infra-definitions/components/ecs"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 
@@ -35,7 +36,7 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...
 			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
 				"prometheus": {
 					Name:  pulumi.String("prometheus"),
-					Image: pulumi.String("ghcr.io/datadog/apps-prometheus:main"),
+					Image: pulumi.String("ghcr.io/datadog/apps-prometheus:" + apps.Version),
 					DockerLabels: pulumi.StringMap{
 						"com.datadoghq.ad.checks": pulumi.String(utils.JSONMustMarshal(
 							map[string]interface{}{

--- a/components/datadog/apps/prometheus/k8s.go
+++ b/components/datadog/apps/prometheus/k8s.go
@@ -3,6 +3,7 @@ package prometheus
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
@@ -60,7 +61,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("prometheus"),
-							Image: pulumi.String("ghcr.io/datadog/apps-prometheus:main"),
+							Image: pulumi.String("ghcr.io/datadog/apps-prometheus:" + apps.Version),
 							Resources: &corev1.ResourceRequirementsArgs{
 								Limits: pulumi.StringMap{
 									"cpu":    pulumi.String("100m"),

--- a/components/datadog/apps/redis/docker-compose.yaml
+++ b/components/datadog/apps/redis/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       - 6379:6379
 
   redis-query:
-    image: ghcr.io/datadog/apps-redis-client:main
+    image: ghcr.io/datadog/apps-redis-client:{APPS_VERSION}
     container_name: redis-query
     command:
       - -min-tps

--- a/components/datadog/apps/redis/docker.go
+++ b/components/datadog/apps/redis/docker.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"strings"
 
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	"github.com/DataDog/test-infra-definitions/components/docker"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
@@ -14,5 +15,5 @@ var dockerComposeYAML string
 
 var DockerComposeManifest = docker.ComposeInlineManifest{
 	Name:    "redis",
-	Content: pulumi.String(strings.ReplaceAll(dockerComposeYAML, "latest", RedisVersion)),
+	Content: pulumi.String(strings.ReplaceAll(dockerComposeYAML, "{APPS_VERSION}", apps.Version)),
 }

--- a/components/datadog/apps/redis/ecs.go
+++ b/components/datadog/apps/redis/ecs.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	ecsComp "github.com/DataDog/test-infra-definitions/components/ecs"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 
@@ -54,7 +55,7 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...
 				},
 				"query": {
 					Name:  pulumi.String("query"),
-					Image: pulumi.String("ghcr.io/datadog/apps-redis-client:main"),
+					Image: pulumi.String("ghcr.io/datadog/apps-redis-client:" + apps.Version),
 					Command: pulumi.StringArray{
 						pulumi.String("-addr"),
 						pulumi.String("redis:6379"),

--- a/components/datadog/apps/redis/ecsFargate.go
+++ b/components/datadog/apps/redis/ecsFargate.go
@@ -2,6 +2,7 @@ package redis
 
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	fakeintakeComp "github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 	ecsClient "github.com/DataDog/test-infra-definitions/resources/aws/ecs"
@@ -52,7 +53,7 @@ func FargateAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, apiK
 
 	queryContainer := &ecs.TaskDefinitionContainerDefinitionArgs{
 		Name:  e.CommonNamer().DisplayName(255, pulumi.String("query")),
-		Image: pulumi.String("ghcr.io/datadog/apps-redis-client:main"),
+		Image: pulumi.String("ghcr.io/datadog/apps-redis-client:" + apps.Version),
 		Command: pulumi.StringArray{
 			pulumi.String("-addr"),
 			pulumi.Sprintf("localhost:6379"),

--- a/components/datadog/apps/redis/k8s.go
+++ b/components/datadog/apps/redis/k8s.go
@@ -3,6 +3,7 @@ package redis
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
 	"github.com/Masterminds/semver"
 
@@ -327,7 +328,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("query"),
-							Image: pulumi.String("ghcr.io/datadog/apps-redis-client:main"),
+							Image: pulumi.String("ghcr.io/datadog/apps-redis-client:" + apps.Version),
 							Args: pulumi.StringArray{
 								pulumi.String("-min-tps"),
 								pulumi.String("1"),

--- a/components/datadog/apps/tracegen/ecs.go
+++ b/components/datadog/apps/tracegen/ecs.go
@@ -2,6 +2,7 @@ package tracegen
 
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	ecsComp "github.com/DataDog/test-infra-definitions/components/ecs"
 	"github.com/DataDog/test-infra-definitions/resources/aws"
 	classicECS "github.com/pulumi/pulumi-aws/sdk/v6/go/aws/ecs"
@@ -34,7 +35,7 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...
 			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
 				"tracegen": {
 					Name:  pulumi.String("tracegen"),
-					Image: pulumi.String("ghcr.io/datadog/apps-tracegen:main"),
+					Image: pulumi.String("ghcr.io/datadog/apps-tracegen:" + apps.Version),
 					Environment: ecs.TaskDefinitionKeyValuePairArray{
 						ecs.TaskDefinitionKeyValuePairArgs{
 							Name:  pulumi.StringPtr("DD_TRACE_AGENT_URL"),
@@ -80,7 +81,7 @@ func EcsAppDefinition(e aws.Environment, clusterArn pulumi.StringInput, opts ...
 			Containers: map[string]ecs.TaskDefinitionContainerDefinitionArgs{
 				"tracegen": {
 					Name:  pulumi.String("tracegen"),
-					Image: pulumi.String("ghcr.io/datadog/apps-tracegen:main"),
+					Image: pulumi.String("ghcr.io/datadog/apps-tracegen:" + apps.Version),
 					Environment: ecs.TaskDefinitionKeyValuePairArray{
 						ecs.TaskDefinitionKeyValuePairArgs{
 							Name:  pulumi.StringPtr("ECS_AGENT_HOST"),

--- a/components/datadog/apps/tracegen/k8s.go
+++ b/components/datadog/apps/tracegen/k8s.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
 
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
@@ -61,7 +62,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("tracegen-uds"),
-							Image: pulumi.String("ghcr.io/datadog/apps-tracegen:main"),
+							Image: pulumi.String("ghcr.io/datadog/apps-tracegen:" + apps.Version),
 							Env: &corev1.EnvVarArray{
 								&corev1.EnvVarArgs{
 									Name:  pulumi.String("DD_TRACE_AGENT_URL"),
@@ -126,7 +127,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("tracegen-tcp"),
-							Image: pulumi.String("ghcr.io/datadog/apps-tracegen:main"),
+							Image: pulumi.String("ghcr.io/datadog/apps-tracegen:" + apps.Version),
 							Env: &corev1.EnvVarArray{
 								&corev1.EnvVarArgs{
 									Name: pulumi.String("DD_AGENT_HOST"),

--- a/components/datadog/apps/version.go
+++ b/components/datadog/apps/version.go
@@ -1,0 +1,3 @@
+package apps
+
+const Version = "v0.0.1"

--- a/components/kubernetes/istio/istio.go
+++ b/components/kubernetes/istio/istio.go
@@ -3,6 +3,7 @@ package istio
 import (
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	"github.com/DataDog/test-infra-definitions/resources/helm"
 
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
@@ -150,7 +151,7 @@ func NewHttpbinServiceInstallation(e config.Env, opts ...pulumi.ResourceOption) 
 					ServiceAccountName: pulumi.String("httpbin"),
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
-							Image: pulumi.String("ghcr.io/datadog/apps-go-httpbin:main"),
+							Image: pulumi.String("ghcr.io/datadog/apps-go-httpbin:" + apps.Version),
 							Name:  pulumi.String("httpbin"),
 							Ports: corev1.ContainerPortArray{
 								&corev1.ContainerPortArgs{


### PR DESCRIPTION
What does this PR do?
---------------------

Use pinned version of the test apps docker images.

Which scenarios this will impact?
-------------------

All.

Motivation
----------

We need to control when a change done in a test app docker image is used by the `datadog-agent` CI.
With the floating `main` tag, a change merged in `test-infra-definitions` was immediately used by all the branches and PRs of `datadog-agent` without any “bump” PR.

Additional Notes
----------------
