### PR TITLE
[APM] Add configurble wait time on tracegen app

### DIFF
--- a/components/datadog/apps/version.go
+++ b/components/datadog/apps/version.go
@@ -1,3 +1,3 @@
 package apps
 
-const Version = "v0.0.3"
+const Version = "v0.0.4"


### PR DESCRIPTION
What does this PR do?
---------------------

This wait time is meant to optionally wait before the trace generation loop starts. This will allow external agents to detect the new process and resolve the appropriate metadata (eg container tags), in order to have more consistent testing environments.

Which scenarios this will impact?
-------------------

Motivation
----------
This PR is a fix for a few flaky tests that depend on container tag resolution.

Additional Notes
----------------
