### PR TITLE
revert [GPUM]: wait for external signal to finish cuda-basic

### DIFF
--- a/components/datadog/apps/gpu/images/cuda-basic/cuda-basic.cu
+++ b/components/datadog/apps/gpu/images/cuda-basic/cuda-basic.cu
@@ -5,20 +5,9 @@
 #include <stdio.h>
 #include <string>
 #include <unistd.h>
-#include <signal.h>
-#include <atomic>
 
 // For the CUDA runtime routines (prefixed with "cuda_")
 #include <cuda_runtime.h>
-
-// Global flag for signal handling
-std::atomic<bool> should_exit{false};
-
-// Signal handler function for graceful shutdown
-void signal_handler(int signum) {
-	printf("Received signal %d, shutting down gracefully...\n", signum);
-	should_exit = true;
-}
 
 // Code to be executed in the GPU. Allows managing the number of loops to have
 // an increased execution time.
@@ -168,20 +157,6 @@ int main(int argc, const char **argv) {
 	}
 
 	printf("Test PASSED\n");
-
-	// Register signal handlers for graceful shutdown
-	signal(SIGTERM, signal_handler);
-	signal(SIGINT, signal_handler);
-
-	printf("GPU computation completed successfully. Container ready for monitoring.\n");
-	printf("Waiting for termination signal...\n");
-
-	// Keep container alive until signal received
-	while (!should_exit) {
-		sleep(5);
-	}
-
-	printf("Shutting down...\n");
 
 	// Free device global memory
 	err = cudaFree(d_A);


### PR DESCRIPTION
What does this PR do?
---------------------

revert the original [PR](https://github.com/DataDog/test-infra-definitions/pull/1625)

Which scenarios this will impact?
-------------------

Motivation
----------

e2e gpu tests started to fail on main in datadog-agent repo

Additional Notes
----------------
