### PR TITLE
[CONTP-675] Enable autoscaling in cluster-agent for k8s test

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -386,6 +386,11 @@ func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentI
 					"value": pulumi.String("*"),
 				},
 			},
+			"autoscaling": pulumi.Map{
+				"workload": pulumi.Map{
+					"enabled": pulumi.Bool(true),
+				},
+			},
 		},
 		"agents": pulumi.Map{
 			"image": pulumi.Map{


### PR DESCRIPTION
What does this PR do?
---------------------
This PR enables autoscaling in k8s cluster for e2e test including local failover workload store.

Which scenarios this will impact?
-------------------
e2e test change : https://github.com/DataDog/datadog-agent/pull/40132

Motivation
----------

Additional Notes
----------------
