### PR TITLE
[ACIX-1036] Updated all AMIs

### DIFF
--- a/resources/aws/platforms.go
+++ b/resources/aws/platforms.go
@@ -18,36 +18,36 @@ var platforms = PlatformsType{
 	"debian": PlatformsArchsType{
 		"x86_64": PlatformsAMIsType{
 			"9":  "ami-0182559468c1975fe",
-			"10": "ami-0ea3c9b1a2bcdabfc",
-			"11": "ami-03039e227b7b461b5",
-			"12": "ami-0eef9d92ec044bc94",
+			"10": "ami-06af96db6765fa419",
+			"11": "ami-0c552d040ce3b66e0",
+			"12": "ami-0531f78dcce082188",
 		},
 		"arm64": PlatformsAMIsType{
-			"10": "ami-0497a51e798361d65",
-			"11": "ami-05f3f532b93bba0b3",
-			"12": "ami-0f6dec0dab168c2f5",
+			"10": "ami-0b1f3e4ea76c9a5d2",
+			"11": "ami-0917ebceb11be2e8a",
+			"12": "ami-04935cdb518e4a366",
 		},
 	},
 	"ubuntu": PlatformsArchsType{
 		"x86_64": PlatformsAMIsType{
 			"14-04": "ami-013d633d3b6cdb22c",
-			"16-04": "ami-0b0ea68c435eb488d",
-			"18-04": "ami-055744c75048d8296",
-			"20-04": "ami-0fb0b230890ccd1e6",
-			"22-04": "ami-090c309e8ced8ecc2",
-			"23-04": "ami-0bf964046a441a4ee",
+			"16-04": "ami-0296699e24cbb4143",
+			"18-04": "ami-0b523f7e6425e2c8c",
+			"20-04": "ami-0c41f56c881c68720",
+			"22-04": "ami-0e3913528c47ae3f5",
+			"23-04": "ami-0533a8aa5b8ad7c7c",
 			"23-10": "ami-0949b45ef274e55a1",
-			"24-04": "ami-0360c520857e3138f",
+			"24-04": "ami-02fb31d76d5fa8d35",
 		},
 		"arm64": PlatformsAMIsType{
-			"18-04":   "ami-0fea31578248bcd6c",
-			"20-04":   "ami-0c7114fa3eac14de1",
+			"18-04":   "ami-0e07da45fcfc0c4c9",
+			"20-04":   "ami-06a75cdeb2f77ae18",
 			"20-04-2": "ami-023f1e40b096c3ebc",
-			"21-04":   "ami-044f0ceee8e885e87",
-			"22-04":   "ami-09059bc76ad3db67f",
-			"23-04":   "ami-09b2701695676705d",
+			"21-04":   "ami-019b0f2a791d2bbc0",
+			"22-04":   "ami-07b7d55284f346a96",
+			"23-04":   "ami-0b32303b545cba4db",
 			"23-10":   "ami-0dea732dd5f1da0a8",
-			"24-04":   "ami-026fccd88446aa0bf",
+			"24-04":   "ami-0a8a1016b19572af2",
 		},
 	},
 	"amazon-linux": PlatformsArchsType{
@@ -55,54 +55,54 @@ var platforms = PlatformsType{
 			"2-4-14":    "ami-038b3df3312ddf25d",
 			"2-5-10":    "ami-06a0cd9728546d178",
 			"2022-5-15": "ami-0f0f00c2d082c52ae",
-			"2023":      "ami-00ca32bbc84273381",
-			"2018":      "ami-07541a4f680f1ba8e",
-			"2":         "ami-0023921b4fcd5382b",
+			"2023":      "ami-058a5d626099cf16c",
+			"2018":      "ami-02caf923ff4b59e8c",
+			"2":         "ami-0da449b9f8245c763",
 		},
 		"arm64": PlatformsAMIsType{
 			"2-4-14":    "ami-090230ed0c6b13c74",
 			"2-5-10":    "ami-09e51988f56677f44",
 			"2022-5-15": "ami-0acc51c3357f26240",
-			"2023":      "ami-0aa7db6294d00216f",
-			"2":         "ami-00aae26e31bb072a2",
+			"2023":      "ami-0aaec32babf1e822c",
+			"2":         "ami-04ede3126a4d26b8e",
 		},
 	},
 	"amazon-linux-ecs": PlatformsArchsType{
 		"x86_64": PlatformsAMIsType{
-			"2023": "ami-0986768eff12aa2b9",
-			"2":    "ami-0293ff221e87260aa",
+			"2023": "ami-0d6b553b43813a487",
+			"2":    "ami-0434f20bd534b3f1d",
 		},
 		"arm64": PlatformsAMIsType{
-			"2023": "ami-032a0cd402947954b",
-			"2":    "ami-07af7b838076acdcc",
+			"2023": "ami-0ac7ab05b219bc7f2",
+			"2":    "ami-0293ff221e87260aa",
 		},
 	},
 	"redhat": PlatformsArchsType{
 		"x86_64": PlatformsAMIsType{
-			"9":       "ami-0c878dd49ca800252",
+			"9":       "ami-04b5ab048661f55a5",
 			"86":      "ami-031eff1ae75bb87e4",
 			"86-fips": "ami-0d0fb96b595c56e03",
 		},
 		"arm64": PlatformsAMIsType{
-			"9":  "ami-089b86d2f4d27cd98",
+			"9":  "ami-05ae470afd4fb9dd6",
 			"86": "ami-0238411fb452f8275",
 		},
 	},
 	"suse": PlatformsArchsType{
 		"x86_64": PlatformsAMIsType{
-			"12":   "ami-0b0597153739840c4",
-			"15-4": "ami-067dfda331f8296b0",
+			"12":   "ami-09fce481fa7fd07b3",
+			"15-4": "ami-0128c2ff9ed3d3978",
 		},
 		"arm64": PlatformsAMIsType{
-			"15-4": "ami-08350d1d1649d8c05",
+			"15-4": "ami-02cf9b47af54755f4",
 		},
 	},
 	"fedora": PlatformsArchsType{
 		"x86_64": PlatformsAMIsType{
-			"40": "ami-004f552bba0e5f64f",
+			"40": "ami-0852a7102687480c5",
 		},
 		"arm64": PlatformsAMIsType{
-			"42": "ami-0184eee8cd4a6080b",
+			"42": "ami-0953cc8b868ba599d",
 		},
 	},
 	"centos": PlatformsArchsType{
@@ -121,18 +121,18 @@ var platforms = PlatformsType{
 	},
 	"windows-server": PlatformsArchsType{
 		"x86_64": PlatformsAMIsType{
-			"2025": "ami-0efee5160a1079475",
-			"2022": "ami-028dc1123403bd543",
-			"2019": "ami-043cf96255cd85b98",
-			"2016": "ami-0fe657c1315199148",
+			"2025": "ami-046960a099673d97d",
+			"2022": "ami-001eb8f77f0589d4b",
+			"2019": "ami-0144cf01bbf315e1b",
+			"2016": "ami-0bab8643e749a877f",
 		},
 	},
 	"macos": PlatformsArchsType{
 		"arm64": PlatformsAMIsType{
-			"sonoma": "ami-0c582a76ed8159789",
+			"sonoma": "ami-04c4082c98a93544e",
 		},
 		"x86_64": PlatformsAMIsType{
-			"sonoma": "ami-0af4746d79fd670cd",
+			"sonoma": "ami-0801764b08904a0e4",
 		},
 	},
 }


### PR DESCRIPTION
What does this PR do?
---------------------

> [!NOTE]
> Agent [PR](https://github.com/DataDog/datadog-agent/pull/43267).

My last bump contained an invalid ubuntu 18 arm64 so I rebuilt and updated everything.

Which scenarios this will impact?
-------------------

Motivation
----------

Additional Notes
----------------

Tried previous wrong AMIs with test infra CLI to verify.
