### PR TITLE
[ACIX-1005] Add a VM option to pass Pulumi resource options

### DIFF
--- a/scenarios/aws/ec2/vmargs.go
+++ b/scenarios/aws/ec2/vmargs.go
@@ -4,6 +4,7 @@ import (
 	"github.com/DataDog/test-infra-definitions/common"
 	"github.com/DataDog/test-infra-definitions/common/utils"
 	"github.com/DataDog/test-infra-definitions/components/os"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
 // Params defines the parameters for a virtual machine.
@@ -18,6 +19,7 @@ import (
 //   - [WithName]
 //   - [WithHostID]
 //   - [WithTenancy]
+//   - [WithPulumiResourceOptions]
 //
 // [Functional options pattern]: https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
 
@@ -30,13 +32,15 @@ type vmArgs struct {
 	tenancy         string
 	hostID          string
 
-	httpTokensRequired bool
+	httpTokensRequired    bool
+	pulumiResourceOptions []pulumi.ResourceOption
 }
 
 type VMOption = func(*vmArgs) error
 
 func buildArgs(options ...VMOption) (*vmArgs, error) {
 	vmArgs := &vmArgs{}
+	vmArgs.pulumiResourceOptions = []pulumi.ResourceOption{}
 	return common.ApplyOption(vmArgs, options)
 }
 
@@ -106,6 +110,13 @@ func WithHostID(hostID string) VMOption {
 func WithTenancy(tenancy string) VMOption {
 	return func(p *vmArgs) error {
 		p.tenancy = tenancy
+		return nil
+	}
+}
+
+func WithPulumiResourceOptions(options ...pulumi.ResourceOption) VMOption {
+	return func(p *vmArgs) error {
+		p.pulumiResourceOptions = options
 		return nil
 	}
 }


### PR DESCRIPTION
What does this PR do?
---------------------

Add an option to pass pulumi option to the VM component

Goal is to be able to add an extra dependency between fakeintake and VM to protect us from an issue where the fakeintake is released while the agent is still running on the host. It leads to a situation where the fakintake IP can be reused in a later test and the old agent sends data to a fakeintake that is used in a new tests, which lead to weird falkiness
https://datadoghq.atlassian.net/jira/software/c/projects/ACIX/boards/6169/backlog?selectedIssue=ACIX-1005


Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
