### PR TITLE
Avoid picking artifact from other pipelines on Windows runner

### DIFF
--- a/components/datadog/agent/host.go
+++ b/components/datadog/agent/host.go
@@ -87,7 +87,7 @@ func (h *HostAgent) installScriptInstallation(env config.Env, params *agentparam
 }
 
 func (h *HostAgent) directInstallInstallation(env config.Env, params *agentparams.Params, baseOpts ...pulumi.ResourceOption) (command.Command, error) {
-	packagePath, err := GetPackagePath(params.Version.LocalPath, h.Host.OS.Descriptor().Flavor, params.Version.Flavor, h.Host.OS.Descriptor().Architecture)
+	packagePath, err := GetPackagePath(params.Version.LocalPath, h.Host.OS.Descriptor().Flavor, params.Version.Flavor, h.Host.OS.Descriptor().Architecture, env.PipelineID())
 	if err != nil {
 		return nil, err
 	}

--- a/components/datadog/agent/package.go
+++ b/components/datadog/agent/package.go
@@ -14,7 +14,7 @@ import (
 // GetPackagePath retrieve the name of the package that should be installed.
 // It will return the path to the package that should be installed for the given flavor and agent flavor.
 // If the package is not found, it will return an error.
-// If multiple packages are found, it will return the first one and print a warning.
+// If multiple packages are found, it will fail.
 // Args:
 //   - localPath: either a path to a folder or a path to a file
 //     if a folder is provided, it should have a structure similar to what the agent CI exposes.
@@ -26,11 +26,12 @@ import (
 //   - flavor: the flavor of the host
 //   - agentFlavor: the flavor of the agent
 //   - arch: the architecture of the host
+//   - pipelineID: the ID of the pipeline, if empty will be ignored, mainly used to avoid an issue with the Windows Runners, can be removed once CIEXE-143 is fixed
 //
 // Returns:
 // - the path to the package that should be installed
 // - an error if the package is not found or if there are multiple packages
-func GetPackagePath(localPath string, flavor tifos.Flavor, agentFlavor string, arch tifos.Architecture) (string, error) {
+func GetPackagePath(localPath string, flavor tifos.Flavor, agentFlavor string, arch tifos.Architecture, pipelineID string) (string, error) {
 	var wantedExt string
 	var subFolder string
 	switch flavor {
@@ -89,6 +90,14 @@ func GetPackagePath(localPath string, flavor tifos.Flavor, agentFlavor string, a
 						continue
 					}
 				} else if !strings.Contains(entry.Name(), archStr) {
+					continue
+				}
+			}
+
+			// If we're on Windows, we need to check if the pipeline ID is in the package name, this is a workaround to avoid an issue with the Windows Runners
+			// where other pipelines packages can pollute the artifacts
+			if flavor == tifos.WindowsServer && pipelineID != "" {
+				if !strings.Contains(entry.Name(), pipelineID) {
 					continue
 				}
 			}


### PR DESCRIPTION
What does this PR do?
---------------------

Check for the pipeline id in the artifact name for windows. Workaround for CIEXE-143

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
