### PR TITLE
Target v2 testing keys directory when downloading artifacts from {apt,yum}testing.datad0g.com

### DIFF
--- a/components/datadog/agent/host_linuxos.go
+++ b/components/datadog/agent/host_linuxos.go
@@ -39,7 +39,7 @@ func (am *agentLinuxManager) getInstallCommand(version agentparams.PackageVersio
 		// TESTING_YUM_VERSION_PATH="testing/pipeline-xxxxx-a7/7"
 		testEnvVars = append(testEnvVars, fmt.Sprintf("TESTING_YUM_VERSION_PATH=testing/pipeline-%[1]v-a%[2]v/%[2]v", version.PipelineID, version.Major))
 		// target testing keys
-		testEnvVars = append(testEnvVars, fmt.Sprintf("TESTING_KEYS_URL=apttesting.datad0g.com/test-keys-vault"))
+		testEnvVars = append(testEnvVars, fmt.Sprintf("TESTING_KEYS_URL=apttesting.datad0g.com/test-keys"))
 	} else {
 		testEnvVars = append(testEnvVars, fmt.Sprintf("DD_AGENT_MAJOR_VERSION=%v", version.Major))
 


### PR DESCRIPTION
What does this PR do?
---------------------

Use the public keys in `apttesting.datad0g.com/test-keys` to verify signatures of test packages and repositories.
This place contains new testing keys that can be used by both the existing and new Gitlab runners in `datadog-agent`.

Which scenarios this will impact?
-------------------

Installs from the apttesting.datad0g.com / yumtestingdatad0g.com repositories.

Motivation
----------

Unblock Gitlab runner migration in `datadog-agent`.

Additional Notes
----------------

n/a