### PR TITLE
[ACIX-896] Allow specifying several imagepull secret for different Cloud Providers

### DIFF
--- a/resources/gcp/environment.go
+++ b/resources/gcp/environment.go
@@ -108,7 +108,7 @@ func logIn(ctx *pulumi.Context) {
 // Cross Cloud Provider config
 
 func (e *Environment) InternalRegistry() string {
-	return "none"
+	return "us-central1-docker.pkg.dev/datadog-agent-qa/agent-qa"
 }
 
 func (e *Environment) InternalDockerhubMirror() string {


### PR DESCRIPTION
What does this PR do?
---------------------

Allow passing multiple image pull secret in `imagePull*` config params. It can be useful when one single command is used to run tests on both GKE and EKS.

Which scenarios this will impact?
-------------------

Should not have any impact on existing scenarios

Motivation
----------

Support running test on GKE with GCR authentication working

Additional Notes
----------------
