### PR TITLE
Deploying Test Workloads onto OpenShift cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,5 +178,5 @@ pulumi up -c scenario=gcp/gke -c ddinfra:env=gcp/agent-sandbox -c ddinfra:gcp/de
 
 ```
 # You need to have a DD APIKey AND APPKey in variable DD_API_KEY / DD_APP_KEY
-pulumi up -c scenario=gcp/openshiftvm -c ddinfra:env=gcp/agent-sandbox -c ddinfra:gcp/openshift/pullSecretPath=<your_pull_secret_path -c ddinfra:gcp/enableNestedVirtualization=true -c ddinfra:gcp/defaultInstanceType=n2-standard-8 -c ddinfra:gcp/defaultPublicKeyPath=$HOME/.ssh/id_ed25519.pub -c ddagent:apiKey=$DD_API_KEY  -c ddagent:appKey=$DD_APP_KEY -c ddtestworkload:deploy=false -s <your_name>-openshift
+pulumi up -c scenario=gcp/openshiftvm -c ddinfra:env=gcp/agent-sandbox -c ddinfra:gcp/openshift/pullSecretPath=<your_pull_secret_path -c ddinfra:gcp/enableNestedVirtualization=true -c ddinfra:gcp/defaultInstanceType=n2-standard-8 -c ddinfra:gcp/defaultPublicKeyPath=$HOME/.ssh/id_ed25519.pub -c ddagent:apiKey=$DD_API_KEY  -c ddagent:appKey=$DD_APP_KEY -s <your_name>-openshift
 ```

--- a/components/datadog/apps/cpustress/openshift.go
+++ b/components/datadog/apps/cpustress/openshift.go
@@ -1,0 +1,102 @@
+package cpustress
+
+import (
+	"fmt"
+
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
+	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
+
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func K8sAppDefinitionOpenShift(e config.Env, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
+	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
+
+	k8sComponent := &componentskube.Workload{}
+	if err := e.Ctx().RegisterComponentResource("dd:apps", fmt.Sprintf("%s-cpustress-openshift", namespace), k8sComponent, opts...); err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, pulumi.Parent(k8sComponent))
+
+	ns, err := corev1.NewNamespace(e.Ctx(), namespace, &corev1.NamespaceArgs{
+		Metadata: metav1.ObjectMetaArgs{
+			Name: pulumi.String(namespace),
+		},
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, utils.PulumiDependsOn(ns))
+
+	if _, err := appsv1.NewDeployment(e.Ctx(), fmt.Sprintf("%s/stress-ng", namespace), &appsv1.DeploymentArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.String("stress-ng"),
+			Namespace: pulumi.String(namespace),
+			Labels: pulumi.StringMap{
+				"app": pulumi.String("stress-ng"),
+			},
+		},
+		Spec: &appsv1.DeploymentSpecArgs{
+			Replicas: pulumi.Int(1),
+			Selector: &metav1.LabelSelectorArgs{
+				MatchLabels: pulumi.StringMap{
+					"app": pulumi.String("stress-ng"),
+				},
+			},
+			Template: &corev1.PodTemplateSpecArgs{
+				Metadata: &metav1.ObjectMetaArgs{
+					Labels: pulumi.StringMap{
+						"app": pulumi.String("stress-ng"),
+					},
+				},
+				Spec: &corev1.PodSpecArgs{
+					Containers: corev1.ContainerArray{
+						corev1.ContainerArgs{
+							Name:  pulumi.String("stress-ng"),
+							Image: pulumi.String("ghcr.io/datadog/apps-stress-ng:" + apps.Version),
+							Args: pulumi.StringArray{
+								pulumi.String("--cpu=1"),
+								pulumi.String("--cpu-load=15"),
+							},
+							WorkingDir: pulumi.String("/tmp"),
+							Resources: &corev1.ResourceRequirementsArgs{
+								Limits: pulumi.StringMap{
+									"cpu":    pulumi.String("200m"),
+									"memory": pulumi.String("128Mi"),
+								},
+								Requests: pulumi.StringMap{
+									"cpu":    pulumi.String("100m"),
+									"memory": pulumi.String("64Mi"),
+								},
+							},
+							VolumeMounts: corev1.VolumeMountArray{
+								corev1.VolumeMountArgs{
+									Name:      pulumi.String("temp-dir"),
+									MountPath: pulumi.String("/tmp"),
+								},
+							},
+						},
+					},
+					Volumes: corev1.VolumeArray{
+						corev1.VolumeArgs{
+							Name:     pulumi.String("temp-dir"),
+							EmptyDir: &corev1.EmptyDirVolumeSourceArgs{},
+						},
+					},
+				},
+			},
+		},
+	}, opts...); err != nil {
+		return nil, err
+	}
+
+	return k8sComponent, nil
+}

