### PR TITLE
Target testing keys directory when downloading artifacts from {apt,yum}testing.datad0g.com

### DIFF
--- a/components/datadog/agent/host_linuxos.go
+++ b/components/datadog/agent/host_linuxos.go
@@ -38,6 +38,8 @@ func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersio
 		// yum testing repo
 		// TESTING_YUM_VERSION_PATH="testing/pipeline-xxxxx-a7/7"
 		testEnvVars = append(testEnvVars, fmt.Sprintf("TESTING_YUM_VERSION_PATH=testing/pipeline-%[1]v-a%[2]v/%[2]v", version.PipelineID, version.Major))
+		// target testing keys
+		testEnvVars = append(testEnvVars, fmt.Sprintf("TESTING_KEYS_URL=apttesting.datad0g.com/test-keys-vault"))
 	} else {
 		testEnvVars = append(testEnvVars, fmt.Sprintf("DD_AGENT_MAJOR_VERSION=%v", version.Major))
 


### PR DESCRIPTION
What does this PR do?
---------------------

When targeting a test artifact from a specific pipeline in `datadog-agent`, use the testing keys to verify the metadata signatures of apttesting.datad0g.com and yumtesting.datad0g.com.

Needed after the merge of https://github.com/DataDog/datadog-agent/pull/36943, which makes the `datadog-agent` pipeline sign testing repositories with a dedicated set of testing keys.

Which scenarios this will impact?
-------------------

Local runs of E2E tests, which need to download artifacts from the testing repositories. CI runs were not affected because they use the local Gitlab pipeline artifact.

Motivation
----------

Fix local use cases.

Additional Notes
----------------

n/a
