### PR TITLE
[GPUM]: wait for external signal to finish cuda-basic app

### DIFF
--- a/components/datadog/apps/gpu/images/cuda-basic/cuda-basic.cu
+++ b/components/datadog/apps/gpu/images/cuda-basic/cuda-basic.cu
@@ -5,9 +5,20 @@
 #include <stdio.h>
 #include <string>
 #include <unistd.h>
+#include <signal.h>
+#include <atomic>
 
 // For the CUDA runtime routines (prefixed with "cuda_")
 #include <cuda_runtime.h>
+
+// Global flag for signal handling
+std::atomic<bool> should_exit{false};
+
+// Signal handler function for graceful shutdown
+void signal_handler(int signum) {
+	printf("Received signal %d, shutting down gracefully...\n", signum);
+	should_exit = true;
+}
 
 // Code to be executed in the GPU. Allows managing the number of loops to have
 // an increased execution time.
@@ -157,6 +168,20 @@ int main(int argc, const char **argv) {
 	}
 
 	printf("Test PASSED\n");
+
+	// Register signal handlers for graceful shutdown
+	signal(SIGTERM, signal_handler);
+	signal(SIGINT, signal_handler);
+
+	printf("GPU computation completed successfully. Container ready for monitoring.\n");
+	printf("Waiting for termination signal...\n");
+
+	// Keep container alive until signal received
+	while (!should_exit) {
+		sleep(5);
+	}
+
+	printf("Shutting down...\n");
 
 	// Free device global memory
 	err = cudaFree(d_A);


### PR DESCRIPTION
What does this PR do?
---------------------

adds graceful termination of the cuda-basic app only upon receiving an external signal

Which scenarios this will impact?
-------------------

gpu e2e tests

Motivation
----------

avoid race conditions when the workload finishes too fast

Additional Notes
----------------

a PR in the e2e tests in datadog-agent repo will follow