### PR TITLE
Provide AMI for macos x86_64

### DIFF
--- a/resources/aws/platforms.go
+++ b/resources/aws/platforms.go
@@ -131,6 +131,9 @@ var platforms = PlatformsType{
 		"arm64": PlatformsAMIsType{
 			"sonoma": "ami-0c582a76ed8159789",
 		},
+		"x86_64": PlatformsAMIsType{
+			"sonoma": "ami-0af4746d79fd670cd",
+		},
 	},
 }
 


### PR DESCRIPTION
What does this PR do?
---------------------

A test on deploy pipeline is broken due to that, we use an amd64 image so we need to provide one as well.

[Example error](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1151592168).

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------
