### PR TITLE
[ACIX-864] Prevent use of some chars in host password for clearer log output in CI

### DIFF
--- a/resources/azure/compute/vm.go
+++ b/resources/azure/compute/vm.go
@@ -64,6 +64,8 @@ func NewWindowsInstance(e azure.Environment, name, imageUrn, instanceType string
 	windowsAdminPassword, err := random.NewRandomString(e.Ctx(), e.Namer.ResourceName(name, "admin-password"), &random.RandomStringArgs{
 		Length:  pulumi.Int(20),
 		Special: pulumi.Bool(true),
+		// Disallow "<", ">" and "&" as they get encoded by json.Marshall in the CI log output, making the password hard to read
+		OverrideSpecial: pulumi.String("!@#$%*()-_=+[]{}:?"),
 	}, pwdOpts...)
 	if err != nil {
 		return nil, pulumi.StringOutput{}, pulumi.StringOutput{}, err


### PR DESCRIPTION
What does this PR do?
---------------------
When generating a host password for Windows-based tests, disallow the use of `<`, `>` and `&`.

Which scenarios this will impact?
-------------------
Hopefully none: we are only limiting the set of possible passwords and not adding any new behavior.
Otherwise, all scenarios that run Windows VMs: only `azure` at this time. 

Motivation
----------
When showing the host password in the Gitlab CI logs, it gets JSON-encoded using `json.Marshal`. As [the docs](https://pkg.go.dev/encoding/json#Marshal) mention, this method URL-encodes the three characters `<`, `>` and `&` to make the JSON safe to embed in HTML.

This means that any passwords containing these characters will be shown encoded in the CI logs, making them impossible to directly copy-paste. To prevent this we disallow the use of these three characters when generating the password for Windows machines.

Additional Notes
----------------
