### PR TITLE
refactor(runner): Pin `dda` version instead of pulling from `datadog-agent-buildimages`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV HELM_VERSION=3.12.3
 ENV HELM_SHA=1b2313cd198d45eab00cc37c38f6b1ca0a948ba279c29e322bdf426d406129b5
 ARG CI_UPLOADER_SHA=873976f0f8de1073235cf558ea12c7b922b28e1be22dc1553bf56162beebf09d
 ARG CI_UPLOADER_VERSION=2.30.1
+ARG DDA_VERSION=v0.23.1
 # Skip Pulumi update warning https://www.pulumi.com/docs/cli/environment-variables/
 ENV PULUMI_SKIP_UPDATE_CHECK=true
 # Always prevent installing dependencies dynamically
@@ -125,8 +126,7 @@ RUN --mount=type=secret,id=github_token \
 
 # Install Agent requirements, required to run invoke tests task
 # Remove AWS-related deps as we already install AWS CLI v2
-RUN DDA_VERSION="$(curl -s https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/dda.env | awk -F= '/^DDA_VERSION=/ {print $2}')" && \
-  pip3 install --no-cache-dir "git+https://github.com/DataDog/datadog-agent-dev.git@${DDA_VERSION}" && \
+RUN pip3 install --no-cache-dir "git+https://github.com/DataDog/datadog-agent-dev.git@${DDA_VERSION}" && \
   dda -v self dep sync -f legacy-e2e -f legacy-github && \
   # Disable update check as it is not needed in the CI and it can pollute the output when displaying changelog
   dda config set update.mode off && \


### PR DESCRIPTION
What does this PR do?
---------------------

Pins the `dda` version used in the runner image instead of pulling it dynamically _at build time (!)_ using `curl` from `datadog-agent-buildimages`

Which scenarios this will impact?
-------------------

N/A

Motivation
----------

This makes it a lot easier to find out and control which version of `dda` is included in the runner image, at the cost of having possible desyncs. This seems like a good idea after [incident-41159](https://app.datadoghq.com/incidents/41159), [41173](https://app.datadoghq.com/incidents/41173) and [41126](https://app.datadoghq.com/incidents/41126).

Additional Notes
----------------

`dda` version mismatches with the rest of the buildimages are probably not that big of a deal for the e2e tests - the only thing we really need is to be able to run the invoke tasks.
