### PR TITLE
nvidia: fix replacement of nvkind cluster

### DIFF
--- a/components/kubernetes/nvidia/nvidia.go
+++ b/components/kubernetes/nvidia/nvidia.go
@@ -212,14 +212,29 @@ func initNvkindCluster(env config.Env, vm *remote.Host, name string, clusterOpts
 
 		// Run the nvkind command to create the cluster
 		kindClusterName := env.CommonNamer().DisplayName(49)
+
+		// Force pulumi to delete the cluster before trying to recreate it,
+		// although this only works if the create command succeeded previously.
+		// If not, it will just try to run the create command again, which is
+		// why we need to run the kind delete command on create failure, see below.
+		clusterOpts := utils.MergeOptions(opts, pulumi.DeleteBeforeReplace(true))
+		deleteClusterCmd := pulumi.Sprintf("kind delete cluster --name %s", kindClusterName)
 		nvkindCreateCluster, err := vm.OS.Runner().Command(
 			env.CommonNamer().ResourceName("nvkind-create"),
 			&command.Args{
-				Create:   pulumi.Sprintf("nvkind cluster create --name %s --config-template %s --config-values %s", kindClusterName, nvkindTemplatePath, nvkindValuesPath),
-				Delete:   pulumi.Sprintf("kind delete clusters %s || true", kindClusterName),
+				// For the create command, delete the cluster if the creation
+				// fails. And if the delete succeeds, still have && false to
+				// ensure that the command returns an exit error anways
+				Create:   pulumi.Sprintf("nvkind cluster create --name %s --config-template %s --config-values %s || (%s && false)", kindClusterName, nvkindTemplatePath, nvkindValuesPath, deleteClusterCmd),
+				// On the other hand, do not fail the delete command if nvkind
+				// delete fails, as it can happen if the cluster hasn't been
+				// created or nvkind deleted it because of an error (nvkind is
+				// not consistent and will not always delete the cluster when it
+				// fails to create it)
+				Delete:   pulumi.Sprintf("%s || true", deleteClusterCmd),
 				Triggers: pulumi.Array{nvkindValuesContent, pulumi.String(nvkindConfigTemplate)},
 			},
-			opts...)
+			clusterOpts...)
 		if err != nil {
 			return fmt.Errorf("failed to create nvkind cluster: %w", err)
 		}

--- a/components/kubernetes/nvidia/nvidia.go
+++ b/components/kubernetes/nvidia/nvidia.go
@@ -225,7 +225,7 @@ func initNvkindCluster(env config.Env, vm *remote.Host, name string, clusterOpts
 				// For the create command, delete the cluster if the creation
 				// fails. And if the delete succeeds, still have && false to
 				// ensure that the command returns an exit error anways
-				Create:   pulumi.Sprintf("nvkind cluster create --name %s --config-template %s --config-values %s || (%s && false)", kindClusterName, nvkindTemplatePath, nvkindValuesPath, deleteClusterCmd),
+				Create: pulumi.Sprintf("nvkind cluster create --name %s --config-template %s --config-values %s || (%s && false)", kindClusterName, nvkindTemplatePath, nvkindValuesPath, deleteClusterCmd),
 				// On the other hand, do not fail the delete command if nvkind
 				// delete fails, as it can happen if the cluster hasn't been
 				// created or nvkind deleted it because of an error (nvkind is


### PR DESCRIPTION
## What does this PR do?

Fixes the nvkind cluster creation command to delete the cluster if it fails, to ensure that pulumi can re-try the creation correctly.

## Which scenarios this will impact?

None

## Motivation

When developing changes for the nvkind component, if the creation fails the cluster can be left over, and then subsequent creation attempts will fail because the cluster already exists. To fix that, it requires manual intervention. With this fix, we can iterate on fixes in the code without manually intervening if something is wrong.

## Additional Notes