### PR TITLE
[AGENTRUN-715] Add TLS 1.3 FIPS validated ciphers to fips-server

### DIFF
--- a/components/datadog/apps/fips/images/fips-server/src/tls.go
+++ b/components/datadog/apps/fips/images/fips-server/src/tls.go
@@ -46,15 +46,18 @@ var (
 	}
 
 	FipsCiphers = map[string]uint16{
-		// This list has been compiled based off the boring crypto supported
-		// ciphers listed here:
-		//    https://github.com/golang/go/blob/dev.boringcrypto.go1.18/src/crypto/tls/boring.go#L53-L61
+		// see: https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/2285633911/Cryptographic+security+recommendations#Transport-Layer-Security-Protocol
+		// TLS 1.2 supported
 		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 		"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 		"TLS_RSA_WITH_AES_128_GCM_SHA256":         tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
 		"TLS_RSA_WITH_AES_256_GCM_SHA384":         tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+
+		// TLS 1.3 supported
+		"TLS_AES_128_GCM_SHA256": tls.TLS_AES_128_GCM_SHA256,
+		"TLS_AES_256_GCM_SHA384": tls.TLS_AES_256_GCM_SHA384,
 	}
 )
 


### PR DESCRIPTION
What does this PR do?
---------------------

The fips-server here is not FIPS compliant, it is a server that accepts HTTPS connections and compares the request TLS negotiated configuration and logs it for the datadog-agent FIPS compliance suite to confirm expected behavior against.

We support TLS 1.3 ciphers with the datadog-fips-agent via OpenSSL bindings provided by [msft/go](https://github.com/microsoft/go/blob/microsoft/main/eng/doc/fips/UserGuide.md#cryptotls) and so should support them in this test to confirm the agent behaves as expected

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
