### PR TITLE
[ACIX-864] [Follow-up] Prevent use of some chars in host password for clearer log output in CI

### DIFF
--- a/scenarios/aws/ec2/vm.go
+++ b/scenarios/aws/ec2/vm.go
@@ -84,11 +84,13 @@ func NewVM(e aws.Environment, name string, params ...VMOption) (*remote.Host, er
 			// 		* Non-alphanumeric characters (special characters): '-!"#$%&()*,./:;?@[]^_`{|}~+<=>
 			// Source: https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/security-policy-settings/password-must-meet-complexity-requirements
 			randomPassword, err := random.NewRandomString(e.Ctx(), e.Namer.ResourceName(name, "win-admin-password"), &random.RandomStringArgs{
-				Length:     pulumi.Int(20),
-				Special:    pulumi.Bool(true),
-				MinLower:   pulumi.Int(1),
-				MinUpper:   pulumi.Int(1),
-				MinNumeric: pulumi.Int(1),
+				Length:  pulumi.Int(20),
+				Special: pulumi.Bool(true),
+				// Disallow "<", ">" and "&" as they get encoded by json.Marshall in the CI log output, making the password hard to read
+				OverrideSpecial: pulumi.String("!@#$%*()-_=+[]{}:?"),
+				MinLower:        pulumi.Int(1),
+				MinUpper:        pulumi.Int(1),
+				MinNumeric:      pulumi.Int(1),
 			}, pulumi.Parent(c), e.WithProviders(config.ProviderRandom))
 			if err != nil {
 				return err


### PR DESCRIPTION
Follow-up to ad2bfe2 (PR #1557), doing the same thing but also for AWS - I missed it in the original PR.
Below the original PR's description:

What does this PR do?
---------------------
When generating a host password for Windows-based tests, disallow the use of `<`, `>` and `&`.

Which scenarios this will impact?
-------------------
Hopefully none: we are only limiting the set of possible passwords and not adding any new behavior.
Otherwise, all scenarios that run Windows VMs: ~~only `azure` at this time.~~ **`azure` and `aws`**

Motivation
----------
When showing the host password in the Gitlab CI logs, it gets JSON-encoded using `json.Marshal`. As [the docs](https://pkg.go.dev/encoding/json#Marshal) mention, this method URL-encodes the three characters `<`, `>` and `&` to make the JSON safe to embed in HTML.

This means that any passwords containing these characters will be shown encoded in the CI logs, making them impossible to directly copy-paste. To prevent this we disallow the use of these three characters when generating the password for Windows machines.

Additional Notes
----------------

