### PR TITLE
Allow skipping openShift pull secret path

### DIFF
--- a/tasks/setup.py
+++ b/tasks/setup.py
@@ -335,9 +335,12 @@ def setup_gcp_config(config: Config):
     while True:
         config.configParams.gcp.pullSecretPath = default_pull_secret_path
         pull_secret_path = ask("🔑 Path to your OpenShift pull secret file (optional, can be set later): ")
-        if pull_secret_path:
-            config.configParams.gcp.pullSecretPath = pull_secret_path
+        if not pull_secret_path:
+            # empty to skip
+            config.configParams.gcp.pullSecretPath = ""
+            break
 
+        config.configParams.gcp.pullSecretPath = pull_secret_path
         if os.path.isfile(config.configParams.gcp.pullSecretPath):
             break
         warn(f"{config.configParams.gcp.pullSecretPath} is not a valid file")


### PR DESCRIPTION
What does this PR do?
---------------------
Currently we do not allow users to skip specifying a path for openShift pull secret in the setup script. This in contrast to the message displayed, which states `Path to your OpenShift pull secret file (optional, can be set later)`, and in contrast to how we handle similar prompts in the setup script. 

This PR allows the user to skip the prompt by inputing no characters. 

Which scenarios this will impact?
-------------------
This impacts no scenarios.

Motivation
----------
[https://datadoghq.atlassian.net/browse/CONTINT-4839](https://datadoghq.atlassian.net/browse/CONTINT-4839
)

Additional Notes
----------------
