### PR TITLE
[components/datadog/agent/kubernetes_helm] Set 2 DCA replicas

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -467,7 +467,7 @@ func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentI
 				"tag":           pulumi.String(clusterAgentImageTag),
 				"doNotCheckTag": pulumi.Bool(true),
 			},
-			"replicas": pulumi.Int(1),
+			"replicas": pulumi.Int(2),
 			"metricsProvider": pulumi.Map{
 				"enabled":           pulumi.Bool(true),
 				"useDatadogMetrics": pulumi.Bool(true),


### PR DESCRIPTION
What does this PR do?
---------------------
Sets the number of DCA replicas to 2 again.
The change was previously reverted in https://github.com/DataDog/test-infra-definitions/pull/1619 because it caused some test flakiness.
https://github.com/DataDog/datadog-agent/pull/38694 fixed the issue.
