### PR TITLE
Print AMI used when resolved

### DIFF
--- a/scenarios/aws/ec2/os_resolver.go
+++ b/scenarios/aws/ec2/os_resolver.go
@@ -56,6 +56,7 @@ func resolveOS(e aws.Environment, vmArgs *vmArgs) (*amiInformation, error) {
 			return nil, err
 		}
 	}
+	fmt.Printf("Using AMI %s\n for stack %s\n", vmArgs.ami, e.Ctx().Stack())
 
 	amiInfo := &amiInformation{
 		id:          vmArgs.ami,


### PR DESCRIPTION
What does this PR do?
---------------------

Print the AMI used.
It uses `fmt.Printf` instead of `e.Ctx().Log()` because the latter is often hidden depending on Pulumi log level

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
