### PR TITLE
Delete the CSI driver with the Kubernetes cluster

### DIFF
--- a/components/datadog/csi-driver/driver.go
+++ b/components/datadog/csi-driver/driver.go
@@ -18,7 +18,7 @@ const (
 )
 
 func NewDatadogCSIDriver(e config.Env, kubeProvider *kubernetes.Provider, csiDriverTag string) error {
-	opts := []pulumi.ResourceOption{pulumi.Providers(kubeProvider)}
+	opts := []pulumi.ResourceOption{pulumi.Providers(kubeProvider), pulumi.DeletedWith(kubeProvider)}
 
 	// Create namespace if necessary
 	ns, err := corev1.NewNamespace(e.Ctx(), CSINamespace, &corev1.NamespaceArgs{


### PR DESCRIPTION
What does this PR do?
---------------------

Indicate that the CSI driver is deleted with the cluster. It helps destroying stack by not trying to delete the CSI driver before deleting the whole cluster

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
