### PR TITLE
Support configurable agent/operator chart path

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -41,12 +41,14 @@ const (
 	DDAgentFlavorParamName               = "flavor"
 	DDAgentPipelineID                    = "pipeline_id"
 	DDAgentLocalPackage                  = "localPackage"
+	DDAgentLocalChartPath                = "localChartPath"
 	DDAgentCommitSHA                     = "commit_sha"
 	DDAgentFullImagePathParamName        = "fullImagePath"
 	DDClusterAgentVersionParamName       = "clusterAgentVersion"
 	DDClusterAgentFullImagePathParamName = "clusterAgentFullImagePath"
 	DDOperatorVersionParamName           = "operatorVersion"
 	DDOperatorFullImagePathParamName     = "operatorFullImagePath"
+	DDOperatorLocalChartPath             = "operatorLocalChartPath"
 	DDImagePullRegistryParamName         = "imagePullRegistry"
 	DDImagePullUsernameParamName         = "imagePullUsername"
 	DDImagePullPasswordParamName         = "imagePullPassword"
@@ -111,6 +113,7 @@ type Env interface {
 	AgentVersion() string
 	AgentFIPS() bool
 	AgentLocalPackage() string
+	AgentLocalChartPath() string
 	PipelineID() string
 	CommitSHA() string
 	ClusterAgentVersion() string
@@ -118,6 +121,7 @@ type Env interface {
 	ClusterAgentFullImagePath() string
 	OperatorFullImagePath() string
 	OperatorVersion() string
+	OperatorLocalChartPath() string
 	ImagePullRegistry() string
 	ImagePullUsername() string
 	ImagePullPassword() pulumi.StringOutput
@@ -276,6 +280,9 @@ func (e *CommonEnvironment) AgentFlavor() string {
 func (e *CommonEnvironment) AgentLocalPackage() string {
 	return e.AgentConfig.Get(DDAgentLocalPackage)
 }
+func (e *CommonEnvironment) AgentLocalChartPath() string {
+	return e.AgentConfig.Get(DDAgentLocalChartPath)
+}
 func (e *CommonEnvironment) PipelineID() string {
 	return e.AgentConfig.Get(DDAgentPipelineID)
 }
@@ -303,7 +310,9 @@ func (e *CommonEnvironment) OperatorVersion() string {
 func (e *CommonEnvironment) OperatorFullImagePath() string {
 	return e.OperatorConfig.Get(DDOperatorFullImagePathParamName)
 }
-
+func (e *CommonEnvironment) OperatorLocalChartPath() string {
+	return e.OperatorConfig.Get(DDOperatorLocalChartPath)
+}
 func (e *CommonEnvironment) ImagePullRegistry() string {
 	return e.AgentConfig.Get(DDImagePullRegistryParamName)
 }

--- a/components/datadog/agent/helm/kubernetes_agent.go
+++ b/components/datadog/agent/helm/kubernetes_agent.go
@@ -14,7 +14,7 @@ import (
 
 func NewKubernetesAgent(e config.Env, resourceName string, kubeProvider *kubernetes.Provider, options ...kubernetesagentparams.Option) (*agent.KubernetesAgent, error) {
 	return components.NewComponent(e, resourceName, func(comp *agent.KubernetesAgent) error {
-		params, err := kubernetesagentparams.NewParams(options...)
+		params, err := kubernetesagentparams.NewParams(e, options...)
 		if err != nil {
 			return err
 		}
@@ -26,6 +26,8 @@ func NewKubernetesAgent(e config.Env, resourceName string, kubeProvider *kuberne
 			KubeProvider:                   kubeProvider,
 			DeployWindows:                  params.DeployWindows,
 			Namespace:                      params.Namespace,
+			ChartPath:                      params.HelmChartPath,
+			RepoURL:                        params.HelmRepoURL,
 			ValuesYAML:                     params.HelmValues,
 			Fakeintake:                     params.FakeIntake,
 			AgentFullImagePath:             params.AgentFullImagePath,

--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -22,16 +22,16 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-const (
-	DatadogHelmRepo = "https://helm.datadoghq.com"
-)
-
 // HelmInstallationArgs is the set of arguments for creating a new HelmInstallation component
 type HelmInstallationArgs struct {
 	// KubeProvider is the Kubernetes provider to use
 	KubeProvider *kubernetes.Provider
 	// Namespace is the namespace in which to install the agent
 	Namespace string
+	// ChartPath is the chart name or local chart path.
+	ChartPath string
+	// RepoURL is the Helm repository URL to use for the remote chart installation.
+	RepoURL string
 	// ValuesYAML is used to provide installation-specific values
 	ValuesYAML pulumi.AssetOrArchiveArray
 	// Fakeintake is used to configure the agent to send data to a fake intake
@@ -177,8 +177,8 @@ func NewHelmInstallation(e config.Env, args HelmInstallationArgs, opts ...pulumi
 	}
 
 	linux, err := helm.NewInstallation(e, helm.InstallArgs{
-		RepoURL:     DatadogHelmRepo,
-		ChartName:   "datadog",
+		RepoURL:     args.RepoURL,
+		ChartName:   args.ChartPath,
 		InstallName: linuxInstallName,
 		Namespace:   args.Namespace,
 		ValuesYAML:  valuesYAML,
@@ -207,8 +207,8 @@ func NewHelmInstallation(e config.Env, args HelmInstallationArgs, opts ...pulumi
 
 		windowsInstallName := baseName + "-windows"
 		windows, err := helm.NewInstallation(e, helm.InstallArgs{
-			RepoURL:     DatadogHelmRepo,
-			ChartName:   "datadog",
+			RepoURL:     args.RepoURL,
+			ChartName:   args.ChartPath,
 			InstallName: windowsInstallName,
 			Namespace:   args.Namespace,
 			ValuesYAML:  windowsValuesYAML,

--- a/components/datadog/kubernetesagentparams/params.go
+++ b/components/datadog/kubernetesagentparams/params.go
@@ -25,6 +25,8 @@ const (
 //   - [WithClusterAgentFullImagePath]
 //   - [WithPulumiResourceOptions]
 //   - [WithDeployWindows]
+//   - [WithHelmRepoURL]
+//   - [WithHelmChartPath]
 //   - [WithHelmValues]
 //   - [WithNamespace]
 //   - [WithDeployWindows]

--- a/components/datadog/operator/helm.go
+++ b/components/datadog/operator/helm.go
@@ -1,20 +1,15 @@
 package operator
 
 import (
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/resources/helm"
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
 	kubeHelm "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/helm/v3"
 	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"gopkg.in/yaml.v3"
-
-	"github.com/DataDog/test-infra-definitions/common/config"
-	"github.com/DataDog/test-infra-definitions/common/utils"
-	"github.com/DataDog/test-infra-definitions/resources/helm"
-)
-
-const (
-	DatadogHelmRepo = "https://helm.datadoghq.com"
 )
 
 // HelmInstallationArgs is the set of arguments for creating a new HelmInstallation component
@@ -27,6 +22,10 @@ type HelmInstallationArgs struct {
 	ValuesYAML pulumi.AssetOrArchiveArray
 	// OperatorFullImagePath is used to specify the full image path for the agent
 	OperatorFullImagePath string
+	// ChartPath is the chart name or local chart path.
+	ChartPath string
+	// RepoURL is the Helm repository URL to use for the remote operator installation.
+	RepoURL string
 }
 
 type HelmComponent struct {
@@ -105,8 +104,8 @@ func NewHelmInstallation(e config.Env, args HelmInstallationArgs, opts ...pulumi
 	valuesYAML = append(valuesYAML, args.ValuesYAML...)
 
 	linux, err := helm.NewInstallation(e, helm.InstallArgs{
-		RepoURL:     DatadogHelmRepo,
-		ChartName:   "datadog-operator",
+		RepoURL:     args.RepoURL,
+		ChartName:   args.ChartPath,
 		InstallName: linuxInstallName,
 		Namespace:   args.Namespace,
 		ValuesYAML:  valuesYAML,

--- a/components/datadog/operatorparams/params.go
+++ b/components/datadog/operatorparams/params.go
@@ -2,12 +2,15 @@ package operatorparams
 
 import (
 	"fmt"
-
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 
 	"github.com/DataDog/test-infra-definitions/common"
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+)
+
+const (
+	DatadogHelmRepo = "https://helm.datadoghq.com"
 )
 
 type Params struct {
@@ -17,6 +20,10 @@ type Params struct {
 	Namespace string
 	// HelmValues is the Helm values to use for the operator installation.
 	HelmValues pulumi.AssetOrArchiveArray
+	// HelmRepoURL is the Helm repo URL to use for the operator installation.
+	HelmRepoURL string
+	// HelmChartPath is the Helm chart path to use for the operator installation.
+	HelmChartPath string
 	// PulumiResourceOptions is a list of resources to depend on.
 	PulumiResourceOptions []pulumi.ResourceOption
 }
@@ -30,6 +37,14 @@ func NewParams(e config.Env, options ...Option) (*Params, error) {
 
 	if e.PipelineID() != "" && e.CommitSHA() != "" {
 		options = append(options, WithOperatorFullImagePath(utils.BuildDockerImagePath(fmt.Sprintf("%s/operator", e.InternalRegistry()), fmt.Sprintf("%s-%s", e.PipelineID(), e.CommitSHA()))))
+	}
+
+	if e.OperatorLocalChartPath() != "" {
+		options = append(options, WithHelmChartPath(e.OperatorLocalChartPath()))
+		options = append(options, WithHelmRepoURL(""))
+	} else {
+		options = append(options, WithHelmChartPath("datadog-operator"))
+		options = append(options, WithHelmRepoURL(DatadogHelmRepo))
 	}
 
 	return common.ApplyOption(version, options)
@@ -58,6 +73,22 @@ func WithOperatorFullImagePath(path string) func(*Params) error {
 func WithHelmValues(values string) func(*Params) error {
 	return func(p *Params) error {
 		p.HelmValues = append(p.HelmValues, pulumi.NewStringAsset(values))
+		return nil
+	}
+}
+
+// WithHelmRepoURL specifies the remote Helm repo URL to use for the datadog-operator installation.
+func WithHelmRepoURL(repoURL string) func(*Params) error {
+	return func(p *Params) error {
+		p.HelmRepoURL = repoURL
+		return nil
+	}
+}
+
+// WithHelmChartPath specifies the remote chart name or local chart path to use for the datadog-operator installation.
+func WithHelmChartPath(chartPath string) func(*Params) error {
+	return func(p *Params) error {
+		p.HelmChartPath = chartPath
 		return nil
 	}
 }

--- a/tasks/aws/eks.py
+++ b/tasks/aws/eks.py
@@ -34,6 +34,7 @@ scenario_name = "aws/eks"
         "cluster_agent_full_image_path": doc.cluster_agent_full_image_path,
         "agent_flavor": doc.agent_flavor,
         "helm_config": doc.helm_config,
+        "local_chart_path": doc.local_chart_path,
     }
 )
 def create_eks(
@@ -53,6 +54,7 @@ def create_eks(
     cluster_agent_full_image_path: Optional[str] = None,
     agent_flavor: Optional[str] = None,
     helm_config: Optional[str] = None,
+    local_chart_path: Optional[str] = None,
 ):
     """
     Create a new EKS environment. It lasts around 20 minutes.
@@ -63,6 +65,7 @@ def create_eks(
         "ddinfra:aws/eks/linuxBottlerocketNodeGroup": bottlerocket_node_group,
         "ddinfra:aws/eks/linuxNodeGroup": str(linux_node_group),
         "ddinfra:aws/eks/windowsNodeGroup": windows_node_group,
+        "ddagent:localChartPath": local_chart_path,
     }
 
     # Override the instance type if specified

--- a/tasks/azure/aks.py
+++ b/tasks/azure/aks.py
@@ -24,6 +24,7 @@ scenario_name = "az/aks"
         "stack_name": doc.stack_name,
         "agent_flavor": doc.agent_flavor,
         "helm_config": doc.helm_config,
+        "local_chart_path": doc.local_chart_path,
     }
 )
 def create_aks(
@@ -41,6 +42,7 @@ def create_aks(
     use_fakeintake: Optional[bool] = False,
     agent_flavor: Optional[str] = None,
     helm_config: Optional[str] = None,
+    local_chart_path: Optional[str] = None,
 ):
     """
     Create a new AKS environment. It lasts around 5 minutes.
@@ -54,6 +56,7 @@ def create_aks(
     extra_flags = {
         "ddinfra:env": f"az/{account if account else cfg.get_azure().account}",
         "ddinfra:az/defaultPublicKeyPath": cfg.get_azure().publicKeyPath,
+        "ddagent:localChartPath": local_chart_path,
     }
 
     full_stack_name = deploy(

--- a/tasks/doc.py
+++ b/tasks/doc.py
@@ -37,3 +37,4 @@ agent_config_path: str = "Agent config to merge with default config from a file 
 agent_env: str = "Extra environment variables to run the agent with, the format is `VAR1=val1,VAR2=val2`"
 helm_config: str = "Path to a custom helm config file that will be merged with the default one"
 local_package: str = "Path to a local package to install, it can be either a folder or a file. If a folder is targetted we automatically take the first file with the correct extension depending on the targetted OS"
+local_chart_path: str = "Path to a local helm chart to install the Datadog Agent."

--- a/tasks/gcp/gke.py
+++ b/tasks/gcp/gke.py
@@ -23,6 +23,7 @@ scenario_name = "gcp/gke"
         "stack_name": doc.stack_name,
         "agent_flavor": doc.agent_flavor,
         "helm_config": doc.helm_config,
+        "local_chart_path": doc.local_chart_path,
     }
 )
 def create_gke(
@@ -41,6 +42,7 @@ def create_gke(
     use_autopilot: Optional[bool] = False,
     agent_flavor: Optional[str] = None,
     helm_config: Optional[str] = None,
+    local_chart_path: Optional[str] = None,
 ) -> None:
     """
     Create a new GKE environment.
@@ -55,6 +57,7 @@ def create_gke(
         "ddinfra:env": f"gcp/{account if account else cfg.get_gcp().account}",
         "ddinfra:gcp/defaultPublicKeyPath": cfg.get_gcp().publicKeyPath,
         "ddinfra:gcp/gke/enableAutopilot": use_autopilot,
+        "ddagent:localChartPath": local_chart_path,
     }
 
     full_stack_name = deploy(


### PR DESCRIPTION
What does this PR do?
---------------------

Add new env config options:
* `ddagent:localChartPath` -- provide custom chart path or chart name for datadog agent installation
* `ddoperator:localChartPath` -- provide custom chart path or chart name for datadog operator installation

Add new params and helper funcs for each `KubernetesAgentParams` and `OperatorParams`:
* `HelmRepoURL` => `WithHelmRepoURL()`
* `HelmChartPath` => `WithHelmChartPath()`

Add the `ddagent:localChartPath` option as an extra_flag to the invoke tasks for gke, aks, and eks. 

Which scenarios this will impact?
-------------------
N/A

Motivation
----------
Support E2E testing of local (unreleased) datadog and datadog-operator charts in the CI.

Additional Notes
----------------
