### PR TITLE
[CONTINT-4791] Bump apps.Version to v0.0.6 to use Alpine image

### DIFF
--- a/components/datadog/apps/etcd/k8s.go
+++ b/components/datadog/apps/etcd/k8s.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/DataDog/test-infra-definitions/common/config"
 	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
 	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
 )
 
@@ -19,8 +20,6 @@ import (
 // the check was discovered.
 const storeCheckConfigScript = `
 set -e
-
-apk add --no-cache curl netcat-openbsd
 
 echo "[init] Waiting for etcd to respond on TCP port 2379..."
 until nc -z localhost 2379; do
@@ -141,10 +140,16 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, opts ...p
 								InitialDelaySeconds: pulumi.Int(10),
 								TimeoutSeconds:      pulumi.Int(5),
 							},
+							VolumeMounts: &corev1.VolumeMountArray{
+								&corev1.VolumeMountArgs{
+									Name:      pulumi.String("etcd-data"),
+									MountPath: pulumi.String("/var/lib/etcd"),
+								},
+							},
 						},
 						&corev1.ContainerArgs{
 							Name:  pulumi.String("etcd-config"),
-							Image: pulumi.String("public.ecr.aws/docker/library/alpine:3.21.3"),
+							Image: pulumi.String("ghcr.io/datadog/apps-alpine:" + apps.Version),
 							Command: pulumi.StringArray{
 								pulumi.String("/bin/sh"),
 								pulumi.String("-c"),
@@ -152,6 +157,12 @@ func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, opts ...p
 							Args: pulumi.StringArray{
 								pulumi.String(storeCheckConfigScript),
 							},
+						},
+					},
+					Volumes: corev1.VolumeArray{
+						&corev1.VolumeArgs{
+							Name:     pulumi.String("etcd-data"),
+							EmptyDir: &corev1.EmptyDirVolumeSourceArgs{},
 						},
 					},
 				},

--- a/components/datadog/apps/version.go
+++ b/components/datadog/apps/version.go
@@ -1,3 +1,3 @@
 package apps
 
-const Version = "v0.0.5"
+const Version = "v0.0.6"


### PR DESCRIPTION
What does this PR do?
---------------------
This PR does three things:
- bumps the version of apps.Version to v0.0.6
- replaces the alpine image used in the `etcd` workload with one built from this repository (with a fixed image tag)
- mounts an empty volume in `etcd` container that should've previously been declared.

Which scenarios this will impact?
-------------------
All scenarios, as all images will now use fixed version `v0.0.6`. 

Motivation
----------
Part of an effort to get all test workloads deployed on OpenShift clusters: https://datadoghq.atlassian.net/browse/CONTINT-4791 

Additional Notes
----------------
