### PR TITLE
Bump apps version to v0.0.4

### DIFF
--- a/components/datadog/apps/version.go
+++ b/components/datadog/apps/version.go
@@ -1,3 +1,3 @@
 package apps
 
-const Version = "v0.0.3"
+const Version = "v0.0.4"


### PR DESCRIPTION
What does this PR do?
---------------------
Bump version after image rebuilt. Needed to have [this](https://github.com/DataDog/test-infra-definitions/pull/1687) change applied

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
