### PR TITLE
Migrate ECS Fargate Tasks to ReadOnly

### DIFF
--- a/components/datadog/agent/ecsFargate.go
+++ b/components/datadog/agent/ecsFargate.go
@@ -20,7 +20,7 @@ func ECSFargateLinuxContainerDefinition(e config.Env, image string, apiKeySSMPar
 		Name:                   pulumi.String("init-copy-agent-config"),
 		Image:                  pulumi.String(image),
 		Essential:              pulumi.BoolPtr(false),
-		ReadonlyRootFilesystem: pulumi.BoolPtr(false),
+		ReadonlyRootFilesystem: pulumi.BoolPtr(true),
 		Command:                pulumi.StringArray{pulumi.String("sh"), pulumi.String("-c"), pulumi.String("cp -R /etc/datadog-agent/* /agent-config/")},
 		MountPoints: ecs.TaskDefinitionMountPointArray{
 			ecs.TaskDefinitionMountPointArgs{
@@ -31,41 +31,18 @@ func ECSFargateLinuxContainerDefinition(e config.Env, image string, apiKeySSMPar
 		},
 	}
 
-	// Init container must terminate successfully before the agent starts
-	readonlyFSDependsOn := ecs.TaskDefinitionContainerDependencyArray{
-		ecs.TaskDefinitionContainerDependencyArgs{
-			ContainerName: pulumi.String("init-copy-agent-config"),
-			Condition:     pulumi.String("SUCCESS"),
-		},
-	}
-
-	// Agent container requires write permissions in following directories:
-	readonlyFSMountPoints := ecs.TaskDefinitionMountPointArray{
-		ecs.TaskDefinitionMountPointArgs{
-			ContainerPath: pulumi.StringPtr("/etc/datadog-agent"),
-			SourceVolume:  pulumi.StringPtr("agent-config"),
-		},
-		ecs.TaskDefinitionMountPointArgs{
-			ContainerPath: pulumi.StringPtr("/opt/datadog-agent/run"),
-			SourceVolume:  pulumi.StringPtr("agent-option"),
-		},
-		ecs.TaskDefinitionMountPointArgs{
-			ContainerPath: pulumi.StringPtr("/tmp"),
-			SourceVolume:  pulumi.StringPtr("agent-tmp"),
-		},
-		ecs.TaskDefinitionMountPointArgs{
-			ContainerPath: pulumi.StringPtr("/var/log/datadog"),
-			SourceVolume:  pulumi.StringPtr("agent-log"),
-		},
-	}
-
 	agentContainer := &ecs.TaskDefinitionContainerDefinitionArgs{
 		Cpu:                    pulumi.IntPtr(0),
 		Name:                   pulumi.String("datadog-agent"),
 		Image:                  pulumi.String(image),
 		Essential:              pulumi.BoolPtr(true),
 		ReadonlyRootFilesystem: pulumi.BoolPtr(true),
-		DependsOn:              readonlyFSDependsOn,
+		DependsOn: ecs.TaskDefinitionContainerDependencyArray{
+			ecs.TaskDefinitionContainerDependencyArgs{
+				ContainerName: pulumi.String("init-copy-agent-config"),
+				Condition:     pulumi.String("SUCCESS"),
+			},
+		},
 		Environment: append(append(ecs.TaskDefinitionKeyValuePairArray{
 			ecs.TaskDefinitionKeyValuePairArgs{
 				Name:  pulumi.StringPtr("DD_DOGSTATSD_SOCKET"),
@@ -102,12 +79,28 @@ func ECSFargateLinuxContainerDefinition(e config.Env, image string, apiKeySSMPar
 				ValueFrom: apiKeySSMParamName,
 			},
 		},
-		MountPoints: append(ecs.TaskDefinitionMountPointArray{
+		MountPoints: ecs.TaskDefinitionMountPointArray{
 			ecs.TaskDefinitionMountPointArgs{
 				ContainerPath: pulumi.StringPtr("/var/run/datadog"),
 				SourceVolume:  pulumi.StringPtr("dd-sockets"),
 			},
-		}, readonlyFSMountPoints...),
+			ecs.TaskDefinitionMountPointArgs{
+				ContainerPath: pulumi.StringPtr("/etc/datadog-agent"),
+				SourceVolume:  pulumi.StringPtr("agent-config"),
+			},
+			ecs.TaskDefinitionMountPointArgs{
+				ContainerPath: pulumi.StringPtr("/opt/datadog-agent/run"),
+				SourceVolume:  pulumi.StringPtr("agent-option"),
+			},
+			ecs.TaskDefinitionMountPointArgs{
+				ContainerPath: pulumi.StringPtr("/tmp"),
+				SourceVolume:  pulumi.StringPtr("agent-tmp"),
+			},
+			ecs.TaskDefinitionMountPointArgs{
+				ContainerPath: pulumi.StringPtr("/var/log/datadog"),
+				SourceVolume:  pulumi.StringPtr("agent-log"),
+			},
+		},
 		HealthCheck: &ecs.TaskDefinitionHealthCheckArgs{
 			Retries:     pulumi.IntPtr(2),
 			Command:     pulumi.ToStringArray([]string{"CMD-SHELL", "/probe.sh"}),

--- a/resources/aws/ecs/fargateService.go
+++ b/resources/aws/ecs/fargateService.go
@@ -84,21 +84,6 @@ func FargateTaskDefinitionWithAgent(
 	containers["init-copy-agent-config"] = *initContainer
 	containers["datadog-agent"] = *agentContainer
 
-	readonlyFSVolumes := classicECS.TaskDefinitionVolumeArray{
-		classicECS.TaskDefinitionVolumeArgs{
-			Name: pulumi.String("agent-config"),
-		},
-		classicECS.TaskDefinitionVolumeArgs{
-			Name: pulumi.String("agent-option"),
-		},
-		classicECS.TaskDefinitionVolumeArgs{
-			Name: pulumi.String("agent-tmp"),
-		},
-		classicECS.TaskDefinitionVolumeArgs{
-			Name: pulumi.String("agent-log"),
-		},
-	}
-
 	containers["log_router"] = *FargateFirelensContainerDefinition()
 
 	return ecs.NewFargateTaskDefinition(e.Ctx(), e.Namer.ResourceName(name), &ecs.FargateTaskDefinitionArgs{
@@ -113,11 +98,23 @@ func FargateTaskDefinitionWithAgent(
 		},
 		Family:  e.CommonNamer().DisplayName(255, family),
 		PidMode: pulumi.StringPtr("task"),
-		Volumes: append(classicECS.TaskDefinitionVolumeArray{
+		Volumes: classicECS.TaskDefinitionVolumeArray{
 			classicECS.TaskDefinitionVolumeArgs{
 				Name: pulumi.String("dd-sockets"),
 			},
-		}, readonlyFSVolumes...),
+			classicECS.TaskDefinitionVolumeArgs{
+				Name: pulumi.String("agent-config"),
+			},
+			classicECS.TaskDefinitionVolumeArgs{
+				Name: pulumi.String("agent-option"),
+			},
+			classicECS.TaskDefinitionVolumeArgs{
+				Name: pulumi.String("agent-tmp"),
+			},
+			classicECS.TaskDefinitionVolumeArgs{
+				Name: pulumi.String("agent-log"),
+			},
+		},
 	}, utils.MergeOptions(opts, e.WithProviders(config.ProviderAWS, config.ProviderAWSX))...)
 }
 


### PR DESCRIPTION
What does this PR do?
---------------------

Updates the AWS ECS Fargate tasks to run the Agent with `readOnlyRootFilesystem:true`

Which scenarios this will impact?
-------------------

AWS ECS (Fargate)

Motivation
----------

Increase coverage of the test environments of the Datadog Agent. ReadOnly is especially popular on ECS Fargate due to AWS security standards and thus many customers request guidance on how to configure this.

[CONTP-785]

Additional Notes
----------------

N/A

[CONTP-785]: https://datadoghq.atlassian.net/browse/CONTP-785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