### PR TITLE
Fix ssh-allow-sftp-root.sh script for OS without defaultUserData

### DIFF
--- a/components/os/scripts/ssh-allow-sftp-root.sh
+++ b/components/os/scripts/ssh-allow-sftp-root.sh
@@ -1,4 +1,6 @@
-# No shebang because this script will be concatenated
+#!/bin/bash
+
+set -e
 
 # Modify root's key restrictions to allow SFTP connections as root
 sed -ie 's/^.* ssh-rsa/restrict,command="internal-sftp" ssh-rsa/' /root/.ssh/authorized_keys


### PR DESCRIPTION
What does this PR do?
---------------------
Fix #1716 which isn't working on OS without `defaultUserData` (RedHat).

Which scenarios this will impact?
-------------------
RedHat E2E tests.

Motivation
----------

Additional Notes
----------------
