### PR TITLE
CONTINT-4687 - add fakeintake options

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -57,6 +57,8 @@ const (
 	DDAgentAPPKeyParamName               = "appKey"
 	DDAgentFakeintake                    = "fakeintake"
 	DDAgentDualShipping                  = "dualshipping"
+	DDAgentFakeintakeStoreType           = "fakeintakeStoreType"
+	DDAGentFakeintakeRetentionPeriod     = "fakeintakeRetentionPeriod"
 	DDAgentSite                          = "site"
 	DDAgentMajorVersion                  = "majorVersion"
 	DDAgentExtraEnvVars                  = "extraEnvVars" // extraEnvVars is expected in the format: <key1>=<value1>,<key2>=<value2>,...
@@ -344,6 +346,14 @@ func (e *CommonEnvironment) AgentUseFakeintake() bool {
 
 func (e *CommonEnvironment) AgentUseDualShipping() bool {
 	return e.GetBoolWithDefault(e.AgentConfig, DDAgentDualShipping, false)
+}
+
+func (e *CommonEnvironment) AgentFakeintakeStoreType() string {
+	return e.GetStringWithDefault(e.AgentConfig, DDAgentFakeintakeStoreType, "memory")
+}
+
+func (e *CommonEnvironment) AgentFakeintakeRetentionPeriod() string {
+	return e.AgentConfig.Get(DDAGentFakeintakeRetentionPeriod)
 }
 
 func (e *CommonEnvironment) Site() string {

--- a/scenarios/aws/ec2/vm_run.go
+++ b/scenarios/aws/ec2/vm_run.go
@@ -45,6 +45,14 @@ func VMRun(ctx *pulumi.Context) error {
 				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithLoadBalancer())
 			}
 
+			if storeType := env.AgentFakeintakeStoreType(); storeType != "" {
+				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithStoreType(storeType))
+			}
+
+			if retentionPeriod := env.AgentFakeintakeRetentionPeriod(); retentionPeriod != "" {
+				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithRetentionPeriod(retentionPeriod))
+			}
+
 			fakeintake, err := fakeintake.NewECSFargateInstance(env, vm.Name(), fakeIntakeOptions...)
 			if err != nil {
 				return err
@@ -134,6 +142,14 @@ func VMRunWithDocker(ctx *pulumi.Context) error {
 
 			if env.InfraShouldDeployFakeintakeWithLB() {
 				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithLoadBalancer())
+			}
+
+			if storeType := env.AgentFakeintakeStoreType(); storeType != "" {
+				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithStoreType(storeType))
+			}
+
+			if retentionPeriod := env.AgentFakeintakeRetentionPeriod(); retentionPeriod != "" {
+				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithRetentionPeriod(retentionPeriod))
 			}
 
 			fakeintake, err := fakeintake.NewECSFargateInstance(env, vm.Name(), fakeIntakeOptions...)

--- a/scenarios/aws/ecs/run.go
+++ b/scenarios/aws/ecs/run.go
@@ -46,6 +46,14 @@ func Run(ctx *pulumi.Context) error {
 				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithLoadBalancer())
 			}
 
+			if storeType := awsEnv.AgentFakeintakeStoreType(); storeType != "" {
+				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithStoreType(storeType))
+			}
+
+			if retentionPeriod := awsEnv.AgentFakeintakeRetentionPeriod(); retentionPeriod != "" {
+				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithRetentionPeriod(retentionPeriod))
+			}
+
 			if fakeIntake, err = fakeintake.NewECSFargateInstance(awsEnv, "ecs", fakeIntakeOptions...); err != nil {
 				return err
 			}

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -69,6 +69,14 @@ func Run(ctx *pulumi.Context) error {
 				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithoutDDDevForwarding())
 			}
 
+			if storeType := awsEnv.AgentFakeintakeStoreType(); storeType != "" {
+				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithStoreType(storeType))
+			}
+
+			if retentionPeriod := awsEnv.AgentFakeintakeRetentionPeriod(); retentionPeriod != "" {
+				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithRetentionPeriod(retentionPeriod))
+			}
+
 			if fakeIntake, err = fakeintake.NewECSFargateInstance(awsEnv, "ecs", fakeIntakeOptions...); err != nil {
 				return err
 			}

