### PR TITLE
remove redundant DD_ECS_TASK_COLLECTION_ENABLED config

### DIFF
--- a/components/datadog/agent/ecs.go
+++ b/components/datadog/agent/ecs.go
@@ -144,10 +144,6 @@ func ecsLinuxAgentSingleContainerDefinition(e config.Env, apiKeySSMParamName pul
 				Name:  pulumi.StringPtr("DD_TELEMETRY_CHECKS"),
 				Value: pulumi.StringPtr("*"),
 			},
-			ecs.TaskDefinitionKeyValuePairArgs{
-				Name:  pulumi.StringPtr("DD_ECS_TASK_COLLECTION_ENABLED"),
-				Value: pulumi.StringPtr("true"),
-			},
 		}, ecsAgentAdditionalEndpointsEnv(params)...), ecsFakeintakeAdditionalEndpointsEnv(fakeintake)...), ecsAgentAdditionalEnvFromConfig(e)...),
 		Secrets: ecs.TaskDefinitionSecretArray{
 			ecs.TaskDefinitionSecretArgs{


### PR DESCRIPTION
What does this PR do?
---------------------

Remove redundant configuration using `DD_ECS_TASK_COLLECTION_ENABLED` since the config is already set to *true* by default.

Motivation
----------

Some config default settings have changed in recent Agent versions, making some flags redundant. Removing these flags improves clarity and maintainability regarding what configs are required and what aren't.

Additional Notes
----------------
