### PR TITLE
Disable automatic update check for `dda` in the runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,6 +128,8 @@ RUN --mount=type=secret,id=github_token \
 RUN DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')" && \
   pip3 install --no-cache-dir "git+https://github.com/DataDog/datadog-agent-dev.git@${DDA_VERSION}" && \
   dda -v self dep sync -f legacy-e2e -f legacy-github && \
+  # Disable update check as it is not needed in the CI and it can pollute the output when displaying changelog
+  dda config set update.mode off && \
   # TODO: Remove once we have a new version of dda where the semver deps is in legacy_github
   pip3 install semver==2.10.0 && \
   go install gotest.tools/gotestsum@latest


### PR DESCRIPTION
What does this PR do?
---------------------

See title.

Which scenarios this will impact?
-------------------

Motivation
----------

`dda` periodically checks for updates and displays its changelog if a new version is found - this is useful when running interactively with a developer but useless in CI. Moreover it can cause some strange issues as the changelog is sometimes pushed in the `stdout` of the command you are trying to run, and can pollute its output.

#incident-41159

Additional Notes
----------------
