### PR TITLE
[incident-43183] Updated Suse arm64 AMI

### DIFF
--- a/resources/aws/platforms.go
+++ b/resources/aws/platforms.go
@@ -94,7 +94,7 @@ var platforms = PlatformsType{
 			"15-4": "ami-067dfda331f8296b0",
 		},
 		"arm64": PlatformsAMIsType{
-			"15-4": "ami-0d446ba26bbe19573",
+			"15-4": "ami-08350d1d1649d8c05",
 		},
 	},
 	"fedora": PlatformsArchsType{

--- a/scenarios/aws/ec2/os_resolver.go
+++ b/scenarios/aws/ec2/os_resolver.go
@@ -216,7 +216,7 @@ func resolveSuseAMI(e aws.Environment, osInfo *os.Descriptor) (string, error) {
 		if osInfo.Architecture == os.AMD64Arch {
 			return "ami-067dfda331f8296b0", nil // Private copy of the AMI dd-agent-sles-15-x86_64
 		} else if osInfo.Architecture == os.ARM64Arch {
-			return "ami-0d446ba26bbe19573", nil // Private copy of the AMI dd-agent-sles-15-arm64
+			return "ami-08350d1d1649d8c05", nil
 		}
 		return "", fmt.Errorf("architecture %s is not supported for SUSE %s", osInfo.Architecture, osInfo.Version)
 	}


### PR DESCRIPTION
What does this PR do?
---------------------

There was an issue with our private copy of the AMI, it was too old. Updated it.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
Tested by creating a VM with invoke commands and running `sudo zypper update`.
