### PR TITLE
Add kubernetes.io/arch nodeselector to windows agent in kubernetes

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -631,6 +631,9 @@ func buildWindowsHelmValues(baseName string, agentImagePath, agentImageTag, _, _
 				"tag":           pulumi.String(agentImageTag),
 				"doNotCheckTag": pulumi.Bool(true),
 			},
+			"nodeSelector": pulumi.Map{
+				"kubernetes.io/arch": pulumi.String("amd64"),
+			},
 		},
 		// Make the Windows node agents target the Linux cluster agent
 		"clusterAgent": pulumi.Map{


### PR DESCRIPTION
What does this PR do?
---------------------

Adds `kubernetes.io/arch: amd64` as a nodeselector to the windows version of the datadog agent

Which scenarios this will impact?
-------------------

Kubernetes based ones that deploy to windows nodes

Motivation
----------

[Failing test](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1041181594)
Windows pod is unable to come online because [of the following](https://dddev.datadoghq.com/event/explorer?query=kube_cluster_name%3Aci-init-71317976-4670-e2e-ekssuite-2f0369522723a4c3%20dda-windows-datadog-9qfr4&cols=&event=AwAAAZgywv-oaT6iFAAAABhBWmd5dzBuZ0FBRDYtQTVSME5hQlVKQnQAAABdMTE5ODMyZGMtZmEzNC00MGVhLWIwY2ItMzQwMjQ4YWMxZjE0LXN5bnRoZXRpYy10aW1lLTE3NTMxOTY0MDAwMDAwMDAwMDBjLTE3NTMxOTk5OTk1NDAwMDAwMDFvAAT8rQ&fromUser=true&messageDisplay=expanded-lg&options=&refresh_mode=paused&sort=DESC&view=all&from_ts=1753198140000&to_ts=1753200600000&live=false):
```
1 FailedCreatePodSandBox: Failed to create pod sandbox: rpc error: code = Unknown desc = failed to setup network for sandbox "717e4993ed8aa075e657268f253d834550f082ea357a47860c7d0f504b7ae454": plugin type="vpc-bridge" name="vpc" failed (add): failed to parse Kubernetes args: failed to get pod IP address dda-windows-datadog-9qfr4: error executing k8s connector: error executing connector binary: exit status 1 with execution error: pod dda-windows-datadog-9qfr4 does not have label vpc.amazonaws.com/PrivateIPv4Address
```

Both EKS's [documentation](https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html#windows-support-pod-deployment) as well as [troubleshooting guide](https://repost.aws/knowledge-center/eks-failed-create-pod-sandbox) both explicitly mention adding BOTH the `kubernetes.io/arch` AND `kubernetes.io/os` label to the nodeSelector field, but we are only adding the latter [via the helm chart](https://github.com/DataDog/helm-charts/blob/ef2c3d878f0941171617cffa6ab1c2865422eba2/charts/datadog/templates/daemonset.yaml#L240-L244)

Additional Notes
----------------
