### PR TITLE
Deploy VPA CRD to prevent deploying unknown resource type on GCP

### DIFF
--- a/scenarios/gcp/gke/run.go
+++ b/scenarios/gcp/gke/run.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/components/datadog/apps/tracegen"
 	dogstatsdstandalone "github.com/DataDog/test-infra-definitions/components/datadog/dogstatsd-standalone"
 	"github.com/DataDog/test-infra-definitions/components/datadog/kubernetesagentparams"
+	"github.com/DataDog/test-infra-definitions/components/kubernetes/vpa"
 	"github.com/DataDog/test-infra-definitions/resources/gcp"
 	"github.com/DataDog/test-infra-definitions/scenarios/gcp/fakeintake"
 
@@ -37,6 +38,12 @@ func Run(ctx *pulumi.Context) error {
 	if err != nil {
 		return err
 	}
+
+	vpaCrd, err := vpa.DeployCRD(&env, cluster.KubeProvider)
+	if err != nil {
+		return err
+	}
+	dependsOnVPA := utils.PulumiDependsOn(vpaCrd)
 
 	var dependsOnDDAgent pulumi.ResourceOption
 
@@ -91,7 +98,7 @@ func Run(ctx *pulumi.Context) error {
 	// Deploy testing workload
 	if env.TestingWorkloadDeploy() {
 
-		if _, err := nginx.K8sAppDefinition(&env, cluster.KubeProvider, "workload-nginx", "", true, dependsOnDDAgent /* for DDM */); err != nil {
+		if _, err := nginx.K8sAppDefinition(&env, cluster.KubeProvider, "workload-nginx", "", true, dependsOnDDAgent /* for DDM */, dependsOnVPA); err != nil {
 			return err
 		}
 


### PR DESCRIPTION

What does this PR do?
---------------------

When deploying test env on GCP, we deploy an nginx with a VerticalPodAutoscaler.

To do so we must first deploy the CRD for the VerticalPodAutoscaler.

Add the missing call to deploy such CRD.


Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
