### PR TITLE
[CONTP-810] use dynamic APP_VERSION as image tag for dogstatsd-uds-csi workload

### DIFF
--- a/components/datadog/apps/dogstatsd/k8s.go
+++ b/components/datadog/apps/dogstatsd/k8s.go
@@ -56,7 +56,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 					Labels: pulumi.StringMap{
 						"admission.datadoghq.com/config.mode": pulumi.String("csi"),
 						"app":                                 pulumi.String("dogstatsd-uds-with-csi"),
-						"admission.datadoghq.com/enabled": pulumi.String("true"),
+						"admission.datadoghq.com/enabled":     pulumi.String("true"),
 					},
 				},
 				Spec: &corev1.PodSpecArgs{


### PR DESCRIPTION
What does this PR do?
---------------------

See title.

Which scenarios this will impact?
-------------------

All kubernetes scenarios.

Motivation
----------

Don't depend on a floating tag for the workload app.

Additional Notes
----------------
