### PR TITLE
read command line input for agent image path name

### DIFF
--- a/scenarios/azure/aks/run.go
+++ b/scenarios/azure/aks/run.go
@@ -67,6 +67,14 @@ providers:
 			kubernetesagentparams.WithHelmValues(customValues),
 		)
 
+		if agentFullImagePath := env.AgentFullImagePath(); agentFullImagePath != "" {
+			k8sAgentOptions = append(k8sAgentOptions, kubernetesagentparams.WithAgentFullImagePath(agentFullImagePath))
+		}
+
+		if clusterAgentFullImagePath := env.ClusterAgentFullImagePath(); clusterAgentFullImagePath != "" {
+			k8sAgentOptions = append(k8sAgentOptions, kubernetesagentparams.WithClusterAgentFullImagePath(clusterAgentFullImagePath))
+		}
+
 		if env.AgentUseFakeintake() {
 			fakeIntakeOptions := []fakeintake.Option{}
 			if env.AgentUseDualShipping() {

--- a/scenarios/gcp/gke/cluster.go
+++ b/scenarios/gcp/gke/cluster.go
@@ -43,8 +43,8 @@ func NewGKECluster(env gcp.Environment, opts ...Option) (*kubeComp.Cluster, erro
 		return nil, err
 	}
 
-	return components.NewComponent(&env, env.Namer.ResourceName("gke"), func(comp *kubeComp.Cluster) error {
-		cluster, kubeConfig, err := gke.NewCluster(env, "gke", params.autopilot)
+	return components.NewComponent(&env, env.Namer.ResourceName(env.Ctx().Stack()), func(comp *kubeComp.Cluster) error {
+		cluster, kubeConfig, err := gke.NewCluster(env, env.Namer.ResourceName(env.Ctx().Stack()), params.autopilot)
 		if err != nil {
 			return err
 		}

--- a/scenarios/gcp/gke/run.go
+++ b/scenarios/gcp/gke/run.go
@@ -55,6 +55,14 @@ func Run(ctx *pulumi.Context) error {
 			kubernetesagentparams.WithNamespace("datadog"),
 		)
 
+		if agentFullImagePath := env.AgentFullImagePath(); agentFullImagePath != "" {
+			k8sAgentOptions = append(k8sAgentOptions, kubernetesagentparams.WithAgentFullImagePath(agentFullImagePath))
+		}
+
+		if clusterAgentFullImagePath := env.ClusterAgentFullImagePath(); clusterAgentFullImagePath != "" {
+			k8sAgentOptions = append(k8sAgentOptions, kubernetesagentparams.WithClusterAgentFullImagePath(clusterAgentFullImagePath))
+		}
+
 		if env.GKEAutopilot() {
 			k8sAgentOptions = append(
 				k8sAgentOptions,


### PR DESCRIPTION
What does this PR do?
---------------------

When the user provides an agent/clusterAgent image full path name use it in the GCP/GKE deployment.

Which scenarios this will impact?
-------------------

GCP + Azure

Motivation
----------

Allows someone to deploy a cluster with a custom image.

Additional Notes
----------------
