### PR TITLE
Add s3 proxy image for install buckets

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -78,7 +78,8 @@ jobs:
             image: calendar-go
           - app: gpu
             image: cuda-basic
-
+          - app: s3-proxy-nginx
+            image: s3-proxy-nginx
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/components/datadog/apps/s3-proxy-nginx/images/s3-proxy-nginx/Dockerfile
+++ b/components/datadog/apps/s3-proxy-nginx/images/s3-proxy-nginx/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx:1.25-alpine
+
+# Replace default config with yours
+COPY nginx.conf /etc/nginx/nginx.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/components/datadog/apps/s3-proxy-nginx/images/s3-proxy-nginx/nginx.conf
+++ b/components/datadog/apps/s3-proxy-nginx/images/s3-proxy-nginx/nginx.conf
@@ -1,0 +1,37 @@
+events {}
+
+http {
+    server_names_hash_bucket_size 128;
+    server {
+        listen 80;
+        server_name install.datad0g.com.internal.dda-testing.com;
+
+        location / {
+            proxy_pass https://install.datad0g.com.s3.amazonaws.com/;
+            proxy_set_header Host install.datad0g.com.s3.amazonaws.com;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_ssl_server_name on;
+        }
+    }
+
+    server {
+        listen 80;
+        server_name installtesting.datad0g.com.internal.dda-testing.com;
+
+        location / {
+            proxy_pass https://installtesting.datad0g.com.s3.amazonaws.com/;
+            proxy_set_header Host installtesting.datad0g.com.s3.amazonaws.com;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_ssl_server_name on;
+        }
+    }
+
+    server {
+        listen 8080;
+        location /health {
+            return 200 "OK";
+        }
+    }
+}


### PR DESCRIPTION
What does this PR do?
---------------------

Create a nginx image to redirect `install(testing).datad0g.com.internal-dda-testing.com` to their respective S3 buckets.
The goal is to be able to fetch these buckets without going through Cloudfront
https://datadoghq.atlassian.net/wiki/x/RoLc9g

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
