### PR TITLE
Adding in Quickstart for GKE Standard and GKE Autopilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ pulumi up -c scenario=gcp/gke -c ddinfra:env=gcp/agent-sandbox -c ddinfra:gcp/de
 ```
 # You need to have a DD APIKey AND APPKey in variable DD_API_KEY / DD_APP_KEY
 pulumi up -c scenario=gcp/openshiftvm -c ddinfra:env=gcp/agent-sandbox -c ddinfra:gcp/openshift/pullSecretPath=<your_pull_secret_path -c ddinfra:gcp/enableNestedVirtualization=true -c ddinfra:gcp/defaultInstanceType=n2-standard-8 -c ddinfra:gcp/defaultPublicKeyPath=$HOME/.ssh/id_ed25519.pub -c ddagent:apiKey=$DD_API_KEY  -c ddagent:appKey=$DD_APP_KEY -c ddtestworkload:deploy=false -s <your_name>-openshift
-
 ```
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -169,6 +169,21 @@ pulumi up -c scenario=aws/ecs -c ddinfra:aws/defaultKeyPairName=<your_exisiting_
 pulumi up -c scenario=aws/eks -c ddinfra:aws/defaultKeyPairName=<your_exisiting_aws_keypair_name> -c ddinfra:env=aws/agent-sandbox -c ddagent:apiKey=$DD_API_KEY -c ddagent:appKey=$DD_APP_KEY -s <your_name>-eks
 ```
 
+## Quick start: Create a GKE Standard + Agent (Helm) or a GKE Autopilot + Agent (Helm)
+**Prerequisites:**
+- Install the GKE authentication plugin: `gcloud components install gke-gcloud-auth-plugin`
+- Add the plugin to your PATH: `export PATH="/opt/homebrew/share/google-cloud-sdk/bin:$PATH"`
+- Authenticate with GCP: `gcloud auth application-default login`
+```
+# You need to have a DD APIKey AND APPKey in variable DD_API_KEY / DD_APP_KEY
+# GKE Standard
+pulumi up -c scenario=gcp/gke -c ddinfra:env=gcp/agent-sandbox -c ddinfra:gcp/defaultPublicKeyPath=$HOME/.ssh/id_ed25519.pub -c ddagent:apiKey=$DD_API_KEY -c ddagent:appKey=$DD_APP_KEY -s <your_name>-gke
+
+# GKE Autopilot
+pulumi up -c scenario=gcp/gke -c ddinfra:env=gcp/agent-sandbox -c ddinfra:gcp/defaultPublicKeyPath=$HOME/.ssh/id_ed25519.pub -c ddinfra:gcp/gke/enableAutopilot=true -c ddagent:apiKey=$DD_API_KEY -c ddagent:appKey=$DD_APP_KEY -s <your_name>-gke-autopilot
+
+```
+
 ## Troubleshooting
 
 ### Environment and configuration


### PR DESCRIPTION
What does this PR do?
---------------------
Adds quick start examples for both GKE Standard and GKE Autopilot clusters in the README.md file.

Motivation
----------
Currently the README.md file is lacking documentation for GKE environments.

