### PR TITLE
Allow SFTP connection for the root user

### DIFF
--- a/components/os/linux_disable_upgrades.go
+++ b/components/os/linux_disable_upgrades.go
@@ -7,5 +7,8 @@ import (
 //go:embed scripts/apt-disable-unattended-upgrades.sh
 var APTDisableUnattendedUpgradesScriptContent string
 
+//go:embed scripts/ssh-allow-sftp-root.sh
+var SSHAllowSFTPRootScriptContent string
+
 //go:embed scripts/zypper-disable-unattended-upgrades.sh
 var ZypperDisableUnattendedUpgradesScriptContent string

--- a/components/os/scripts/ssh-allow-sftp-root.sh
+++ b/components/os/scripts/ssh-allow-sftp-root.sh
@@ -1,0 +1,4 @@
+# No shebang because this script will be concatenated
+
+# Modify root's key restrictions to allow SFTP connections as root
+sed -ie 's/^.* ssh-rsa/restrict,command="internal-sftp" ssh-rsa/' /root/.ssh/authorized_keys

--- a/scenarios/aws/ec2/vm.go
+++ b/scenarios/aws/ec2/vm.go
@@ -190,12 +190,15 @@ func defaultVMArgs(e aws.Environment, vmArgs *vmArgs) error {
 	} else if vmArgs.osInfo.Flavor == os.Suse {
 		defaultUserData = os.ZypperDisableUnattendedUpgradesScriptContent
 	}
-	userDataParts := make([]string, 0, 2)
+	userDataParts := make([]string, 0, 3)
 	if vmArgs.userData != "" {
 		userDataParts = append(userDataParts, vmArgs.userData)
 	}
 	if defaultUserData != "" {
 		userDataParts = append(userDataParts, defaultUserData)
+	}
+	if vmArgs.osInfo.Family() == os.LinuxFamily {
+		userDataParts = append(userDataParts, os.SSHAllowSFTPRootScriptContent)
 	}
 	vmArgs.userData = strings.Join(userDataParts, "\n")
 


### PR DESCRIPTION
What does this PR do?
---------------------
This PR allows to open SFTP connection as the root user for the EC2 instances used in E2E tests.


Which scenarios this will impact?
-------------------
E2E tests using an AWS EC2 instance, with either Unixes or Windows (no-op here, since the client user is aldready `Administrator`) OS.

Motivation
----------
With [[AGENTRUN-609] Apply stricter permissions to log folder](https://github.com/DataDog/datadog-agent/pull/40257), which aims to strengthen permissions for the Agent's log files, E2E may still require to validate that an action performed has taken effect by reading the content of the Agent's logs. This PR provides the needed infrastructure to open privileged SFTP session.


Additional Notes
----------------
- It seems trivial to escalate from the `sftp` only session, to a full-blown session.
- Thanks to @KevinFairise2 for his guidance

[AGENTRUN-609]: https://datadoghq.atlassian.net/browse/AGENTRUN-609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