### PR TITLE
Frank.spano/contint 4708

### DIFF
--- a/components/kubernetes/kind.go
+++ b/components/kubernetes/kind.go
@@ -70,11 +70,9 @@ func NewKindClusterWithConfig(env config.Env, vm *remote.Host, name string, kube
 		if kindVersionConfig.UsePublicRegistry {
 			// Use public Docker Hub for latest/dynamic versions not available in internal mirror
 			nodeImage = fmt.Sprintf("docker.io/%s:%s", kindNodeImageName, kindVersionConfig.NodeImageVersion)
-			env.Ctx().Log.Info(fmt.Sprintf("CONTINT-4708: Using PUBLIC registry for Kind node image: %s (KindVersion: %s, KubeVersion: %s)", nodeImage, kindVersionConfig.KindVersion, kindVersionConfig.KubeVersion), nil)
 		} else {
 			// Use internal mirror for cached/static versions
 			nodeImage = fmt.Sprintf("%s/%s:%s", env.InternalDockerhubMirror(), kindNodeImageName, kindVersionConfig.NodeImageVersion)
-			env.Ctx().Log.Info(fmt.Sprintf("CONTINT-4708: Using INTERNAL mirror for Kind node image: %s (KindVersion: %s, KubeVersion: %s)", nodeImage, kindVersionConfig.KindVersion, kindVersionConfig.KubeVersion), nil)
 		}
 		createCluster, err := runner.Command(
 			commonEnvironment.CommonNamer().ResourceName("kind-create-cluster"),
@@ -142,11 +140,9 @@ func NewLocalKindCluster(env config.Env, name string, kubeVersion string, opts .
 		if kindVersionConfig.UsePublicRegistry {
 			// Use public Docker Hub for latest/dynamic versions not available in internal mirror
 			nodeImage = fmt.Sprintf("docker.io/%s:%s", kindNodeImageName, kindVersionConfig.NodeImageVersion)
-			env.Ctx().Log.Info(fmt.Sprintf("CONTINT-4708: Using PUBLIC registry for Kind node image: %s (KindVersion: %s, KubeVersion: %s)", nodeImage, kindVersionConfig.KindVersion, kindVersionConfig.KubeVersion), nil)
 		} else {
 			// Use internal mirror for cached/static versions
 			nodeImage = fmt.Sprintf("%s/%s:%s", env.InternalDockerhubMirror(), kindNodeImageName, kindVersionConfig.NodeImageVersion)
-			env.Ctx().Log.Info(fmt.Sprintf("CONTINT-4708: Using INTERNAL mirror for Kind node image: %s (KindVersion: %s, KubeVersion: %s)", nodeImage, kindVersionConfig.KindVersion, kindVersionConfig.KubeVersion), nil)
 		}
 		createCluster, err := runner.Command(
 			commonEnvironment.CommonNamer().ResourceName("kind-create-cluster"),
@@ -185,7 +181,6 @@ func InstallKindBinary(env config.Env, vm *remote.Host, kindVersion string, opts
 		kindArch = "amd64"
 	}
 	kindBinaryURL := fmt.Sprintf("https://kind.sigs.k8s.io/dl/%s/kind-linux-%s", kindVersion, kindArch)
-	env.Ctx().Log.Info(fmt.Sprintf("CONTINT-4708: Installing Kind binary version %s for architecture %s from: %s", kindVersion, kindArch, kindBinaryURL), nil)
 	return vm.OS.Runner().Command(
 		env.CommonNamer().ResourceName("kind-install"),
 		&command.Args{

--- a/components/kubernetes/kind.go
+++ b/components/kubernetes/kind.go
@@ -66,7 +66,16 @@ func NewKindClusterWithConfig(env config.Env, vm *remote.Host, name string, kube
 			return err
 		}
 
-		nodeImage := fmt.Sprintf("%s/%s:%s", env.InternalDockerhubMirror(), kindNodeImageName, kindVersionConfig.NodeImageVersion)
+		var nodeImage string
+		if kindVersionConfig.UsePublicRegistry {
+			// Use public Docker Hub for latest/dynamic versions not available in internal mirror
+			nodeImage = fmt.Sprintf("docker.io/%s:%s", kindNodeImageName, kindVersionConfig.NodeImageVersion)
+			env.Ctx().Log.Info(fmt.Sprintf("CONTINT-4708: Using PUBLIC registry for Kind node image: %s (KindVersion: %s, KubeVersion: %s)", nodeImage, kindVersionConfig.KindVersion, kindVersionConfig.KubeVersion), nil)
+		} else {
+			// Use internal mirror for cached/static versions
+			nodeImage = fmt.Sprintf("%s/%s:%s", env.InternalDockerhubMirror(), kindNodeImageName, kindVersionConfig.NodeImageVersion)
+			env.Ctx().Log.Info(fmt.Sprintf("CONTINT-4708: Using INTERNAL mirror for Kind node image: %s (KindVersion: %s, KubeVersion: %s)", nodeImage, kindVersionConfig.KindVersion, kindVersionConfig.KubeVersion), nil)
+		}
 		createCluster, err := runner.Command(
 			commonEnvironment.CommonNamer().ResourceName("kind-create-cluster"),
 			&command.Args{
@@ -129,7 +138,16 @@ func NewLocalKindCluster(env config.Env, name string, kubeVersion string, opts .
 			return err
 		}
 
-		nodeImage := fmt.Sprintf("%s/%s:%s", env.InternalDockerhubMirror(), kindNodeImageName, kindVersionConfig.NodeImageVersion)
+		var nodeImage string
+		if kindVersionConfig.UsePublicRegistry {
+			// Use public Docker Hub for latest/dynamic versions not available in internal mirror
+			nodeImage = fmt.Sprintf("docker.io/%s:%s", kindNodeImageName, kindVersionConfig.NodeImageVersion)
+			env.Ctx().Log.Info(fmt.Sprintf("CONTINT-4708: Using PUBLIC registry for Kind node image: %s (KindVersion: %s, KubeVersion: %s)", nodeImage, kindVersionConfig.KindVersion, kindVersionConfig.KubeVersion), nil)
+		} else {
+			// Use internal mirror for cached/static versions
+			nodeImage = fmt.Sprintf("%s/%s:%s", env.InternalDockerhubMirror(), kindNodeImageName, kindVersionConfig.NodeImageVersion)
+			env.Ctx().Log.Info(fmt.Sprintf("CONTINT-4708: Using INTERNAL mirror for Kind node image: %s (KindVersion: %s, KubeVersion: %s)", nodeImage, kindVersionConfig.KindVersion, kindVersionConfig.KubeVersion), nil)
+		}
 		createCluster, err := runner.Command(
 			commonEnvironment.CommonNamer().ResourceName("kind-create-cluster"),
 			&command.Args{
@@ -166,10 +184,12 @@ func InstallKindBinary(env config.Env, vm *remote.Host, kindVersion string, opts
 	if kindArch == os.AMD64Arch {
 		kindArch = "amd64"
 	}
+	kindBinaryURL := fmt.Sprintf("https://kind.sigs.k8s.io/dl/%s/kind-linux-%s", kindVersion, kindArch)
+	env.Ctx().Log.Info(fmt.Sprintf("CONTINT-4708: Installing Kind binary version %s for architecture %s from: %s", kindVersion, kindArch, kindBinaryURL), nil)
 	return vm.OS.Runner().Command(
 		env.CommonNamer().ResourceName("kind-install"),
 		&command.Args{
-			Create: pulumi.Sprintf(`curl --retry 10 -fsSLo ./kind "https://kind.sigs.k8s.io/dl/%s/kind-linux-%s" && sudo install kind /usr/local/bin/kind`, kindVersion, kindArch),
+			Create: pulumi.Sprintf(`curl --retry 10 -fsSLo ./kind "%s" && sudo install kind /usr/local/bin/kind`, kindBinaryURL),
 		},
 		opts...,
 	)

--- a/components/kubernetes/kind_versions.go
+++ b/components/kubernetes/kind_versions.go
@@ -16,6 +16,7 @@ import (
 type KindConfig struct {
 	KindVersion      string
 	NodeImageVersion string
+	KubeVersion      string // Clean Kubernetes version for semantic parsing
 }
 
 // DockerHubTag represents a tag from Docker Hub API
@@ -162,6 +163,7 @@ func getLatestKindVersion() (*KindConfig, error) {
 	return &KindConfig{
 		KindVersion:      latestKindVersion,
 		NodeImageVersion: fullTag,
+		KubeVersion:      latestVersion.String(), // Clean version for semantic parsing
 	}, nil
 }
 
@@ -182,6 +184,8 @@ func GetKindVersionConfig(kubeVersion string) (*KindConfig, error) {
 		return nil, fmt.Errorf("unsupported kubernetes version. Supported versions are %s", strings.Join(kubeSupportedVersions(), ", "))
 	}
 
+	// Ensure KubeVersion is populated for static configs too
+	kindVersionConfig.KubeVersion = kubeVersion
 	return &kindVersionConfig, nil
 }
 

--- a/components/kubernetes/kind_versions_test.go
+++ b/components/kubernetes/kind_versions_test.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/Masterminds/semver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -46,12 +47,38 @@ func TestGetKindVersionConfig(t *testing.T) {
 func TestGetLatestKindVersion(t *testing.T) {
 	config, err := getLatestKindVersion()
 	require.NoError(t, err)
-	
+
 	// Should return a valid Kind version
 	assert.Regexp(t, regexp.MustCompile(`^v\d+\.\d+\.\d+$`), config.KindVersion)
-	
+
 	// Should return a Kubernetes version with SHA digest
 	assert.Regexp(t, regexp.MustCompile(`^v\d+\.\d+\.\d+@sha256:[a-f0-9]{64}$`), config.NodeImageVersion)
-	
+
 	t.Logf("Fetched latest: %s with Kind version: %s", config.NodeImageVersion, config.KindVersion)
+}
+
+func TestGetLatestKindVersionDynamic(t *testing.T) {
+	t.Skip("Skipping test that requires network access")
+
+	version, err := getLatestKindVersionDynamic()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, version)
+	assert.Regexp(t, `^v\d+\.\d+\.\d+$`, version, "Version should match semver format with 'v' prefix")
+
+	t.Logf("Dynamic Kind version: %s", version)
+}
+
+func TestGetKindVersionForKubernetesDynamic(t *testing.T) {
+	t.Skip("Skipping test that requires network access")
+
+	// Create a test Kubernetes version
+	kubeVersion, err := semver.NewVersion("1.30.0")
+	require.NoError(t, err)
+
+	kindVersion, err := getKindVersionForKubernetesDynamic(kubeVersion)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, kindVersion)
+	assert.Regexp(t, `^v\d+\.\d+\.\d+$`, kindVersion, "Kind version should match semver format with 'v' prefix")
+
+	t.Logf("Dynamic Kind version for k8s %s: %s", kubeVersion.String(), kindVersion)
 }

--- a/components/kubernetes/kind_versions_test.go
+++ b/components/kubernetes/kind_versions_test.go
@@ -1,0 +1,57 @@
+package kubernetes
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetKindVersionConfig(t *testing.T) {
+	t.Run("existing version", func(t *testing.T) {
+		config, err := GetKindVersionConfig("1.32.0")
+		require.NoError(t, err)
+		assert.Equal(t, "v0.26.0", config.KindVersion)
+		assert.Contains(t, config.NodeImageVersion, "v1.32.0@sha256:")
+	})
+
+	t.Run("latest version", func(t *testing.T) {
+		config, err := GetKindVersionConfig("latest")
+		require.NoError(t, err)
+		
+		// Should return a valid Kind version
+		assert.Regexp(t, regexp.MustCompile(`^v\d+\.\d+\.\d+$`), config.KindVersion)
+		
+		// Should return a version with SHA digest
+		assert.Regexp(t, regexp.MustCompile(`^v\d+\.\d+\.\d+@sha256:[a-f0-9]{64}$`), config.NodeImageVersion)
+		
+		// Latest should be higher than any hardcoded version
+		assert.True(t, config.NodeImageVersion >= "v1.32.0", "Latest version should be >= v1.32.0")
+		
+		t.Logf("Latest Kubernetes version: %s", config.NodeImageVersion)
+	})
+
+	t.Run("invalid version", func(t *testing.T) {
+		_, err := GetKindVersionConfig("invalid")
+		assert.Error(t, err)
+	})
+
+	t.Run("unsupported version", func(t *testing.T) {
+		_, err := GetKindVersionConfig("999.999.999")
+		assert.Error(t, err)
+	})
+}
+
+func TestGetLatestKindVersion(t *testing.T) {
+	config, err := getLatestKindVersion()
+	require.NoError(t, err)
+	
+	// Should return a valid Kind version
+	assert.Regexp(t, regexp.MustCompile(`^v\d+\.\d+\.\d+$`), config.KindVersion)
+	
+	// Should return a Kubernetes version with SHA digest
+	assert.Regexp(t, regexp.MustCompile(`^v\d+\.\d+\.\d+@sha256:[a-f0-9]{64}$`), config.NodeImageVersion)
+	
+	t.Logf("Fetched latest: %s with Kind version: %s", config.NodeImageVersion, config.KindVersion)
+}

--- a/components/kubernetes/kind_versions_test.go
+++ b/components/kubernetes/kind_versions_test.go
@@ -20,16 +20,16 @@ func TestGetKindVersionConfig(t *testing.T) {
 	t.Run("latest version", func(t *testing.T) {
 		config, err := GetKindVersionConfig("latest")
 		require.NoError(t, err)
-		
+
 		// Should return a valid Kind version
 		assert.Regexp(t, regexp.MustCompile(`^v\d+\.\d+\.\d+$`), config.KindVersion)
-		
+
 		// Should return a version with SHA digest
 		assert.Regexp(t, regexp.MustCompile(`^v\d+\.\d+\.\d+@sha256:[a-f0-9]{64}$`), config.NodeImageVersion)
-		
+
 		// Latest should be higher than any hardcoded version
 		assert.True(t, config.NodeImageVersion >= "v1.32.0", "Latest version should be >= v1.32.0")
-		
+
 		t.Logf("Latest Kubernetes version: %s", config.NodeImageVersion)
 	})
 
@@ -44,8 +44,8 @@ func TestGetKindVersionConfig(t *testing.T) {
 	})
 }
 
-func TestGetLatestKindVersion(t *testing.T) {
-	config, err := getLatestKindVersion()
+func TestGetLatestKindVersionConfig(t *testing.T) {
+	config, err := getLatestKindVersionConfig()
 	require.NoError(t, err)
 
 	// Should return a valid Kind version
@@ -68,17 +68,14 @@ func TestGetLatestKindVersionDynamic(t *testing.T) {
 	t.Logf("Dynamic Kind version: %s", version)
 }
 
-func TestGetKindVersionForKubernetesDynamic(t *testing.T) {
-	t.Skip("Skipping test that requires network access")
-
-	// Create a test Kubernetes version
+func TestGetKindVersionForKubernetes(t *testing.T) {
+	// Test the static version mapping function
 	kubeVersion, err := semver.NewVersion("1.30.0")
 	require.NoError(t, err)
 
-	kindVersion, err := getKindVersionForKubernetesDynamic(kubeVersion)
-	assert.NoError(t, err)
+	kindVersion := getKindVersionForKubernetes(kubeVersion)
 	assert.NotEmpty(t, kindVersion)
 	assert.Regexp(t, `^v\d+\.\d+\.\d+$`, kindVersion, "Kind version should match semver format with 'v' prefix")
 
-	t.Logf("Dynamic Kind version for k8s %s: %s", kubeVersion.String(), kindVersion)
+	t.Logf("Static Kind version for k8s %s: %s", kubeVersion.String(), kindVersion)
 }


### PR DESCRIPTION
What does this PR do?
---------------------
Pulls latest release version of kubernetes and kind to use in test suite when "latest" is passed as kubernetes version.

Which scenarios this will impact?
-------------------
Right now only TestKindSuite, invoked by the datadog-agent repo

Motivation
----------
Outage detailed in https://datadoghq.atlassian.net/browse/CONTINT-4708

Additional Notes
----------------
