### PR TITLE
[CONTP-898] configure KSM check to run as clustercheck in clc runners

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -304,8 +304,9 @@ func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentI
 				"enabled": pulumi.Bool(true),
 			},
 			"kubeStateMetricsCore": pulumi.Map{
-				"enabled":           pulumi.Bool(true),
-				"collectVpaMetrics": pulumi.Bool(true),
+				"enabled":                pulumi.Bool(true),
+				"collectVpaMetrics":      pulumi.Bool(true),
+				"useClusterCheckRunners": pulumi.Bool(true),
 				"collectCrMetrics": pulumi.MapArray{
 					pulumi.Map{
 						"groupVersionKind": pulumi.StringMap{
@@ -521,6 +522,13 @@ func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentI
 				pulumi.StringMap{
 					"name":  pulumi.String("DD_CLC_RUNNER_REMOTE_TAGGER_ENABLED"),
 					"value": pulumi.String("true"),
+				},
+				// namespace labels as tags are removed here ƒrom the cluster check runner to
+				// be able to test that it can get the namespace labels from the cluster tagger
+				// via the remote tagger
+				pulumi.StringMap{
+					"name":  pulumi.String("DD_KUBERNETES_NAMESPACE_LABELS_AS_TAGS"),
+					"value": pulumi.JSONMarshal(map[string]interface{}{}),
 				},
 			},
 			"resources": pulumi.StringMapMap{


### PR DESCRIPTION
What does this PR do?
---------------------

Runs the KSM check as a cluster check in the CLC runner.

Which scenarios this will impact?
-------------------

Any scenario deploying the agent with Helm.

Motivation
----------

Additional Notes
----------------

Updates to e2e tests in datadog-agent should be done in the same PR bumping test-infra in datadog-agent

These tests are already updated in [this](https://github.com/DataDog/datadog-agent/pull/39245) PR.
