### PR TITLE
Refresh test-infra readme, to use dda, and to move Pulumi commands in  a dedicated section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ To run scripts and code in this repository, you will need:
 
 - [Go](https://golang.org/doc/install) 1.22 or later. You'll also need to set your `$GOPATH` and have `$GOPATH/bin` in your path.
 - Python 3.9+ along with development libraries for tooling.
-- `account-admin` role on AWS `agent-sandbox` account. Ensure it by running
+- `account-admin` role on AWS `agent-sandbox` account. Ensure it by running `aws-vault login sso-agent-sandbox-account-admin`
+- [dda](https://datadoghq.dev/datadog-agent/setup/#tooling) installed on your laptop
 
   ```bash
   aws-vault login sso-agent-sandbox-account-admin
@@ -33,7 +34,7 @@ cd ~/dd && git clone git@github.com:DataDog/test-infra-definitions.git
 2. Install Python dependencies
 
 ```bash
-cd ~/dd/test-infra-definitions && pip3 install --requirement requirements.txt
+cd ~/dd/test-infra-definitions && dda -v self dep sync -f legacy-e2e -f legacy-github
 ```
 
 3. Add a PULUMI_CONFIG_PASSPHRASE to your Terminal rc file. Create a random password using 1Password and store it there
@@ -45,47 +46,35 @@ export PULUMI_CONFIG_PASSPHRASE=<random password stored in 1Password>
 4. Run and follow the setup script
 
 ```bash
-inv setup
+dda inv setup
 ```
 
 ### Create an environment for manual tests
 
-Invoke tasks help deploying most common environments - VMs, Docker, ECS, EKS. Run `inv -l` to learn more.
+Invoke tasks help deploying most common environments - VMs, Docker, ECS, EKS. Run `dda inv -l` to learn more.
 
+To get the list of available tasks
 ```bash
-❯ inv -l
-Available tasks:
-
-  check-s3-image-exists                                     Verify if an image exists in the s3 repository to create a vm
-  retry-job                                                 Retry gitlab pipeline job
-  aws.create-docker                                         Create a docker environment.
-  aws.create-ecs                                            Create a new ECS environment.
-  aws.create-eks                                            Create a new EKS environment. It lasts around 20 minutes.
-  aws.create-installer-lab
-  aws.create-kind                                           Create a kind environment.
-  aws.create-vm                                             Create a new virtual machine on aws.
-  aws.destroy-docker                                        Destroy an environment created by invoke aws.create-docker.
-  aws.destroy-ecs                                           Destroy a ECS environment created with invoke aws.create-ecs.
-  aws.destroy-eks                                           Destroy a EKS environment created with invoke aws.create-eks.
-  aws.destroy-installer-lab
-  aws.destroy-kind                                          Destroy an environment created by invoke aws.create-kind.
-  aws.destroy-vm                                            Destroy a new virtual machine on aws.
-  az.create-aks                                             Create a new AKS environment. It lasts around 5 minutes.
-  az.create-vm                                              Create a new virtual machine on azure.
-  az.destroy-aks                                            Destroy a AKS environment created with invoke az.create-aks.
-  az.destroy-vm                                             Destroy a new virtual machine on azure.
-  ci.create-bump-pr-and-close-stale-ones-on-datadog-agent
-  gcp.create-openshift                                      Create an OpenShift environment.
-  gcp.create-vm                                             Create a new virtual machine on GCP.
-  gcp.destroy-openshift                                     Destroy an environment created by invoke gcp.create-openshift.
-  gcp.destroy-vm                                            Destroy a virtual machine environment created with invoke gcp.create-vm.
-  setup.debug                                               Debug E2E and test-infra-definitions required tools and configuration
-  setup.debug-keys                                          Debug E2E and test-infra-definitions SSH keys
-  setup.setup (setup)                                       Setup a local environment, interactively by default
-  test.check-xslt                                           Checks the XSLT transformations in the scenarios/aws/microVMs/microvms/resources path
+❯ dda inv -l
 ```
 
 Run any `-h` on any of the available tasks for more information
+
+## Troubleshooting
+
+### Environment and configuration
+
+The `setup.debug` invoke task will check for common mistakes such as key unavailable in configured AWS region, ssh-agent not running, invalid key format, and more.
+
+```
+aws-vault exec sso-agent-sandbox-account-admin -- dda inv setup.debug
+aws-vault exec sso-agent-sandbox-account-admin -- dda inv setup --debug --no-interactive
+```
+
+
+## Interact with Pulumi
+
+Note: For most of the users interacting with Pulumi directly should not be required, you should be able to rely exclusively on the available tasks.
 
 ### Pulumi: Stack & Storage
 
@@ -176,15 +165,4 @@ pulumi up -c scenario=aws/eks -c ddinfra:aws/defaultKeyPairName=<your_exisiting_
 ```
 # You need to have a DD APIKey AND APPKey in variable DD_API_KEY / DD_APP_KEY
 pulumi up -c scenario=gcp/openshiftvm -c ddinfra:env=gcp/agent-sandbox -c ddinfra:gcp/openshift/pullSecretPath=<your_pull_secret_path -c ddinfra:gcp/enableNestedVirtualization=true -c ddinfra:gcp/defaultInstanceType=n2-standard-8 -c ddinfra:gcp/defaultPublicKeyPath=$HOME/.ssh/id_ed25519.pub -c ddagent:apiKey=$DD_API_KEY  -c ddagent:appKey=$DD_APP_KEY -c ddtestworkload:deploy=false -s <your_name>-openshift
-```
-
-## Troubleshooting
-
-### Environment and configuration
-
-The `setup.debug` invoke task will check for common mistakes such as key unavailable in configured AWS region, ssh-agent not running, invalid key format, and more.
-
-```
-aws-vault exec sso-agent-sandbox-account-admin -- inv setup.debug
-aws-vault exec sso-agent-sandbox-account-admin -- inv setup --debug --no-interactive
 ```


### PR DESCRIPTION
What does this PR do?
---------------------

Update the README, to mention the new way to install dependencies as `dda`.
It also move the section about running pulumi command at the end with a disclaimer. This is not something that should be done by users, unless they know what they are doing


Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
