### PR TITLE
Azure support client OSes

### DIFF
--- a/components/os/const.go
+++ b/components/os/const.go
@@ -52,6 +52,7 @@ const (
 
 	// Windows
 	WindowsServer Flavor = 500
+	WindowsClient Flavor = 501
 
 	// MacOS
 	MacosOS Flavor = 1000
@@ -80,6 +81,8 @@ func FlavorFromString(flavorStr string) Flavor {
 		return RockyLinux
 	case "windows", "windows-server":
 		return WindowsServer
+	case "windows-client":
+		return WindowsClient
 	case "macos":
 		return MacosOS
 	default:
@@ -122,6 +125,8 @@ func (f Flavor) String() string {
 		return "rocky-linux"
 	case WindowsServer:
 		return "windows-server"
+	case WindowsClient:
+		return "windows-client"
 	case MacosOS:
 		return "macos"
 	case Unknown:

--- a/components/os/windows_descriptors.go
+++ b/components/os/windows_descriptors.go
@@ -5,4 +5,13 @@ var (
 	WindowsDefault    = WindowsServer2022
 	WindowsServer2022 = NewDescriptor(WindowsServer, "2022")
 	WindowsServer2019 = NewDescriptor(WindowsServer, "2019")
+	WindowsServer2016 = NewDescriptor(WindowsServer, "2016")
+
+	WindowsClient11     = WindowsClient1124H2
+	WindowsClient1124H2 = NewDescriptor(WindowsClient, "windows-11:win11-24h2-pro")
+	WindowsClient1122H2 = NewDescriptor(WindowsClient, "windows-11:win11-22h2-pro")
+	WindowsClient10     = WindowsClient1022H2
+	WindowsClient1022H2 = NewDescriptor(WindowsClient, "windows-10:win10-22h2-pro")
+	WindowsClient1021H2 = NewDescriptor(WindowsClient, "windows-10:win10-21h2-pro")
+	WindowsClient1019H1 = NewDescriptor(WindowsClient, "Windows-10:19h1-pro-gensecond")
 )

--- a/scenarios/azure/compute/os_resolver.go
+++ b/scenarios/azure/compute/os_resolver.go
@@ -16,6 +16,7 @@ type imageResolveFunc func(azure.Environment, os.Descriptor) (string, error)
 
 var imageResolvers = map[os.Flavor]imageResolveFunc{
 	os.WindowsServer: resolveWindowsURN,
+	os.WindowsClient: resolveWindowsClientURN,
 	os.Ubuntu:        resolveUbuntuURN,
 }
 
@@ -48,7 +49,23 @@ func resolveWindowsURN(_ azure.Environment, osInfo os.Descriptor) (string, error
 		osInfo.Version = os.WindowsDefault.Version
 	}
 
+	if osInfo.Version == "2016" {
+		// 2016 uses a different URN format
+		return "MicrosoftWindowsServer:WindowsServer:2016-datacenter-gensecond:latest", nil
+	}
+
 	return fmt.Sprintf("MicrosoftWindowsServer:WindowsServer:%s-datacenter-azure-edition-core:latest", osInfo.Version), nil
+}
+
+func resolveWindowsClientURN(_ azure.Environment, osInfo os.Descriptor) (string, error) {
+	if osInfo.Architecture == os.ARM64Arch {
+		return "", errors.New("ARM64 is not supported for Windows")
+	}
+	if osInfo.Version == "" {
+		osInfo.Version = os.WindowsDefault.Version
+	}
+
+	return fmt.Sprintf("MicrosoftWindowsDesktop:%s:latest", osInfo.Version), nil
 }
 
 func resolveUbuntuURN(_ azure.Environment, osInfo os.Descriptor) (string, error) {


### PR DESCRIPTION
What does this PR do?
---------------------
Updates AZURE to allow for client OSes to be provisioned. 

Which scenarios this will impact?
-------------------

Needed for testing our kernel components on all supported Windows OSes to make sure there are no errors.

Motivation
----------
https://datadoghq.atlassian.net/browse/WINA-1593
https://datadoghq.atlassian.net/browse/WINA-1592

Additional Notes
----------------
