### PR TITLE
[CONTINT-4792] Grant less privileges to test apps accessing unix sockets

### DIFF
--- a/components/datadog/apps/dogstatsd/k8s.go
+++ b/components/datadog/apps/dogstatsd/k8s.go
@@ -16,7 +16,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
-func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace string, statsdPort int, statsdSocket string, withServiceAccount bool, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
+func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace string, statsdPort int, statsdSocket string, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &componentskube.Workload{}
@@ -37,40 +37,37 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 
 	opts = append(opts, utils.PulumiDependsOn(ns))
 
-	var serviceAccountName pulumi.StringInput
-	if withServiceAccount {
-		serviceAccountName = pulumi.String("dogstatsd-uds-sa")
+	// openshift requires a non-default service account tighted to the privileged scc
+	sa, err := corev1.NewServiceAccount(e.Ctx(), fmt.Sprintf("dogstatsd-uds-sa-%d", statsdPort), &corev1.ServiceAccountArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.StringPtr("dogstatsd-uds-sa"),
+			Namespace: pulumi.StringPtr(namespace),
+		},
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
 
-		// openshift requires a non-default service account tighted to the privileged scc
-		if _, err := corev1.NewServiceAccount(e.Ctx(), e.CommonNamer().ResourceName("dogstatsd-uds-sa"), &corev1.ServiceAccountArgs{
-			Metadata: &metav1.ObjectMetaArgs{
-				Name:      serviceAccountName,
+	// create a clusterRoleBinding to bind the new service account with the existing privileged scc
+	if _, err := rbacv1.NewRoleBinding(e.Ctx(), fmt.Sprintf("dogstatsd-uds-scc-binding-%d", statsdPort), &rbacv1.RoleBindingArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.String("dogstatsd-scc-binding"),
+			Namespace: pulumi.StringPtr(namespace),
+		},
+		RoleRef: &rbacv1.RoleRefArgs{
+			ApiGroup: pulumi.String("rbac.authorization.k8s.io"),
+			Kind:     pulumi.String("ClusterRole"),
+			Name:     pulumi.String("system:openshift:scc:hostaccess"),
+		},
+		Subjects: rbacv1.SubjectArray{
+			rbacv1.SubjectArgs{
+				Kind:      pulumi.String("ServiceAccount"),
+				Name:      sa.Metadata.Name().Elem(),
 				Namespace: pulumi.String(namespace),
 			},
-		}, opts...); err != nil {
-			return nil, err
-		}
-
-		// create a clusterRoleBinding to bind the new service account with the existing privileged scc
-		if _, err := rbacv1.NewClusterRoleBinding(e.Ctx(), e.CommonNamer().ResourceName("dogstatsd-uds-scc-binding"), &rbacv1.ClusterRoleBindingArgs{
-			Metadata: &metav1.ObjectMetaArgs{
-				Name: pulumi.String("dogstatsd-scc-binding"),
-			},
-			RoleRef: &rbacv1.RoleRefArgs{
-				ApiGroup: pulumi.String("rbac.authorization.k8s.io"),
-				Kind:     pulumi.String("ClusterRole"),
-				Name:     pulumi.String("system:openshift:scc:privileged"),
-			},
-			Subjects: rbacv1.SubjectArray{
-				rbacv1.SubjectArgs{
-					Kind:      pulumi.String("ServiceAccount"),
-					Name:      serviceAccountName,
-					Namespace: pulumi.String(namespace),
-				},
-			},
-		}, opts...); err != nil {
-			return nil, err
-		}
+		},
+	}, opts...); err != nil {
+		return nil, err
 	}
 
 	if _, err := appsv1.NewDeployment(e.Ctx(), fmt.Sprintf("dogstatsd-uds-with-csi-%d", statsdPort), &appsv1.DeploymentArgs{
@@ -97,7 +94,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 					},
 				},
 				Spec: &corev1.PodSpecArgs{
-					ServiceAccountName: serviceAccountName,
+					ServiceAccountName: sa.Metadata.Name().Elem(),
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("dogstatsd"),
@@ -144,7 +141,7 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 					},
 				},
 				Spec: &corev1.PodSpecArgs{
-					ServiceAccountName: serviceAccountName,
+					ServiceAccountName: sa.Metadata.Name().Elem(),
 					Containers: corev1.ContainerArray{
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("dogstatsd"),

--- a/components/datadog/apps/tracegen/k8s.go
+++ b/components/datadog/apps/tracegen/k8s.go
@@ -138,7 +138,7 @@ func generateTracegenUdsSpec(namespace string, serviceAccountName pulumi.StringP
 	}
 }
 
-func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace string, withServiceAccount bool, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
+func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
 	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
 
 	k8sComponent := &componentskube.Workload{}
@@ -159,44 +159,39 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace
 
 	opts = append(opts, utils.PulumiDependsOn(ns))
 
-	var serviceAccountName pulumi.StringInput
-
-	if withServiceAccount {
-		serviceAccountName = pulumi.String("tracegen-uds-sa")
-
-		// openshift requires a non-default service account tighted to the privileged scc
-		if _, err := corev1.NewServiceAccount(e.Ctx(), e.CommonNamer().ResourceName("tracegen-uds-sa"), &corev1.ServiceAccountArgs{
-			Metadata: &metav1.ObjectMetaArgs{
-				Name:      serviceAccountName,
-				Namespace: pulumi.String("workload-tracegen"),
-			},
-		}, opts...); err != nil {
-			return nil, err
-		}
-
-		// create a clusterRoleBinding to bind the new service account with the existing privileged scc
-		if _, err := rbacv1.NewClusterRoleBinding(e.Ctx(), e.CommonNamer().ResourceName("tracegen-uds-scc-binding"), &rbacv1.ClusterRoleBindingArgs{
-			Metadata: &metav1.ObjectMetaArgs{
-				Name: pulumi.String("tracegen-scc-binding"),
-			},
-			RoleRef: &rbacv1.RoleRefArgs{
-				ApiGroup: pulumi.String("rbac.authorization.k8s.io"),
-				Kind:     pulumi.String("ClusterRole"),
-				Name:     pulumi.String("system:openshift:scc:privileged"),
-			},
-			Subjects: rbacv1.SubjectArray{
-				rbacv1.SubjectArgs{
-					Kind:      pulumi.String("ServiceAccount"),
-					Name:      serviceAccountName,
-					Namespace: pulumi.String("workload-tracegen"),
-				},
-			},
-		}, opts...); err != nil {
-			return nil, err
-		}
+	// openshift requires a non-default service account tighted to the privileged scc
+	sa, err := corev1.NewServiceAccount(e.Ctx(), e.CommonNamer().ResourceName("tracegen-uds-sa"), &corev1.ServiceAccountArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.StringPtr("tracegen-uds-sa"),
+			Namespace: pulumi.StringPtr("workload-tracegen"),
+		},
+	}, opts...)
+	if err != nil {
+		return nil, err
 	}
 
-	if _, err := appsv1.NewDeployment(e.Ctx(), namespace+"/tracegen-uds", generateTracegenUdsSpec(namespace, serviceAccountName), opts...); err != nil {
+	// create a clusterRoleBinding to bind the new service account with the existing privileged scc
+	if _, err := rbacv1.NewRoleBinding(e.Ctx(), e.CommonNamer().ResourceName("tracegen-uds-scc-binding"), &rbacv1.RoleBindingArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name: pulumi.String("tracegen-scc-binding"),
+		},
+		RoleRef: &rbacv1.RoleRefArgs{
+			ApiGroup: pulumi.String("rbac.authorization.k8s.io"),
+			Kind:     pulumi.String("ClusterRole"),
+			Name:     pulumi.String("system:openshift:scc:hostaccess"),
+		},
+		Subjects: rbacv1.SubjectArray{
+			rbacv1.SubjectArgs{
+				Kind:      pulumi.String("ServiceAccount"),
+				Name:      sa.Metadata.Name().Elem(),
+				Namespace: pulumi.String("workload-tracegen"),
+			},
+		},
+	}, opts...); err != nil {
+		return nil, err
+	}
+
+	if _, err := appsv1.NewDeployment(e.Ctx(), namespace+"/tracegen-uds", generateTracegenUdsSpec(namespace, sa.Metadata.Name().Elem()), opts...); err != nil {
 		return nil, err
 	}
 

--- a/scenarios/aws/eks/run.go
+++ b/scenarios/aws/eks/run.go
@@ -140,7 +140,7 @@ func Run(ctx *pulumi.Context) error {
 			}
 
 			// dogstatsd clients that report to the Agent
-			if _, err := dogstatsd.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket", false, dependsOnDDAgent /* for admission */); err != nil {
+			if _, err := dogstatsd.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket", dependsOnDDAgent /* for admission */); err != nil {
 				return err
 			}
 
@@ -150,12 +150,12 @@ func Run(ctx *pulumi.Context) error {
 
 			if awsEnv.DogstatsdDeploy() {
 				// dogstatsd clients that report to the dogstatsd standalone deployment
-				if _, err := dogstatsd.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket, false, dependsOnDDAgent /* for admission */); err != nil {
+				if _, err := dogstatsd.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket, dependsOnDDAgent /* for admission */); err != nil {
 					return err
 				}
 			}
 
-			if _, err := tracegen.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-tracegen", false); err != nil {
+			if _, err := tracegen.K8sAppDefinition(&awsEnv, cluster.KubeProvider, "workload-tracegen"); err != nil {
 				return err
 			}
 

--- a/scenarios/aws/kindvm/run.go
+++ b/scenarios/aws/kindvm/run.go
@@ -227,19 +227,19 @@ spec:
 		}
 
 		// dogstatsd clients that report to the Agent
