### PR TITLE
re-enable dependabot with 14-day cooldown

### DIFF
--- a/github/dependabot.yml
+++ b/github/dependabot.yml
@@ -1,0 +1,129 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 14
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 14
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: daily
+  groups:
+    aws-sdk-go-v2:
+      patterns:
+      - github.com/aws/aws-sdk-go-v2*
+    pulumi-azure-native-sdk:
+      patterns:
+      - github.com/pulumi/pulumi-azure-native-sdk*
+  cooldown:
+    default-days: 14
+- package-ecosystem: pip
+  directory: /
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 14
+- package-ecosystem: docker
+  directory: /components/datadog/apps/dogstatsd/images/dogstatsd
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 14
+- package-ecosystem: gomod
+  directory: /components/datadog/apps/dogstatsd/images/dogstatsd
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 14
+- package-ecosystem: docker
+  directory: /components/datadog/apps/mutatedbyadmissioncontroller/images/mutated
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 14
+- package-ecosystem: docker
+  directory: /components/datadog/apps/nginx/images/http-client
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 14
+- package-ecosystem: gomod
+  directory: /components/datadog/apps/nginx/images/http-client
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 14
+- package-ecosystem: docker
+  directory: /components/datadog/apps/nginx/images/nginx-server
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 14
+- package-ecosystem: docker
+  directory: /components/datadog/apps/prometheus/images/prometheus
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 14
+- package-ecosystem: gomod
+  directory: /components/datadog/apps/prometheus/images/prometheus
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 14
+- package-ecosystem: docker
+  directory: /components/datadog/apps/redis/images/redis-client
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 14
+- package-ecosystem: gomod
+  directory: /components/datadog/apps/redis/images/redis-client
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 14
+- package-ecosystem: docker
+  directory: /components/datadog/apps/redis/images/redis-server
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 14
+- package-ecosystem: docker
+  directory: /components/datadog/apps/cpustress/images/stress-ng
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 14
+- package-ecosystem: docker
+  directory: /components/datadog/apps/npm-tools/images/go-httpbin
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 14
+- package-ecosystem: docker
+  directory: /components/datadog/apps/npm-tools/images/npm-tools
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 14
+- package-ecosystem: docker
+  directory: /components/datadog/apps/cws/images/cws-centos7
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 14
+- package-ecosystem: docker
+  directory: /components/datadog/apps/etcd/images/alpine
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 14


### PR DESCRIPTION
> [!NOTE]
> **Merge only if this is still needed and your repo is not managed by ADMS.**
> If your repository is already managed by ADMS, feel free to close or ignore this PR.

---

We are adding a mandatory 14-day cooldown on dependencies to reduce the risk of zero-day vulnerabilities.

This PR re-enables your Dependabot configuration and introduces the cooldown setting. If you notice any other Dependabot configurations in your repo that are missing the cooldown, please ensure it is added.

If your repository is already managed by ADMS and no longer requires these configurations, feel free to close or ignore the PR.