--- a/components/datadog/apps/dogstatsd/openshift.go
+++ b/components/datadog/apps/dogstatsd/openshift.go
@@ -1,0 +1,325 @@
+package dogstatsd
+
+import (
+	"fmt"
+
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
+	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
+
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// K8sAppDefinitionOpenShift creates only UDP deployments for OpenShift
+func K8sAppDefinitionOpenShift(e config.Env, kubeProvider *kubernetes.Provider, namespace string, statsdPort int, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
+	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
+
+	k8sComponent := &componentskube.Workload{}
+	if err := e.Ctx().RegisterComponentResource("dd:apps", fmt.Sprintf("dogstatsd-openshift-%d", statsdPort), k8sComponent, opts...); err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, pulumi.Parent(k8sComponent))
+
+	ns, err := corev1.NewNamespace(e.Ctx(), namespace, &corev1.NamespaceArgs{
+		Metadata: metav1.ObjectMetaArgs{
+			Name: pulumi.String(namespace),
+		},
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, utils.PulumiDependsOn(ns))
+
+	if _, err := appsv1.NewDeployment(e.Ctx(), fmt.Sprintf("dogstatsd-udp-%d", statsdPort), &appsv1.DeploymentArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.String("dogstatsd-udp"),
+			Namespace: pulumi.String(namespace),
+			Labels: pulumi.StringMap{
+				"app": pulumi.String("dogstatsd-udp"),
+			},
+		},
+		Spec: &appsv1.DeploymentSpecArgs{
+			Replicas: pulumi.Int(1),
+			Selector: &metav1.LabelSelectorArgs{
+				MatchLabels: pulumi.StringMap{
+					"app": pulumi.String("dogstatsd-udp"),
+				},
+			},
+			Template: &corev1.PodTemplateSpecArgs{
+				Metadata: &metav1.ObjectMetaArgs{
+					Labels: pulumi.StringMap{
+						"app": pulumi.String("dogstatsd-udp"),
+					},
+				},
+				Spec: &corev1.PodSpecArgs{
+					Containers: corev1.ContainerArray{
+						&corev1.ContainerArgs{
+							Name:  pulumi.String("dogstatsd"),
+							Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:" + apps.Version),
+							Env: &corev1.EnvVarArray{
+								&corev1.EnvVarArgs{
+									Name: pulumi.String("HOST_IP"),
+									ValueFrom: &corev1.EnvVarSourceArgs{
+										FieldRef: &corev1.ObjectFieldSelectorArgs{
+											FieldPath: pulumi.String("status.hostIP"),
+										},
+									},
+								},
+								&corev1.EnvVarArgs{
+									Name:  pulumi.String("STATSD_URL"),
+									Value: pulumi.Sprintf("$(HOST_IP):%d", statsdPort),
+								},
+								&corev1.EnvVarArgs{
+									Name: pulumi.String("DD_INTERNAL_POD_UID"),
+									ValueFrom: &corev1.EnvVarSourceArgs{
+										FieldRef: &corev1.ObjectFieldSelectorArgs{
+											FieldPath: pulumi.String("metadata.uid"),
+										},
+									},
+								},
+								&corev1.EnvVarArgs{
+									Name:  pulumi.String("DD_ENTITY_ID"),
+									Value: pulumi.String("en-$(DD_INTERNAL_POD_UID)/dogstatsd"),
+								},
+							},
+							Resources: &corev1.ResourceRequirementsArgs{
+								Limits: pulumi.StringMap{
+									"cpu":    pulumi.String("10m"),
+									"memory": pulumi.String("32Mi"),
+								},
+								Requests: pulumi.StringMap{
+									"cpu":    pulumi.String("2m"),
+									"memory": pulumi.String("32Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, opts...); err != nil {
+		return nil, err
+	}
+
+	if _, err := appsv1.NewDeployment(e.Ctx(), fmt.Sprintf("dogstatsd-udp-origin-detection-%d", statsdPort), &appsv1.DeploymentArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.String("dogstatsd-udp-origin-detection"),
+			Namespace: pulumi.String(namespace),
+			Labels: pulumi.StringMap{
+				"app": pulumi.String("dogstatsd-udp-origin-detection"),
+			},
+		},
+		Spec: &appsv1.DeploymentSpecArgs{
+			Replicas: pulumi.Int(1),
+			Selector: &metav1.LabelSelectorArgs{
+				MatchLabels: pulumi.StringMap{
+					"app": pulumi.String("dogstatsd-udp-origin-detection"),
+				},
+			},
+			Template: &corev1.PodTemplateSpecArgs{
+				Metadata: &metav1.ObjectMetaArgs{
+					Labels: pulumi.StringMap{
+						"app": pulumi.String("dogstatsd-udp-origin-detection"),
+					},
+				},
+				Spec: &corev1.PodSpecArgs{
+					Containers: corev1.ContainerArray{
+						&corev1.ContainerArgs{
+							Name:  pulumi.String("dogstatsd"),
+							Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:" + apps.Version),
+							Env: &corev1.EnvVarArray{
+								&corev1.EnvVarArgs{
+									Name: pulumi.String("HOST_IP"),
+									ValueFrom: &corev1.EnvVarSourceArgs{
+										FieldRef: &corev1.ObjectFieldSelectorArgs{
+											FieldPath: pulumi.String("status.hostIP"),
+										},
+									},
+								},
+								&corev1.EnvVarArgs{
+									Name:  pulumi.String("STATSD_URL"),
+									Value: pulumi.Sprintf("$(HOST_IP):%d", statsdPort),
+								},
+								&corev1.EnvVarArgs{
+									Name: pulumi.String("DD_ENTITY_ID"),
+									ValueFrom: &corev1.EnvVarSourceArgs{
+										FieldRef: &corev1.ObjectFieldSelectorArgs{
+											FieldPath: pulumi.String("metadata.uid"),
+										},
+									},
+								},
+								&corev1.EnvVarArgs{
+									Name:  pulumi.String("DD_EXTERNAL_DATA_ONLY"),
+									Value: pulumi.String("true"),
+								},
+							},
+							Resources: &corev1.ResourceRequirementsArgs{
+								Limits: pulumi.StringMap{
+									"cpu":    pulumi.String("10m"),
+									"memory": pulumi.String("32Mi"),
+								},
+								Requests: pulumi.StringMap{
+									"cpu":    pulumi.String("2m"),
+									"memory": pulumi.String("32Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, opts...); err != nil {
+		return nil, err
+	}
+
+	if _, err := appsv1.NewDeployment(e.Ctx(), fmt.Sprintf("dogstatsd-udp-contname-injected-%d", statsdPort), &appsv1.DeploymentArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.String("dogstatsd-udp-contname-injected"),
+			Namespace: pulumi.String(namespace),
+			Labels: pulumi.StringMap{
+				"app": pulumi.String("dogstatsd-udp-contname-injected"),
+			},
+		},
+		Spec: &appsv1.DeploymentSpecArgs{
+			Replicas: pulumi.Int(1),
+			Selector: &metav1.LabelSelectorArgs{
+				MatchLabels: pulumi.StringMap{
+					"app": pulumi.String("dogstatsd-udp-contname-injected"),
+				},
+			},
+			Template: &corev1.PodTemplateSpecArgs{
+				Metadata: &metav1.ObjectMetaArgs{
+					Labels: pulumi.StringMap{
+						"app": pulumi.String("dogstatsd-udp-contname-injected"),
+					},
+				},
+				Spec: &corev1.PodSpecArgs{
+					Containers: corev1.ContainerArray{
+						&corev1.ContainerArgs{
+							Name:  pulumi.String("dogstatsd"),
+							Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:" + apps.Version),
+							Env: &corev1.EnvVarArray{
+								&corev1.EnvVarArgs{
+									Name: pulumi.String("HOST_IP"),
+									ValueFrom: &corev1.EnvVarSourceArgs{
+										FieldRef: &corev1.ObjectFieldSelectorArgs{
+											FieldPath: pulumi.String("status.hostIP"),
+										},
+									},
+								},
+								&corev1.EnvVarArgs{
+									Name:  pulumi.String("STATSD_URL"),
+									Value: pulumi.Sprintf("$(HOST_IP):%d", statsdPort),
+								},
+								&corev1.EnvVarArgs{
+									Name: pulumi.String("DD_INTERNAL_POD_UID"),
+									ValueFrom: &corev1.EnvVarSourceArgs{
+										FieldRef: &corev1.ObjectFieldSelectorArgs{
+											FieldPath: pulumi.String("metadata.uid"),
+										},
+									},
+								},
+								&corev1.EnvVarArgs{
+									Name:  pulumi.String("DD_ENTITY_ID"),
+									Value: pulumi.String("en-$(DD_INTERNAL_POD_UID)/dogstatsd"),
+								},
+							},
+							Resources: &corev1.ResourceRequirementsArgs{
+								Limits: pulumi.StringMap{
+									"cpu":    pulumi.String("10m"),
+									"memory": pulumi.String("32Mi"),
+								},
+								Requests: pulumi.StringMap{
+									"cpu":    pulumi.String("2m"),
+									"memory": pulumi.String("32Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, opts...); err != nil {
+		return nil, err
+	}
+
+	if _, err := appsv1.NewDeployment(e.Ctx(), fmt.Sprintf("dogstatsd-udp-external-data-only-%d", statsdPort), &appsv1.DeploymentArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.String("dogstatsd-udp-external-data-only"),
+			Namespace: pulumi.String(namespace),
+			Labels: pulumi.StringMap{
+				"app": pulumi.String("dogstatsd-udp-external-data-only"),
+			},
+		},
+		Spec: &appsv1.DeploymentSpecArgs{
+			Replicas: pulumi.Int(1),
+			Selector: &metav1.LabelSelectorArgs{
+				MatchLabels: pulumi.StringMap{
+					"app": pulumi.String("dogstatsd-udp-external-data-only"),
+				},
+			},
+			Template: &corev1.PodTemplateSpecArgs{
+				Metadata: &metav1.ObjectMetaArgs{
+					Labels: pulumi.StringMap{
+						"app": pulumi.String("dogstatsd-udp-external-data-only"),
+					},
+				},
+				Spec: &corev1.PodSpecArgs{
+					Containers: corev1.ContainerArray{
+						&corev1.ContainerArgs{
+							Name:  pulumi.String("dogstatsd"),
+							Image: pulumi.String("ghcr.io/datadog/apps-dogstatsd:" + apps.Version),
+							Env: &corev1.EnvVarArray{
+								&corev1.EnvVarArgs{
+									Name: pulumi.String("HOST_IP"),
+									ValueFrom: &corev1.EnvVarSourceArgs{
+										FieldRef: &corev1.ObjectFieldSelectorArgs{
+											FieldPath: pulumi.String("status.hostIP"),
+										},
+									},
+								},
+								&corev1.EnvVarArgs{
+									Name:  pulumi.String("STATSD_URL"),
+									Value: pulumi.Sprintf("$(HOST_IP):%d", statsdPort),
+								},
+								&corev1.EnvVarArgs{
+									Name: pulumi.String("DD_INTERNAL_POD_UID"),
+									ValueFrom: &corev1.EnvVarSourceArgs{
+										FieldRef: &corev1.ObjectFieldSelectorArgs{
+											FieldPath: pulumi.String("metadata.uid"),
+										},
+									},
+								},
+								&corev1.EnvVarArgs{
+									Name:  pulumi.String("DD_EXTERNAL_DATA_ONLY"),
+									Value: pulumi.String("true"),
+								},
+							},
+							Resources: &corev1.ResourceRequirementsArgs{
+								Limits: pulumi.StringMap{
+									"cpu":    pulumi.String("10m"),
+									"memory": pulumi.String("32Mi"),
+								},
+								Requests: pulumi.StringMap{
+									"cpu":    pulumi.String("2m"),
+									"memory": pulumi.String("32Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, opts...); err != nil {
+		return nil, err
+	}
+
+	return k8sComponent, nil
+}

--- a/components/datadog/apps/tracegen/openshift.go
+++ b/components/datadog/apps/tracegen/openshift.go
@@ -1,0 +1,96 @@
+package tracegen
+
+import (
+	"fmt"
+
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
+	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
+
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// K8sAppDefinitionOpenShift creates only TCP deployments
+func K8sAppDefinitionOpenShift(e config.Env, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
+	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
+
+	k8sComponent := &componentskube.Workload{}
+	if err := e.Ctx().RegisterComponentResource("dd:apps", fmt.Sprintf("%s-tracegen-openshift", namespace), k8sComponent, opts...); err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, pulumi.Parent(k8sComponent))
+
+	ns, err := corev1.NewNamespace(e.Ctx(), namespace, &corev1.NamespaceArgs{
+		Metadata: metav1.ObjectMetaArgs{
+			Name: pulumi.String(namespace),
+		},
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, utils.PulumiDependsOn(ns))
+
+	if _, err := appsv1.NewDeployment(e.Ctx(), fmt.Sprintf("%s/tracegen-tcp", namespace), &appsv1.DeploymentArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.String("tracegen-tcp"),
+			Namespace: pulumi.String(namespace),
+			Labels: pulumi.StringMap{
+				"app": pulumi.String("tracegen-tcp"),
+			},
+		},
+		Spec: &appsv1.DeploymentSpecArgs{
+			Replicas: pulumi.Int(1),
+			Selector: &metav1.LabelSelectorArgs{
+				MatchLabels: pulumi.StringMap{
+					"app": pulumi.String("tracegen-tcp"),
+				},
+			},
+			Template: &corev1.PodTemplateSpecArgs{
+				Metadata: &metav1.ObjectMetaArgs{
+					Labels: pulumi.StringMap{
+						"app": pulumi.String("tracegen-tcp"),
+					},
+				},
+				Spec: &corev1.PodSpecArgs{
+					Containers: corev1.ContainerArray{
+						&corev1.ContainerArgs{
+							Name:  pulumi.String("tracegen-tcp"),
+							Image: pulumi.String("ghcr.io/datadog/apps-tracegen:" + apps.Version),
+							Env: &corev1.EnvVarArray{
+								&corev1.EnvVarArgs{
+									Name: pulumi.String("DD_AGENT_HOST"),
+									ValueFrom: &corev1.EnvVarSourceArgs{
+										FieldRef: &corev1.ObjectFieldSelectorArgs{
+											FieldPath: pulumi.String("status.hostIP"),
+										},
+									},
+								},
+							},
+							Resources: &corev1.ResourceRequirementsArgs{
+								Limits: pulumi.StringMap{
+									"cpu":    pulumi.String("10m"),
+									"memory": pulumi.String("32Mi"),
+								},
+								Requests: pulumi.StringMap{
+									"cpu":    pulumi.String("2m"),
+									"memory": pulumi.String("32Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, opts...); err != nil {
+		return nil, err
+	}
+
+	return k8sComponent, nil
+}

--- a/scenarios/gcp/openshiftvm/run.go
+++ b/scenarios/gcp/openshiftvm/run.go
@@ -89,6 +89,7 @@ func Run(ctx *pulumi.Context) error {
 datadog:
   kubelet:
     tlsVerify: false
+  # https://docs.datadoghq.com/containers/troubleshooting/admission-controller/?tab=helm#openshift
   apm:
     portEnabled: true
     socketEnabled: false

--- a/scenarios/gcp/openshiftvm/run.go
+++ b/scenarios/gcp/openshiftvm/run.go
@@ -6,6 +6,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/cpustress"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/prometheus"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/redis"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/tracegen"
 	fakeintakeComp "github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
 	"github.com/DataDog/test-infra-definitions/components/datadog/kubernetesagentparams"
 	"github.com/DataDog/test-infra-definitions/components/kubernetes"
@@ -166,6 +167,9 @@ clusterAgent:
 		}
 
 		if _, err := cpustress.K8sAppDefinitionOpenShift(&gcpEnv, openshiftKubeProvider, "workload-cpustress"); err != nil {
+			return err
+		}
+		if _, err := tracegen.K8sAppDefinitionOpenShift(&gcpEnv, openshiftKubeProvider, "workload-tracegen"); err != nil {
 			return err
 		}
 	}

--- a/scenarios/gcp/openshiftvm/run.go
+++ b/scenarios/gcp/openshiftvm/run.go
@@ -3,6 +3,7 @@ package openshiftvm
 import (
 	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent/helm"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/cpustress"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/prometheus"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/redis"
 	fakeintakeComp "github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
@@ -164,6 +165,9 @@ clusterAgent:
 			return err
 		}
 
+		if _, err := cpustress.K8sAppDefinitionOpenShift(&gcpEnv, openshiftKubeProvider, "workload-cpustress"); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/scenarios/gcp/openshiftvm/run.go
+++ b/scenarios/gcp/openshiftvm/run.go
@@ -4,6 +4,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent/helm"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/cpustress"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps/dogstatsd"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/prometheus"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/redis"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/tracegen"
@@ -170,6 +171,9 @@ clusterAgent:
 			return err
 		}
 		if _, err := tracegen.K8sAppDefinitionOpenShift(&gcpEnv, openshiftKubeProvider, "workload-tracegen"); err != nil {
+			return err
+		}
+		if _, err := dogstatsd.K8sAppDefinitionOpenShift(&gcpEnv, openshiftKubeProvider, "workload-dogstatsd", 8125, dependsOnDDAgent /* for admission */); err != nil {
 			return err
 		}
 	}

--- a/scenarios/gcp/openshiftvm/run.go
+++ b/scenarios/gcp/openshiftvm/run.go
@@ -3,7 +3,6 @@ package openshiftvm
 import (
 	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/components/datadog/agent/helm"
-	"github.com/DataDog/test-infra-definitions/components/datadog/apps/mutatedbyadmissioncontroller"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/prometheus"
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/redis"
 	fakeintakeComp "github.com/DataDog/test-infra-definitions/components/datadog/fakeintake"
@@ -87,6 +86,9 @@ func Run(ctx *pulumi.Context) error {
 datadog:
   kubelet:
     tlsVerify: false
+  apm:
+    portEnabled: true
+    socketEnabled: false
 agents:
   enabled: true
   tolerations:
@@ -162,9 +164,6 @@ clusterAgent:
 			return err
 		}
 
-		if _, err := mutatedbyadmissioncontroller.K8sAppDefinition(&gcpEnv, openshiftKubeProvider, "workload-mutated", "workload-mutated-lib-injection", dependsOnDDAgent /* for admission */); err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/tasks/gcp/openshift.py
+++ b/tasks/gcp/openshift.py
@@ -36,7 +36,7 @@ def create_openshift(
     pull_secret_path: Optional[str] = None,
     use_nested_virtualization: Optional[bool] = True,
     install_agent: Optional[bool] = True,
-    install_workload: Optional[bool] = False,
+    install_workload: Optional[bool] = True,
     use_fakeintake: Optional[bool] = False,
     use_loadBalancer: Optional[bool] = False,
     agent_version: Optional[str] = None,


### PR DESCRIPTION
What does this PR do?
---------------------
This PR enables deploying test workloads on an OpenShift cluster. In this PR Redis, Prometheus, CPUStress, Tracegen, Dogstatsd are deployed.

Which scenarios this will impact?
-------------------
This change impacts `gcp\openshiftvm`

Motivation
----------
Previously, deploying test workloads was disabled.

Additional Notes
----------------
I've had to make additional changes for test workloads because of OpenShift's SCCs. All changes are outlined in this [documentation](https://docs.google.com/document/d/1Ea_gBRH5q8La99PZIgcPa4ALWZD9Oaf22PFdOAY_udg/edit?tab=t.0)