### PR TITLE
Add Software Inventory to the fake intake hostname list

### DIFF
--- a/components/datadog/agentparams/params.go
+++ b/components/datadog/agentparams/params.go
@@ -293,6 +293,8 @@ sbom.logs_dd_url: %[1]s:%[2]d
 sbom.logs_no_ssl: true
 service_discovery.forwarder.logs_dd_url: %[1]s:%[2]d
 service_discovery.forwarder.logs_no_ssl: true
+software_inventory.forwarder.logs_dd_url: %[1]s:%[2]d
+software_inventory.forwarder.logs_no_ssl: true
 `, hostname, port, scheme)
 		p.ExtraAgentConfig = append(p.ExtraAgentConfig, extraConfig)
 		return nil


### PR DESCRIPTION
What does this PR do?
---------------------
This PR adds Software Inventory to the list of EvP hostnames that get replaced with fake intake hostnames.

Which scenarios this will impact?
-------------------
connectivity-datadog-event-platform

Motivation
----------
Passing E2E tests

Additional Notes
----------------
