### PR TITLE
chore: Updated CODEOWNERS removing @DataDog/agent-metrics-logs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,8 +12,8 @@
 *                                       @DataDog/agent-e2e-testing
 /scenarios/aws/microVMs/                @DataDog/ebpf-platform
 /scenarios/aws/installer/               @DataDog/fleet
-/components/datadog/apps/jmxfetch       @DataDog/agent-metrics-logs
-/components/datadog/apps/logger         @DataDog/agent-metrics-logs
+/components/datadog/apps/jmxfetch       @DataDog/agent-metric-pipelines
+/components/datadog/apps/logger         @DataDog/agent-log-pipelines
 /components/datadog/apps/tracegen       @DataDog/agent-apm
 /components/datadog/apps/cws            @DataDog/agent-security
 /components/datadog/apps/fips           @DataDog/agent-runtimes


### PR DESCRIPTION
What does this PR do?
---------------------

Update CODEOWNERS

Which scenarios this will impact?
-------------------

AMP and ALP e2e tests.

Motivation
----------

`agent-metrics-logs` no longer exists.

Additional Notes
----------------
