### PR TITLE
[ACIX-924] Authorize ddbuild VPN private IPs

### DIFF
--- a/resources/gcp/gke/cluster.go
+++ b/resources/gcp/gke/cluster.go
@@ -30,6 +30,10 @@ func NewCluster(e gcp.Environment, name string, autopilot bool, opts ...pulumi.R
 					CidrBlock:   pulumi.String("10.0.0.0/8"),
 					DisplayName: pulumi.String("all private ips"),
 				},
+				&container.ClusterMasterAuthorizedNetworksConfigCidrBlockArgs{
+					CidrBlock:   pulumi.String("172.16.0.0/12"),
+					DisplayName: pulumi.String("ddbuild vpn private ips"),
+				},
 			}, // Empty array to disable master authorized networks
 		},
 		NodeConfig: &container.ClusterNodeConfigArgs{


### PR DESCRIPTION
What does this PR do?
---------------------

Authorize private GKE cluster API to be queried from ddbuild VPN IPs

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
