### PR TITLE
Fix `golangci-lint` errors

### DIFF
--- a/components/datadog/agent/kubernetes.go
+++ b/components/datadog/agent/kubernetes.go
@@ -35,7 +35,7 @@ type KubernetesAgent struct {
 	WindowsClusterChecks *kubernetes.KubernetesObjectRef `pulumi:"windowsClusterChecks"`
 
 	ClusterAgentToken pulumi.StringOutput
-	FIPSEnabled pulumi.BoolOutput `pulumi:"fipsEnabled"`
+	FIPSEnabled       pulumi.BoolOutput `pulumi:"fipsEnabled"`
 }
 
 func (h *KubernetesAgent) Export(ctx *pulumi.Context, out *KubernetesAgentOutput) error {

--- a/resources/aws/ec2/asg.go
+++ b/resources/aws/ec2/asg.go
@@ -13,13 +13,13 @@ import (
 func NewAutoscalingGroup(e aws.Environment, name string,
 	launchTemplateID pulumi.StringInput,
 	launchTemplateVersion pulumi.IntInput,
-	desired, min, max int,
+	desiredCapacity, minSize, maxSize int,
 ) (*autoscaling.Group, error) {
 	return autoscaling.NewGroup(e.Ctx(), e.Namer.ResourceName(name), &autoscaling.GroupArgs{
 		NamePrefix:      e.CommonNamer().DisplayName(255, pulumi.String(name)),
-		DesiredCapacity: pulumi.Int(desired),
-		MinSize:         pulumi.Int(min),
-		MaxSize:         pulumi.Int(max),
+		DesiredCapacity: pulumi.Int(desiredCapacity),
+		MinSize:         pulumi.Int(minSize),
+		MaxSize:         pulumi.Int(maxSize),
 		LaunchTemplate: autoscaling.GroupLaunchTemplateArgs{
 			Id:      launchTemplateID,
 			Version: launchTemplateVersion.ToIntOutput().ApplyT(func(v int) pulumi.String { return pulumi.String(strconv.Itoa(v)) }).(pulumi.StringInput),


### PR DESCRIPTION
What does this PR do?
---------------------

Fix the following [`golangci-lint` errors](https://github.com/DataDog/test-infra-definitions/actions/runs/14979841357/job/42081959557?pr=1522):
```
  Error: components/datadog/agent/kubernetes.go:38:1: File is not properly formatted (gofmt)
  	FIPSEnabled pulumi.BoolOutput `pulumi:"fipsEnabled"`
  ^
  Error: resources/aws/ec2/asg.go:16:11: redefines-builtin-id: redefinition of the built-in function min (revive)
  	desired, min, max int,
  	         ^
```

Which scenarios this will impact?
-------------------

Motivation
----------

Those errors are failing the CI of PRs that are not touching those files like #1522 for ex.

Additional Notes
----------------
