### PR TITLE
fix(ci): Do not use the deprecated requirements from buildimages

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install lint python requirements
-        run: pip3 install -r https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/requirements.txt
+        run: pip3 install ruff vulture
       - name: Run linters
         run: |
           ruff format --check tasks

--- a/tasks/deploy.py
+++ b/tasks/deploy.py
@@ -119,7 +119,9 @@ def check_s3_image_exists(_, pipeline_id: str, deploy_job: str):
     response = s3.list_objects_v2(Bucket=bucket, Prefix=path)
     exists = "Contents" in response
 
-    assert exists, f"Latest job {deploy_job} is outdated, use `inv retry-job {pipeline_id} {deploy_job}` to run it again or use --no-verify to force deploy"
+    assert exists, (
+        f"Latest job {deploy_job} is outdated, use `inv retry-job {pipeline_id} {deploy_job}` to run it again or use --no-verify to force deploy"
+    )
 
 
 # creates a stack with the given stack_name if it doesn't already exists


### PR DESCRIPTION
What does this PR do?
---------------------
Remove usage of the `requirements.txt` from buildimages (see https://github.com/DataDog/datadog-agent-buildimages/pull/841).
Install directly the only required dependencies for the linter task.

Which scenarios this will impact?
-------------------
None

Motivation
----------
[Job is currently broken](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40git.repository.name%3A%22DataDog%2Ftest-infra-definitions%22%20%40git.branch%3Amain%20%40ci.job.name%3Alint-python&agg_m=count&agg_m_source=base&agg_t=count&colorBy=meta%5B%27ci.job.name%27%5D&colorByAttr=meta%5B%27ci.job.name%27%5D&currentTab=trace&fromUser=false&graphType=flamegraph&index=cipipeline&spanViewType=metadata&start=1747315189287&end=1747401589287&paused=false)

Additional Notes
----------------
