### PR TITLE
fix(FIPS): Prevent autoscaling in FIPS mode

### DIFF
--- a/components/datadog/agent/kubernetes_helm.go
+++ b/components/datadog/agent/kubernetes_helm.go
@@ -242,6 +242,10 @@ type HelmValues pulumi.Map
 
 func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentImagePath, clusterAgentImageTag string, clusterAgentToken pulumi.StringInput, logsContainerCollectAll bool, testingWorkloadsEnabled bool, isFIPS bool) HelmValues {
 	var containerRegistry, imageName string
+	isAutoscaling := true
+	if isFIPS {
+		isAutoscaling = false
+	}
 	if strings.Contains(agentImagePath, "/") {
 		agentImageElem := strings.Split(agentImagePath, "/")
 		containerRegistry = strings.Join(agentImageElem[:len(agentImageElem)-1], "/")
@@ -389,7 +393,7 @@ func buildLinuxHelmValues(baseName, agentImagePath, agentImageTag, clusterAgentI
 			"autoscaling": pulumi.Map{
 				"workload": pulumi.Map{
 					// Autoscaling is not possible for FIPS as it requires remote-config and this is not available in FIPS agent.
-					"enabled": pulumi.Bool(!isFIPS),
+					"enabled": pulumi.Bool(isAutoscaling),
 				},
 			},
 		},


### PR DESCRIPTION
What does this PR do?
---------------------
Prevent the activation of autoscaling in FIPS mode

Which scenarios this will impact?
-------------------
Kubernetes

Motivation
----------
Autoscaling requires remote-config. 
```
Error: Remote config is disabled or failed to initialize, remote config is a required dependency for autoscaling
```
This error is [raised](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1106410256) on the FIPS downstream pipeline, and remote-config [is not available on FIPS agent](https://github.com/DataDog/datadog-agent/blob/main/.gitlab/e2e/e2e.yml#L579-L580). As consequence since we integrated [this update](https://github.com/DataDog/test-infra-definitions/commit/afa021e5ea491da8b5970cb739ed819f47d0a394) in the `datadog-agent` repository [all the FIPS pipelines are failing](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Astage%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent%20%40git.branch%3Amain%20%40ci.stage.name%3Anew-e2e-fips&agg_m=count&agg_m_source=base&agg_t=count&cipipeline_explorer_sort=time%2Cdesc&fromUser=false&index=cipipeline&mode=sliding&saved-view-id=2643993&tab=overview&start=1756112447052&end=1756717247052&paused=false).


Additional Notes
----------------
