### PR TITLE
Try to find Windows packages on a pipeline-ID specific folder before common folder

### DIFF
--- a/components/datadog/agent/package.go
+++ b/components/datadog/agent/package.go
@@ -57,11 +57,16 @@ func GetPackagePath(localPath string, flavor tifos.Flavor, agentFlavor string, a
 	packagePath := localPath
 	matches := []string{}
 	if pathInfo.IsDir() {
-		packagePath = path.Join(packagePath, subFolder)
-		packagePath = path.Join(packagePath, "pkg")
+		packagePath = path.Join(packagePath, subFolder, "pkg")
+
+		// On Windows, if a dedicated pipeline-identified folder is available, use that
 		if flavor == tifos.WindowsServer {
-			packagePath = path.Join(packagePath, "pipeline-"+pipelineID)
+			packagePathWithPipelineID := path.Join(packagePath, "pipeline-"+pipelineID)
+			if info, err := os.Stat(packagePathWithPipelineID); err == nil && info.IsDir() {
+				packagePath = packagePathWithPipelineID
+			}
 		}
+
 		entries, err := os.ReadDir(packagePath)
 		if err != nil {
 			return "", err

--- a/components/datadog/agent/package.go
+++ b/components/datadog/agent/package.go
@@ -59,6 +59,9 @@ func GetPackagePath(localPath string, flavor tifos.Flavor, agentFlavor string, a
 	if pathInfo.IsDir() {
 		packagePath = path.Join(packagePath, subFolder)
 		packagePath = path.Join(packagePath, "pkg")
+		if flavor == tifos.WindowsServer {
+			packagePath = path.Join(packagePath, "pipeline-"+pipelineID)
+		}
 		entries, err := os.ReadDir(packagePath)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
What does this PR do?
---------------------

Re-does https://github.com/DataDog/test-infra-definitions/pull/1601.

> Prepare test-infra-definition for a change that will provide a basic build artifact isolation on Windows, where the packages are now located in a pipeline-$CI_PIPELINE_ID directory

But it does so in a way that is safe to merge before https://github.com/DataDog/datadog-agent/pull/38219 gets merged, by looking for the pipeline ID named subfolder first and falling back to the currently acceptable behavior otherwise.

Which scenarios this will impact?
-------------------

Motivation
----------

#incident-39868

Additional Notes
----------------

Tested [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/70022339) against main and [here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/70019843) against https://github.com/DataDog/datadog-agent/pull/38219