### PR TITLE
Remove reference to `appgate-gateway` sg in `agent-sandbox`

### DIFF
--- a/resources/aws/environmentDefaults.go
+++ b/resources/aws/environmentDefaults.go
@@ -202,7 +202,7 @@ func agentSandboxDefault() environmentDefault {
 						SubnetID: "subnet-0ba7fbd4fed03bbdd",
 					},
 				},
-				allowedInboundSecurityGroups:         []string{"sg-038231b976eb13d44", "sg-0d82a3ae7646ca5f4"},
+				allowedInboundSecurityGroups:         []string{"sg-038231b976eb13d44"},
 				allowedInboundManagedPrefixListNames: []string{"vpn-services-commercial-appgate"},
 				fargateNamespace:                     "",
 				linuxNodeGroup:                       true,


### PR DESCRIPTION
What does this PR do?
---------------------

Remove reference to `appgate-gateway` security group in the `agent-sandbox` AWS account.

Which scenarios this will impact?
-------------------

* `aws/eks`

Motivation
----------

AppGate gateways have moved away from this project. We’re now using gateways from `vpn-services-commercial` and access from those new gateways has already been granted by #1717

Additional Notes
----------------

https://dd.slack.com/archives/C09J6FZRTKJ/p1759263207417739