### PR TITLE
Bump version to v0.0.3

### DIFF
--- a/components/datadog/apps/version.go
+++ b/components/datadog/apps/version.go
@@ -1,3 +1,3 @@
 package apps
 
-const Version = "v0.0.2"
+const Version = "v0.0.3"


### PR DESCRIPTION
What does this PR do?
---------------------

Bump the version of the test apps to `v0.0.3`.

Which scenarios this will impact?
-------------------

* `aws/docker`
* `aws/eks`
* `aws/kind`

Motivation
----------

Several `dependabot` :dependabot: PRs have been merged since `v0.0.2`.
* #1528 
* #1502 
* #1532
* #1421 
* #1420 
* #1419 
* #1418
In order to take all those changes into account, we need a new tag for the test apps docker images.

Additional Notes
----------------
