### PR TITLE
Bump orchestrion to 1.4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install orchestrion
         run: |
-          go install github.com/DataDog/orchestrion@v1.1.0
+          go install github.com/DataDog/orchestrion@v1.4.0
           orchestrion pin
 
       - name: Test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,7 +81,7 @@ integration-testing:
     - chmod 400 $E2E_PRIVATE_KEY_PATH
     - ssh-add $E2E_PRIVATE_KEY_PATH
     - pip install -r requirements.txt
-    - go install github.com/DataDog/orchestrion@v1.1.0
+    - go install github.com/DataDog/orchestrion@v1.4.0
     - orchestrion pin
     - export DD_CIVISIBILITY_ENABLED=true
     - export DD_CIVISIBILITY_AGENTLESS_ENABLED=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,7 +133,7 @@ RUN DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-age
   go install gotest.tools/gotestsum@latest
 
 # Install Orchestrion for native Go Test Visibility support
-RUN go install github.com/DataDog/orchestrion@v1.0.1
+RUN go install github.com/DataDog/orchestrion@v1.4.0
 
 RUN rm -rf /tmp/test-infra
 


### PR DESCRIPTION
What does this PR do?
---------------------

This fixes issues we have for the `build` github action.
There is a nil pointer exception which is fixed with orchestrion `v1.4.0`.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------

Cf this [thread](https://dd.slack.com/archives/C02DW5ZH1EF/p1752666719370799).