### PR TITLE
[ARTSEC-INT] Instrument runner image build with image-integrity signing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,9 @@ build-runner-image:
   stage: build
   image: ${BUILD_STABLE_REGISTRY}/images/docker:27.3.1
   tags: ["arch:amd64"]
+  id_tokens:
+    DDSIGN_ID_TOKEN:
+      aud: image-integrity
   variables:
     RELEASE_IMAGE: "false"
   rules:
@@ -30,7 +33,9 @@ build-runner-image:
     - |
       export GITHUB_TOKEN=`curl -s --fail --retry 10 -X POST -H "Accept: application/vnd.github+json" -H "Authorization: Bearer $JWT" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/app/installations/$GITHUB_INSTALLATION_ID/access_tokens | jq -r '.token'`
   script:
-    - docker buildx build --no-cache --pull --push --label target=build --tag ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA} --tag ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHA:0:12} --secret id=github_token,env=GITHUB_TOKEN .
+    - METADATA_FILE=$(mktemp)
+    - docker buildx build --no-cache --pull --push --label target=build --tag ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA} --tag ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHA:0:12} --metadata-file ${METADATA_FILE} --secret id=github_token,env=GITHUB_TOKEN .
+    - ddsign sign ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA} --docker-metadata-file ${METADATA_FILE}
   retry: 2
 
 build-pulumi-go-main:
@@ -105,8 +110,13 @@ release-runner-image:
   stage: release
   image: ${BUILD_STABLE_REGISTRY}/images/docker:27.3.1
   tags: ["arch:amd64"]
+  id_tokens:
+    DDSIGN_ID_TOKEN:
+      aud: image-integrity
   script:
     - crane copy ${CI_REGISTRY_IMAGE_TEST}:${CI_COMMIT_SHORT_SHA} ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA:0:12}
+    - DIGEST=$(crane digest ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA:0:12})
+    - ddsign sign ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA:0:12}@${DIGEST}
   rules:
     - if: $CI_COMMIT_BRANCH == "main"
       when: on_success


### PR DESCRIPTION
## Summary
We'll soon [require image-integrity signatures on CI images.](https://dd.slack.com/archives/C0RLPU7AN/p1772571423931249)

- Adds `ddsign` image signing to the `build-runner-image` and `release-runner-image` CI jobs
- Configures GitLab ID tokens (`DDSIGN_ID_TOKEN`) for both jobs
- Uses `--metadata-file` with `docker buildx build` and `crane digest` for the release copy to obtain image digests for signing