-		if _, err := dogstatsd.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket", false, dependsOnDDAgent /* for admission */); err != nil {
+		if _, err := dogstatsd.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket", dependsOnDDAgent /* for admission */); err != nil {
 			return err
 		}
 
 		// dogstatsd clients that report to the dogstatsd standalone deployment
 		if awsEnv.DogstatsdDeploy() {
-			if _, err := dogstatsd.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket, false, dependsOnDDAgent /* for admission */); err != nil {
+			if _, err := dogstatsd.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket, dependsOnDDAgent /* for admission */); err != nil {
 				return err
 			}
 		}
 
 		// for tracegen we can't find the cgroup version as it depends on the underlying version of the kernel
-		if _, err := tracegen.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-tracegen", false); err != nil {
+		if _, err := tracegen.K8sAppDefinition(&awsEnv, kindKubeProvider, "workload-tracegen"); err != nil {
 			return err
 		}
 

--- a/scenarios/azure/aks/run.go
+++ b/scenarios/azure/aks/run.go
@@ -135,13 +135,13 @@ providers:
 		}
 
 		// dogstatsd clients that report to the Agent
-		if _, err := dogstatsd.K8sAppDefinition(&env, aksCluster.KubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket", false, dependsOnDDAgent /* for admission */); err != nil {
+		if _, err := dogstatsd.K8sAppDefinition(&env, aksCluster.KubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket", dependsOnDDAgent /* for admission */); err != nil {
 			return err
 		}
 
 		if env.DogstatsdDeploy() {
 			// dogstatsd clients that report to the dogstatsd standalone deployment
-			if _, err := dogstatsd.K8sAppDefinition(&env, aksCluster.KubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket, false, dependsOnDDAgent /* for admission */); err != nil {
+			if _, err := dogstatsd.K8sAppDefinition(&env, aksCluster.KubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket, dependsOnDDAgent /* for admission */); err != nil {
 				return err
 			}
 		}

--- a/scenarios/gcp/gke/run.go
+++ b/scenarios/gcp/gke/run.go
@@ -139,17 +139,17 @@ func Run(ctx *pulumi.Context) error {
 				}
 
 				// dogstatsd clients that report to the dogstatsd standalone deployment
-				if _, err := dogstatsd.K8sAppDefinition(&env, cluster.KubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket, false, dependsOnDDAgent /* for admission */); err != nil {
+				if _, err := dogstatsd.K8sAppDefinition(&env, cluster.KubeProvider, "workload-dogstatsd-standalone", dogstatsdstandalone.HostPort, dogstatsdstandalone.Socket, dependsOnDDAgent /* for admission */); err != nil {
 					return err
 				}
 			}
 
 			// dogstatsd clients that report to the Agent
-			if _, err := dogstatsd.K8sAppDefinition(&env, cluster.KubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket", false, dependsOnDDAgent /* for admission */); err != nil {
+			if _, err := dogstatsd.K8sAppDefinition(&env, cluster.KubeProvider, "workload-dogstatsd", 8125, "/var/run/datadog/dsd.socket", dependsOnDDAgent /* for admission */); err != nil {
 				return err
 			}
 
-			if _, err := tracegen.K8sAppDefinition(&env, cluster.KubeProvider, "workload-tracegen", false); err != nil {
+			if _, err := tracegen.K8sAppDefinition(&env, cluster.KubeProvider, "workload-tracegen"); err != nil {
 				return err
 			}
 		}

--- a/scenarios/gcp/openshiftvm/run.go
+++ b/scenarios/gcp/openshiftvm/run.go
@@ -183,11 +183,11 @@ clusterAgent:
 			return err
 		}
 
-		if _, err := tracegen.K8sAppDefinition(&gcpEnv, openshiftKubeProvider, "workload-tracegen", true); err != nil {
+		if _, err := tracegen.K8sAppDefinition(&gcpEnv, openshiftKubeProvider, "workload-tracegen"); err != nil {
 			return err
 		}
 
-		if _, err := dogstatsd.K8sAppDefinition(&gcpEnv, openshiftKubeProvider, "workload-dogstatsd", 8125, "/run/datadog/dsd.socket", true, dependsOnDDAgent /* for admission */); err != nil {
+		if _, err := dogstatsd.K8sAppDefinition(&gcpEnv, openshiftKubeProvider, "workload-dogstatsd", 8125, "/run/datadog/dsd.socket", dependsOnDDAgent /* for admission */); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
What does this PR do?
---------------------

Reduce the amount of privileges granted to test apps that need to access the agent unix sockets.
OpenShift default `restricted` SCC blocks `HostPath` volumes.
`privileged` SCC is a bit overkill. `hostaccess` should be enough.

Also remove the condition to create a specific ServiceAccount for test apps. Although it’s mandatory only for the OpenShift scenario, it’s harmless to create them elsewhere.

Which scenarios this will impact?
-------------------

* `gcp/gke`

Motivation
----------

Additional Notes
----------------

Follow-up of #1709.
