### PR TITLE
Bump apps version to v0.0.5

### DIFF
--- a/components/datadog/apps/version.go
+++ b/components/datadog/apps/version.go
@@ -1,3 +1,3 @@
 package apps
 
-const Version = "v0.0.4"
+const Version = "v0.0.5"


### PR DESCRIPTION
What does this PR do?
---------------------

Bump version after image rebuilt to incorporate https://github.com/DataDog/test-infra-definitions/pull/1699 in the datadog-agent e2e tests

<img width="794" height="440" alt="not latest version" src="https://github.com/user-attachments/assets/8d653b2d-e4bc-4323-ac86-2ef4ec68026d" />

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
