### PR TITLE
Do not deploy VPA CRD on GKE with autopilot enabled

### DIFF
--- a/scenarios/gcp/gke/run.go
+++ b/scenarios/gcp/gke/run.go
@@ -39,11 +39,15 @@ func Run(ctx *pulumi.Context) error {
 		return err
 	}
 
-	vpaCrd, err := vpa.DeployCRD(&env, cluster.KubeProvider)
-	if err != nil {
-		return err
+	var dependsOnVPA pulumi.ResourceOption
+	if !env.GKEAutopilot() {
+		vpaCrd, err := vpa.DeployCRD(&env, cluster.KubeProvider)
+		if err != nil {
+			return err
+		}
+
+		dependsOnVPA = utils.PulumiDependsOn(vpaCrd)
 	}
-	dependsOnVPA := utils.PulumiDependsOn(vpaCrd)
 
 	var dependsOnDDAgent pulumi.ResourceOption
 


### PR DESCRIPTION
What does this PR do?
---------------------

When depoloying a cluster on GKE with autopilot, GKE will deploy a vertical pod autoscaler, wo when trying to deploy the same CRD it will fail.

Which scenarios this will impact?
-------------------

GKE + autopilot

Motivation
----------

make this scenario work

Additional Notes
----------------
