### PR TITLE
fix(build): Use more recent image and install awscli at runtime

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,9 @@ build-runner-image:
     - when: on_success
   before_script:
     - set +x
+    - curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+    - unzip awscliv2.zip
+    - ./aws/install
     - export GITHUB_APP_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.github_app_id --with-decryption --query "Parameter.Value" --out text)
     - export GITHUB_INSTALLATION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.github_installation_id --with-decryption --query "Parameter.Value" --out text)
     - export GITHUB_PRIVATE_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.test-infra-definitions.github_private_key --with-decryption --query "Parameter.Value" --out text)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ stages:
 
 build-runner-image:
   stage: build
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci-containers-project:v2.0.0
+  image: ${BUILD_STABLE_REGISTRY}/images/docker:27.3.1
   tags: ["arch:amd64"]
   variables:
     RELEASE_IMAGE: "false"
@@ -35,7 +35,7 @@ build-runner-image:
 
 build-pulumi-go-main:
   stage: build
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64:v48815877-9bfad02c
+  image: ${BUILD_STABLE_REGISTRY}/ci/datadog-agent-buildimages/deb_x64:v68913450-a14377f4
   tags: ["arch:amd64"]
   rules:
     - when: on_success
@@ -103,7 +103,7 @@ integration-testing:
 
 release-runner-image:
   stage: release
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:20.10.13
+  image: ${BUILD_STABLE_REGISTRY}/images/docker:27.3.1
   tags: ["arch:amd64"]
   script:
     - crane copy ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA} ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA:0:12}


### PR DESCRIPTION
What does this PR do?
---------------------
- Use more recent version of images
- Install the awscli at runtime


Which scenarios this will impact?
-------------------
None

Motivation
----------
https://datadoghq.atlassian.net/browse/CONTSEC-1634

Additional Notes
----------------
We need to install awscli to prevent dockerhub rate limiting.
As we are using images from the `datadog/images` repo we can workaround with runtime installation. I will check if we can update these images to have the cli installed as we have the same need in buildimages