--- a/scenarios/aws/fakeintake/params.go
+++ b/scenarios/aws/fakeintake/params.go
@@ -8,6 +8,8 @@ type Params struct {
 	CPU                 int
 	Memory              int
 	DDDevForwarding     bool
+	StoreStype          string
+	RetentionPeriod     string
 }
 
 type Option = func(*Params) error
@@ -59,6 +61,22 @@ func WithMemory(memory int) Option {
 func WithoutDDDevForwarding() Option {
 	return func(p *Params) error {
 		p.DDDevForwarding = false
+		return nil
+	}
+}
+
+// WithRetentionPeriod set the retention period for the fakeintake
+func WithRetentionPeriod(retentionPeriod string) Option {
+	return func(p *Params) error {
+		p.RetentionPeriod = retentionPeriod
+		return nil
+	}
+}
+
+// WithStoreType set the store type for the fakeintake
+func WithStoreType(storeType string) Option {
+	return func(p *Params) error {
+		p.StoreStype = storeType
 		return nil
 	}
 }

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -89,6 +89,14 @@ func Run(ctx *pulumi.Context) error {
 			fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithoutDDDevForwarding())
 		}
 
+		if storeType := awsEnv.AgentFakeintakeStoreType(); storeType != "" {
+			fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithStoreType(storeType))
+		}
+
+		if retentionPeriod := awsEnv.AgentFakeintakeRetentionPeriod(); retentionPeriod != "" {
+			fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithRetentionPeriod(retentionPeriod))
+		}
+
 		if fakeIntake, err = fakeintake.NewECSFargateInstance(awsEnv, kindCluster.Name(), fakeIntakeOptions...); err != nil {
 			return err
 		}

--- a/scenarios/azure/aks/run.go
+++ b/scenarios/azure/aks/run.go
@@ -73,6 +73,14 @@ providers:
 				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithoutDDDevForwarding())
 			}
 
+			if storeType := env.AgentFakeintakeStoreType(); storeType != "" {
+				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithStoreType(storeType))
+			}
+
+			if retentionPeriod := env.AgentFakeintakeRetentionPeriod(); retentionPeriod != "" {
+				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithRetentionPeriod(retentionPeriod))
+			}
+
 			fakeintake, err := fakeintake.NewVMInstance(env, fakeIntakeOptions...)
 			if err != nil {
 				return err

--- a/scenarios/azure/fakeintake/fakeintake.go
+++ b/scenarios/azure/fakeintake/fakeintake.go
@@ -34,6 +34,14 @@ func NewVMInstance(e azure.Environment, option ...Option) (*fakeintake.Fakeintak
 			cmdArgs = append(cmdArgs, "--dddev-forward")
 		}
 
+		if params.RetentionPeriod != "" {
+			cmdArgs = append(cmdArgs, "-retention-period="+params.RetentionPeriod)
+		}
+
+		if params.StoreStype != "" {
+			cmdArgs = append(cmdArgs, "-store="+params.StoreStype)
+		}
+
 		_, err = vm.OS.Runner().Command("docker_run_fakeintake", &command.Args{
 			Create: pulumi.Sprintf("docker run --restart unless-stopped --name fakeintake -d -p 80:80 -e DD_API_KEY=%s %s %s", e.AgentAPIKey(), params.ImageURL, cmdArgs),
 			Delete: pulumi.String("docker stop fakeintake"),

--- a/scenarios/azure/fakeintake/params.go
+++ b/scenarios/azure/fakeintake/params.go
@@ -5,6 +5,8 @@ import "github.com/DataDog/test-infra-definitions/common"
 type Params struct {
 	DDDevForwarding bool
 	ImageURL        string
+	StoreStype      string
+	RetentionPeriod string
 }
 
 type Option = func(*Params) error
@@ -30,6 +32,22 @@ func WithImageURL(imageURL string) Option {
 func WithoutDDDevForwarding() Option {
 	return func(p *Params) error {
 		p.DDDevForwarding = false
+		return nil
+	}
+}
+
+// WithRetentionPeriod set the retention period for the fakeintake
+func WithRetentionPeriod(retentionPeriod string) Option {
+	return func(p *Params) error {
+		p.RetentionPeriod = retentionPeriod
+		return nil
+	}
+}
+
+// WithStoreType set the store type for the fakeintake
+func WithStoreType(storeType string) Option {
+	return func(p *Params) error {
+		p.StoreStype = storeType
 		return nil
 	}
 }

--- a/scenarios/gcp/fakeintake/params.go
+++ b/scenarios/gcp/fakeintake/params.go
@@ -7,6 +7,8 @@ type Params struct {
 	ImageURL        string
 	Memory          int
 	LoadBalancer    bool
+	StoreStype      string
+	RetentionPeriod string
 }
 
 type Option = func(*Params) error
@@ -50,6 +52,22 @@ func WithMemory(memory int) Option {
 func WithLoadBalancer() Option {
 	return func(p *Params) error {
 		p.LoadBalancer = true
+		return nil
+	}
+}
+
+// WithRetentionPeriod set the retention period for the fakeintake
+func WithRetentionPeriod(retentionPeriod string) Option {
+	return func(p *Params) error {
+		p.RetentionPeriod = retentionPeriod
+		return nil
+	}
+}
+
+// WithStoreType set the store type for the fakeintake
+func WithStoreType(storeType string) Option {
+	return func(p *Params) error {
+		p.StoreStype = storeType
 		return nil
 	}
 }

--- a/scenarios/gcp/gke/run.go
+++ b/scenarios/gcp/gke/run.go
@@ -76,6 +76,14 @@ func Run(ctx *pulumi.Context) error {
 				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithoutDDDevForwarding())
 			}
 
+			if storeType := env.AgentFakeintakeStoreType(); storeType != "" {
+				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithStoreType(storeType))
+			}
+
+			if retentionPeriod := env.AgentFakeintakeRetentionPeriod(); retentionPeriod != "" {
+				fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithRetentionPeriod(retentionPeriod))
+			}
+
 			fakeintake, err := fakeintake.NewVMInstance(env, fakeIntakeOptions...)
 			if err != nil {
 				return err

--- a/scenarios/gcp/openshiftvm/run.go
+++ b/scenarios/gcp/openshiftvm/run.go
@@ -72,6 +72,14 @@ func Run(ctx *pulumi.Context) error {
 			fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithoutDDDevForwarding())
 		}
 
+		if storeType := gcpEnv.AgentFakeintakeStoreType(); storeType != "" {
+			fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithStoreType(storeType))
+		}
+
+		if retentionPeriod := gcpEnv.AgentFakeintakeRetentionPeriod(); retentionPeriod != "" {
+			fakeIntakeOptions = append(fakeIntakeOptions, fakeintake.WithRetentionPeriod(retentionPeriod))
+		}
+
 		if fakeIntake, err = fakeintake.NewVMInstance(gcpEnv, fakeIntakeOptions...); err != nil {
 			return err
 		}


### PR DESCRIPTION
What does this PR do?
---------------------

Add necessary code to pass option to start fakeintake server:

- `ddagent:fakeintakeStoreType` to select the store tyep (sql or memory)
- `ddagent:fakeintakeRetentionPeriod` to select the data retention period

The `fakeintakeRetentionPeriod` is useful for the coming end2end tests to ensure we store the data we want to test long enough for the test to run and prevent having the scenario where the test runs and the data we request has been cleaned-up.

Added the argument parsing for all scenarios that use the fakeintake and allows it to be configured.


Which scenarios this will impact?
-------------------

- aws
- azure
- gcp

Motivation
----------

- For end2end tests on the agent we have a check that runs every 30 minutes.
- the fakeintake has a defautl 15 minute retention.
- if the test runs after the 15 minutes retention the data are missing
- we need to be able to increase that retention period for some tests to ensure data presence
- As we will increase retention time, add a choice of store type to make sure we don't go OOM

Additional Notes
----------------
