### PR TITLE
ci(images): Use more recent versions of images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ stages:
 
 build-runner-image:
   stage: build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci-containers-project:v2.0.0
+  image: ${BUILD_STABLE_REGISTRY}/ci-containers-project:v2.0.0
   tags: ["arch:amd64"]
   variables:
     RELEASE_IMAGE: "false"
@@ -32,7 +32,7 @@ build-runner-image:
 
 build-pulumi-go-main:
   stage: build
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64:v48815877-9bfad02c
+  image: ${BUILD_STABLE_REGISTRY}/ci/datadog-agent-buildimages/deb_x64:v68913450-a14377f4
   tags: ["arch:amd64"]
   rules:
     - when: on_success
@@ -99,7 +99,7 @@ integration-testing:
 
 release-runner-image:
   stage: release
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10.13
+  image: ${BUILD_STABLE_REGISTRY}/images/docker:27.3.1
   tags: ["arch:amd64"]
   script:
     - crane copy ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA} ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA:0:12}


### PR DESCRIPTION
What does this PR do?
---------------------
https://datadoghq.atlassian.net/browse/CONTSEC-1634
Update CI images to not rely on old Ubuntu
- TBC for ci-containers-project:v2.0.0 and the deb_x64

Which scenarios this will impact?
-------------------

Motivation
----------
Ubuntu EOL

Additional Notes
----------------
