### PR TITLE
kmt: allow ssh env CI_COMMIT_SHA

### DIFF
--- a/scenarios/aws/microVMs/microvms/provision.go
+++ b/scenarios/aws/microVMs/microvms/provision.go
@@ -73,8 +73,9 @@ func readMicroVMSSHKey(instance *Instance, depends []pulumi.Resource) (pulumi.St
 }
 
 func setupSSHAllowEnv(runner command.Runner, depends []pulumi.Resource) ([]pulumi.Resource, error) {
+	allowedEnvVars := []string{"DD_API_KEY", "CI_COMMIT_SHA"}
 	args := command.Args{
-		Create: pulumi.Sprintf("echo -e 'AcceptEnv DD_API_KEY\n' | sudo tee -a /etc/ssh/sshd_config"),
+		Create: pulumi.Sprintf("echo -e 'AcceptEnv %s\n' | sudo tee -a /etc/ssh/sshd_config", strings.Join(allowedEnvVars, " ")),
 	}
 	done, err := runner.Command("allow-ssh-env", &args, pulumi.DependsOn(depends))
 	if err != nil {


### PR DESCRIPTION
What does this PR do?
---------------------

This PR adds support for pushing `CI_COMMIT_SHA` to KMT microVMs, this is something we want to use in CWS tests.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
