### PR TITLE
[CONTP-1184] Support GPU instance in EKS cluster

### DIFF
--- a/components/datadog/apps/gpu/k8s.go
+++ b/components/datadog/apps/gpu/k8s.go
@@ -1,0 +1,103 @@
+package gpu
+
+import (
+	"github.com/DataDog/test-infra-definitions/common/config"
+	"github.com/DataDog/test-infra-definitions/common/utils"
+	"github.com/DataDog/test-infra-definitions/components/datadog/apps"
+	componentskube "github.com/DataDog/test-infra-definitions/components/kubernetes"
+
+	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/apps/v1"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+// K8sAppDefinition deploys a GPU workload (cuda-basic) as a DaemonSet to all GPU nodes.
+// The workload runs a simple CUDA vector addition program that requires a GPU.
+// This is useful for testing GPU monitoring and container-to-GPU mapping.
+func K8sAppDefinition(e config.Env, kubeProvider *kubernetes.Provider, namespace string, opts ...pulumi.ResourceOption) (*componentskube.Workload, error) {
+	opts = append(opts, pulumi.Provider(kubeProvider), pulumi.Parent(kubeProvider), pulumi.DeletedWith(kubeProvider))
+
+	k8sComponent := &componentskube.Workload{}
+	if err := e.Ctx().RegisterComponentResource("dd:apps", "gpu", k8sComponent, opts...); err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, pulumi.Parent(k8sComponent))
+
+	ns, err := corev1.NewNamespace(e.Ctx(), namespace, &corev1.NamespaceArgs{
+		Metadata: metav1.ObjectMetaArgs{
+			Name: pulumi.String(namespace),
+		},
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	opts = append(opts, utils.PulumiDependsOn(ns))
+
+	// Deploy cuda-basic workload as DaemonSet to run on all GPU nodes
+	// Each pod runs a simple CUDA vector addition in a loop for testing
+	if _, err := appsv1.NewDaemonSet(e.Ctx(), "cuda-basic", &appsv1.DaemonSetArgs{
+		Metadata: &metav1.ObjectMetaArgs{
+			Name:      pulumi.String("cuda-basic"),
+			Namespace: pulumi.String(namespace),
+			Labels: pulumi.StringMap{
+				"app": pulumi.String("cuda-basic"),
+			},
+		},
+		Spec: &appsv1.DaemonSetSpecArgs{
+			Selector: &metav1.LabelSelectorArgs{
+				MatchLabels: pulumi.StringMap{
+					"app": pulumi.String("cuda-basic"),
+				},
+			},
+			Template: &corev1.PodTemplateSpecArgs{
+				Metadata: &metav1.ObjectMetaArgs{
+					Labels: pulumi.StringMap{
+						"app": pulumi.String("cuda-basic"),
+					},
+				},
+				Spec: &corev1.PodSpecArgs{
+					Containers: corev1.ContainerArray{
+						corev1.ContainerArgs{
+							Name:  pulumi.String("cuda-basic"),
+							Image: pulumi.String("ghcr.io/datadog/apps-cuda-basic:" + apps.Version),
+							// Run cuda-basic in a loop: 50000 elements, 1000 loops, 0s wait
+							// Then sleep 5s between iterations for continuous GPU activity
+							Command: pulumi.StringArray{
+								pulumi.String("/bin/sh"),
+								pulumi.String("-c"),
+								pulumi.String("while true; do /usr/local/bin/cuda-basic 50000 1000 0; sleep 5; done"),
+							},
+							Resources: &corev1.ResourceRequirementsArgs{
+								Limits: pulumi.StringMap{
+									// Request 1 GPU - this triggers NVIDIA device plugin
+									// to set NVIDIA_VISIBLE_DEVICES in the container spec
+									"nvidia.com/gpu": pulumi.String("1"),
+								},
+							},
+						},
+					},
+					// Tolerate GPU node taints (if any)
+					Tolerations: corev1.TolerationArray{
+						corev1.TolerationArgs{
+							Key:      pulumi.String("nvidia.com/gpu"),
+							Operator: pulumi.String("Exists"),
+							Effect:   pulumi.String("NoSchedule"),
+						},
+					},
+					// Only schedule on GPU nodes (labeled by test-infra-definitions)
+					NodeSelector: pulumi.StringMap{
+						"accelerator": pulumi.String("nvidia-gpu"),
+					},
+				},
+			},
+		},
+	}, opts...); err != nil {
+		return nil, err
+	}
+
+	return k8sComponent, nil
+}

--- a/components/datadog/kubernetesagentparams/params.go
+++ b/components/datadog/kubernetesagentparams/params.go
@@ -237,6 +237,21 @@ func WithGKEAutopilot() func(*Params) error {
 	}
 }
 
+// WithGPUMonitoring enables GPU monitoring in the agent.
+// runtimeClassName is set to empty string because EKS doesn't have the "nvidia" RuntimeClass by default.
+func WithGPUMonitoring() func(*Params) error {
+	return func(p *Params) error {
+		gpuMonitoringValues := `
+datadog:
+  gpuMonitoring:
+    enabled: true
+    runtimeClassName: ""
+`
+		p.HelmValues = append(p.HelmValues, pulumi.NewStringAsset(gpuMonitoringValues))
+		return nil
+	}
+}
+
 func WithTags(tags []string) func(*Params) error {
 	return func(p *Params) error {
 		tagsYAML, err := yaml.Marshal(tags)

--- a/resources/aws/environment.go
+++ b/resources/aws/environment.go
@@ -63,6 +63,8 @@ const (
 	DDInfraEksLinuxARMNodeGroup                    = "aws/eks/linuxARMNodeGroup"
 	DDInfraEksLinuxBottlerocketNodeGroup           = "aws/eks/linuxBottlerocketNodeGroup"
 	DDInfraEksWindowsNodeGroup                     = "aws/eks/windowsNodeGroup"
+	DDInfraEksGPUNodeGroup                         = "aws/eks/gpuNodeGroup"
+	DDInfraEksGPUInstanceType                      = "aws/eks/gpuInstanceType"
 	DDInfraEksAccountAdminSSORole                  = "aws/eks/accountAdminSSORole"
 	DDInfraEksReadOnlySSORole                      = "aws/eks/readOnlySSORole"
 )
@@ -397,6 +399,14 @@ func (e *Environment) EKSBottlerocketNodeGroup() bool {
 
 func (e *Environment) EKSWindowsNodeGroup() bool {
 	return e.GetBoolWithDefault(e.InfraConfig, DDInfraEksWindowsNodeGroup, e.envDefault.ddInfra.eks.windowsLTSCNodeGroup)
+}
+
+func (e *Environment) EKSGPUNodeGroup() bool {
+	return e.GetBoolWithDefault(e.InfraConfig, DDInfraEksGPUNodeGroup, e.envDefault.ddInfra.eks.gpuNodeGroup)
+}
+
+func (e *Environment) EKSGPUInstanceType() string {
+	return e.GetStringWithDefault(e.InfraConfig, DDInfraEksGPUInstanceType, e.envDefault.ddInfra.eks.gpuInstanceType)
 }
 
 func (e *Environment) EKSAccountAdminSSORole() string {

--- a/resources/aws/environmentDefaults.go
+++ b/resources/aws/environmentDefaults.go
@@ -75,6 +75,8 @@ type ddInfraEKS struct {
 	linuxARMNodeGroup                    bool
 	linuxBottlerocketNodeGroup           bool
 	windowsLTSCNodeGroup                 bool
+	gpuNodeGroup                         bool
+	gpuInstanceType                      string
 }
 
 type DDInfraEKSPodSubnets struct {

--- a/tasks/aws/eks.py
+++ b/tasks/aws/eks.py
@@ -30,6 +30,8 @@ scenario_name = "aws/eks"
         "linux_arm_node_group": doc.linux_arm_node_group,
         "bottlerocket_node_group": doc.bottlerocket_node_group,
         "windows_node_group": doc.windows_node_group,
+        "gpu_node_group": "Create a GPU-enabled node group with NVIDIA GPUs (uses AL2 GPU AMI with pre-installed NVIDIA drivers)",
+        "gpu_instance_type": "GPU instance type (e.g., 'g4dn.xlarge', 'g4dn.12xlarge', 'g5.xlarge'). Defaults to 'g4dn.xlarge' if not specified.",
         "instance_type": aws_doc.instance_type,
         "full_image_path": doc.full_image_path,
         "cluster_agent_full_image_path": doc.cluster_agent_full_image_path,
@@ -51,6 +53,8 @@ def create_eks(
     linux_arm_node_group: bool = False,
     bottlerocket_node_group: bool = True,
     windows_node_group: bool = False,
+    gpu_node_group: bool = False,
+    gpu_instance_type: Optional[str] = None,
     instance_type: Optional[str] = None,
     full_image_path: Optional[str] = None,
     cluster_agent_full_image_path: Optional[str] = None,
@@ -67,9 +71,13 @@ def create_eks(
         "ddinfra:aws/eks/linuxBottlerocketNodeGroup": bottlerocket_node_group,
         "ddinfra:aws/eks/linuxNodeGroup": str(linux_node_group),
         "ddinfra:aws/eks/windowsNodeGroup": windows_node_group,
+        "ddinfra:aws/eks/gpuNodeGroup": gpu_node_group,
         "ddagent:localChartPath": local_chart_path,
         "ddtestworkload:deployArgoRollout": install_argorollout,
     }
+
+    if gpu_instance_type is not None:
+        extra_flags["ddinfra:aws/eks/gpuInstanceType"] = gpu_instance_type
 
     # Override the instance type if specified
     # ARM node groups use defaultARMInstanceType, all others (Linux, Bottlerocket, Windows) use defaultInstanceType

--- a/tasks/eks.py
+++ b/tasks/eks.py
@@ -20,6 +20,8 @@ from . import doc
         "linux_arm_node_group": doc.linux_arm_node_group,
         "bottlerocket_node_group": doc.bottlerocket_node_group,
         "windows_node_group": doc.windows_node_group,
+        "gpu_node_group": "Create a GPU-enabled node group with NVIDIA GPUs",
+        "gpu_instance_type": "GPU instance type (e.g., 'g4dn.xlarge')",
         "instance_type": aws_doc.instance_type,
     }
 )
@@ -36,6 +38,8 @@ def create_eks(
     linux_arm_node_group: bool = False,
     bottlerocket_node_group: bool = True,
     windows_node_group: bool = False,
+    gpu_node_group: bool = False,
+    gpu_instance_type: Optional[str] = None,
     instance_type: Optional[str] = None,
 ):
     print('This command is deprecated, please use `aws.create-eks` instead')
@@ -44,18 +48,20 @@ def create_eks(
 
     create_eks_aws(
         ctx,
-        config_path,
-        debug,
-        stack_name,
-        install_agent,
-        install_workload,
-        install_argorollout,
-        agent_version,
-        linux_node_group,
-        linux_arm_node_group,
-        bottlerocket_node_group,
-        windows_node_group,
-        instance_type,
+        config_path=config_path,
+        debug=debug,
+        stack_name=stack_name,
+        install_agent=install_agent,
+        install_workload=install_workload,
+        install_argorollout=install_argorollout,
+        agent_version=agent_version,
+        linux_node_group=linux_node_group,
+        linux_arm_node_group=linux_arm_node_group,
+        bottlerocket_node_group=bottlerocket_node_group,
+        windows_node_group=windows_node_group,
+        gpu_node_group=gpu_node_group,
+        gpu_instance_type=gpu_instance_type,
+        instance_type=instance_type,
     )
 
 


### PR DESCRIPTION
**What does this PR do?**
Adds GPU node group support to EKS clusters with the following changes:

  1. GPU Node Group with NVIDIA Device Plugin (scenarios/aws/eks/cluster.go)
    - Installs NVIDIA device plugin via Helm when GPU node group is enabled
  2. GPU Node Labeling (resources/aws/eks/nodeGroups.go)
    - Adds accelerator=nvidia-gpu label to GPU nodes for easy identification and workload scheduling
    - Introduces newManagedNodeGroupWithLabels() helper function
  3. GPU Workload Deployment (components/datadog/apps/gpu/k8s.go) - NEW FILE
    - Adds K8sAppDefinition() to deploy cuda-basic workload as a DaemonSet
    - Uses nodeSelector: accelerator=nvidia-gpu to only run on GPU nodes
    - Runs CUDA vector addition in a loop for testing GPU monitoring

GPU cluster in GPUM page:
<img width="1260" height="721" alt="Screenshot 2026-01-13 at 11 49 14 PM" src="https://github.com/user-attachments/assets/bdfbf973-8aa7-4108-8f5a-fa36a2a4302b" />


**Which scenarios this will impact?**
- aws/eks - EKS cluster creation with --gpu-node-group flag

**Motivation**
  Enable GPU testing infrastructure for Datadog GPU monitoring feature development and validation. The GPU node group provides:
  - Pre-installed NVIDIA drivers (EKS GPU AMI)
  - NVIDIA device plugin for Kubernetes GPU resource management
  - NVIDIA_VISIBLE_DEVICES env var in container specs 
  
**Additional Notes**
  - Default GPU instance type: g4dn.xlarge (1x NVIDIA T4 GPU, ~$0.526/hr on-demand)
  - Supports custom instance types via --gpu-instance-type flag (e.g., g4dn.12xlarge, g5.xlarge)
  - GPU workload (cuda-basic) image source already exists at components/datadog/apps/gpu/images/cuda-basic/
  - The accelerator=nvidia-gpu label enables clean DaemonSet scheduling without pending pods on non-GPU nodes

**Usage Examples**

  Create EKS cluster with GPU node group
  - Basic GPU cluster (default: g4dn.xlarge with 1x T4 GPU)
  ```
inv aws.create-eks --stack-name my-gpu-test --gpu-node-group
```
  - GPU cluster with custom instance type (4x T4 GPUs)
  ```
inv aws.create-eks --stack-name my-gpu-test --gpu-node-group --gpu-instance-type g4dn.12xlarge
```
  - GPU cluster without default workloads (bare cluster)
  ```
inv aws.create-eks --stack-name my-gpu-test --gpu-node-group --no-install-workload --no-install-agent
```
  - GPU cluster with only GPU nodes (no bottlerocket/linux nodes)
  ```
inv aws.create-eks --stack-name my-gpu-test --gpu-node-group --no-linux-node-group --no-bottlerocket-node-group
```

  Destroy cluster
 ```inv aws.destroy-eks --stack-name my-gpu-test```
